### PR TITLE
HL7 server - on incorrect hl7 message raise an exception

### DIFF
--- a/hl7_server/hl7_server/app_config.py
+++ b/hl7_server/hl7_server/app_config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 @dataclass
 class AppConfig:
     connection_string: str | None
-    egress_queue_name: str | None
+    egress_queue_name: str
     service_bus_namespace: str | None
     audit_queue_name: str
     workflow_id: str
@@ -16,17 +16,22 @@ class AppConfig:
     @staticmethod
     def read_env_config() -> AppConfig:
         return AppConfig(
-            connection_string=_read_env("SERVICE_BUS_CONNECTION_STRING", required=False),
-            egress_queue_name=_read_env("EGRESS_QUEUE_NAME", required=True),
-            service_bus_namespace=_read_env("SERVICE_BUS_NAMESPACE", required=False),
-            audit_queue_name=_read_env("AUDIT_QUEUE_NAME", required=True),
-            workflow_id=_read_env("WORKFLOW_ID", required=True),
-            microservice_id=_read_env("MICROSERVICE_ID", required=True),
+            connection_string=_read_env("SERVICE_BUS_CONNECTION_STRING"),
+            egress_queue_name=_read_required_env("EGRESS_QUEUE_NAME"),
+            service_bus_namespace=_read_env("SERVICE_BUS_NAMESPACE"),
+            audit_queue_name=_read_required_env("AUDIT_QUEUE_NAME"),
+            workflow_id=_read_required_env("WORKFLOW_ID"),
+            microservice_id=_read_required_env("MICROSERVICE_ID"),
         )
 
 
-def _read_env(name: str, required: bool = False) -> str | None:
+def _read_env(name: str) -> str | None:
+    return os.getenv(name)
+
+
+def _read_required_env(name: str) -> str:
     value = os.getenv(name)
-    if required and (value is None or value.strip() == ""):
+    if value is None or value.strip() == "":
         raise RuntimeError(f"Missing required configuration: {name}")
-    return value
+    else:
+        return value

--- a/hl7_server/hl7_server/error_handler.py
+++ b/hl7_server/hl7_server/error_handler.py
@@ -7,11 +7,11 @@ logger = logging.getLogger(__name__)
 
 
 class ErrorHandler(AbstractErrorHandler):
-    def __init__(self, exc: Exception, msg, audit_client: AuditServiceClient):
+    def __init__(self, exc: Exception, msg: str, audit_client: AuditServiceClient):
         super().__init__(exc, msg)
         self.audit_client = audit_client
 
-    def reply(self):
+    def reply(self) -> str:
         if isinstance(self.exc, UnsupportedMessageType):
             error_msg = f"Unsupported Message Type: {self.exc}"
             logger.error(error_msg)
@@ -20,5 +20,4 @@ class ErrorHandler(AbstractErrorHandler):
             error_msg = f"Invalid HL7 Message: {self.exc}"
             logger.error(error_msg)
             self.audit_client.log_message_failed(self.incoming_message, error_msg, "Invalid HL7 message format")
-
         raise self.exc

--- a/hl7_server/hl7_server/generic_handler.py
+++ b/hl7_server/hl7_server/generic_handler.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class GenericHandler(AbstractHandler):
-    def __init__(self, msg, sender_client: MessageSenderClient, audit_client: AuditServiceClient):
+    def __init__(self, msg: str, sender_client: MessageSenderClient, audit_client: AuditServiceClient):
         super(GenericHandler, self).__init__(msg)
         self.sender_client = sender_client
         self.audit_client = audit_client
@@ -61,7 +61,7 @@ class GenericHandler(AbstractHandler):
         ack_msg = ack_builder.build_ack(message_control_id, msg)
         return ack_msg.to_mllp()
 
-    def _send_to_service_bus(self, message_control_id: str) -> bool:
+    def _send_to_service_bus(self, message_control_id: str) -> None:
         try:
             self.sender_client.send_text_message(self.incoming_message)
             logger.info("Message %s sent to Service Bus queue successfully", message_control_id)

--- a/hl7_server/hl7_server/hl7_server_application.py
+++ b/hl7_server/hl7_server/hl7_server_application.py
@@ -24,14 +24,14 @@ class Hl7ServerApplication:
     def __init__(self) -> None:
         self.sender_client = None
         self.audit_client = None
-        self._server_thread = None
+        self._server_thread: threading.Thread | None = None
         self.HOST = os.environ.get("HOST", "127.0.0.1")
         self.PORT = int(os.environ.get("PORT", "2575"))
 
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
 
-        self._server: MLLPServer = None
+        self._server: MLLPServer | None = None
 
     def _signal_handler(self, signum: Any, frame: Any) -> None:
         logger.info("Shutdown signal received (signal %s).", signum)

--- a/hl7_server/tests/test_error_handler.py
+++ b/hl7_server/tests/test_error_handler.py
@@ -8,7 +8,7 @@ from hl7_server.error_handler import ErrorHandler
 
 class TestErrorHandler(unittest.TestCase):
     @patch("hl7_server.error_handler.logger")
-    def test_reply_with_unsupported_message_type(self, mock_logger):
+    def test_reply_with_unsupported_message_type(self, mock_logger) -> None:
         exception = UnsupportedMessageType("Unsupported type")
         unsupported_message = r"MSH|^~\&|GHH_ADT||||20080115153000||ADT^A01^ADT_A01|0123456789|P|2.5||||AL"
         mock_audit_client = MagicMock()
@@ -25,7 +25,7 @@ class TestErrorHandler(unittest.TestCase):
         )
 
     @patch("hl7_server.error_handler.logger")
-    def test_reply_with_invalid_hl7_message_exception(self, mock_logger):
+    def test_reply_with_invalid_hl7_message_exception(self, mock_logger) -> None:
         exception = InvalidHL7Message("invalid message")
         invalid_message = "<hello>"
         mock_audit_client = MagicMock()


### PR DESCRIPTION
MLLPRequestHandler expects reply message to return the response, in case of errors, when we do want to stop the connection, the exception shouldn`t be swallowed

Change was done already in other branch, but this PR contains also typing fixes