### PR TITLE
INSE-539514: Add health check to hl7_transformer

### DIFF
--- a/hl7_sender/hl7_sender/application.py
+++ b/hl7_sender/hl7_sender/application.py
@@ -43,10 +43,12 @@ def main():
     app_config = AppConfig.read_env_config()
     client_config = ConnectionConfig(app_config.connection_string, app_config.service_bus_namespace)
     factory = ServiceBusClientFactory(client_config)
-    health_check_server = TCPHealthCheckServer()
 
-    with factory.create_message_receiver_client(app_config.ingress_queue_name) as receiver_client, \
-            HL7SenderClient(app_config.receiver_mllp_hostname, app_config.receiver_mllp_port) as hl7_sender_client:
+    with (
+        factory.create_message_receiver_client(app_config.ingress_queue_name) as receiver_client,
+        HL7SenderClient(app_config.receiver_mllp_hostname, app_config.receiver_mllp_port) as hl7_sender_client,
+        TCPHealthCheckServer() as health_check_server
+    ):
 
         logger.info("Processor started.")
         health_check_server.start()

--- a/hl7_sender/tests/test_application.py
+++ b/hl7_sender/tests/test_application.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from azure.servicebus import ServiceBusMessage
 from hl7apy.core import Message
 
-from hl7_sender.application import _process_message
+from hl7_sender.application import _process_message, main
 
 
 def _setup():
@@ -35,6 +35,29 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.assert_called_once_with(hl7_string)
         mock_mllp_client.send_message.assert_called_once_with(hl7_message.to_er7())
         mock_ack_processor.assert_called_once_with(hl7_ack_message)
+
+    @patch("hl7_sender.application.ServiceBusClientFactory")
+    @patch("hl7_sender.application.AppConfig")
+    @patch("hl7_sender.application.TCPHealthCheckServer")
+    @patch("hl7_sender.application.HL7SenderClient")
+    def test_health_check_server_starts_and_stops(
+        self, mock_hl7_sender, mock_health_check, mock_app_config, mock_factory):
+        # Arrange
+        mock_health_server = MagicMock()
+        mock_health_check_ctx = MagicMock()
+        mock_health_check_ctx.__enter__.return_value = mock_health_server
+        mock_health_check.return_value = mock_health_check_ctx
+
+        # Set PROCESSOR_RUNNING to False to exit the loop immediately
+        with patch("hl7_sender.application.PROCESSOR_RUNNING", False):
+            # Act
+            main()
+
+            # Assert
+            mock_health_check.assert_called_once()
+            mock_health_server.start.assert_called_once()
+            mock_health_check_ctx.__exit__.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hl7_transformer/hl7_transformer/application.py
+++ b/hl7_transformer/hl7_transformer/application.py
@@ -11,6 +11,7 @@ from message_bus_lib.message_sender_client import MessageSenderClient
 from message_bus_lib.servicebus_client_factory import ServiceBusClientFactory
 from message_bus_lib.processing_result import ProcessingResult
 from message_bus_lib.audit_service_client import AuditServiceClient
+from health_check_lib.health_check_server import TCPHealthCheckServer
 from .datetime_transformer import transform_datetime
 
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "ERROR").upper())
@@ -46,8 +47,10 @@ def main():
         factory.create_queue_sender_client(app_config.audit_queue_name) as audit_sender_client,
         factory.create_message_receiver_client(app_config.ingress_queue_name) as receiver_client,
         AuditServiceClient(audit_sender_client, app_config.workflow_id, app_config.microservice_id) as audit_client,
+        TCPHealthCheckServer() as health_check_server,
     ):
         logger.info("Processor started.")
+        health_check_server.start()
 
         while PROCESSOR_RUNNING:
             receiver_client.receive_messages(

--- a/hl7_transformer/requirements.txt
+++ b/hl7_transformer/requirements.txt
@@ -2,3 +2,4 @@ azure-servicebus==7.14.2
 azure-identity==1.21.0
 hl7apy==1.3.5
 ../shared_libs/message_bus_lib
+../shared_libs/health_check_lib

--- a/hl7_transformer/tests/test_application.py
+++ b/hl7_transformer/tests/test_application.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from azure.servicebus import ServiceBusMessage
 from hl7apy.core import Message
 
-from hl7_transformer.application import _process_message
+from hl7_transformer.application import _process_message, main
 
 
 def _setup(created_datetime: str):
@@ -77,6 +77,28 @@ class TestProcessMessage(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertEqual(result.error_reason, error_reason)
+
+    @patch("hl7_transformer.application.AuditServiceClient")
+    @patch("hl7_transformer.application.AppConfig")
+    @patch("hl7_transformer.application.ServiceBusClientFactory")
+    @patch("hl7_transformer.application.TCPHealthCheckServer")
+    def test_health_check_server_starts_and_stops(
+        self, mock_health_check, mock_factory, mock_app_config, mock_audit_client):
+        # Arrange
+        mock_health_server = MagicMock()
+        mock_health_check_ctx = MagicMock()
+        mock_health_check_ctx.__enter__.return_value = mock_health_server
+        mock_health_check.return_value = mock_health_check_ctx
+
+        # Set PROCESSOR_RUNNING to False to exit the loop immediately
+        with patch("hl7_transformer.application.PROCESSOR_RUNNING", False):
+            # Act
+            main()
+
+            # Assert
+            mock_health_check.assert_called_once()
+            mock_health_server.start.assert_called_once()
+            mock_health_check_ctx.__exit__.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - shared_libs=../shared_libs
     env_file:
       - ./phw-hl7-transformer.env
+    <<: *default-healthcheck
     depends_on:
       - sb-emulator
     restart: on-failure
@@ -88,8 +89,6 @@ services:
         - shared_libs=../shared_libs
     env_file:
       - ./phw-hl7-sender.env
-    ports:
-      - "9000:9000"
     <<: *default-healthcheck
     restart: on-failure
     depends_on:

--- a/shared_libs/health_check_lib/health_check_lib/health_check_server.py
+++ b/shared_libs/health_check_lib/health_check_lib/health_check_server.py
@@ -2,6 +2,8 @@ import socket
 import threading
 import logging
 
+logger = logging.getLogger(__name__)
+
 class TCPHealthCheckServer:
     def __init__(self, host='127.0.0.1', port=9000):
         self.host = host
@@ -33,4 +35,11 @@ class TCPHealthCheckServer:
             try:
                 self._server_socket.close()
             except Exception as e:
-                logging.warning(f"Failed to close socket: {e}")
+                logger.warning(f"Failed to close socket: {e}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.stop()
+        logger.debug("Health check server closed.")


### PR DESCRIPTION
- Add health check to hl7_transformer
- Add context manager to health check server to ensure socket is closed automatically
- Add unit test to verify health check started and stopped
- Change hl7_sender to use context manager for health check
- Update docker compose to use health check for hl7_transformer