### PR TITLE
fix uv depdendency download

### DIFF
--- a/hl7_server/Dockerfile
+++ b/hl7_server/Dockerfile
@@ -1,5 +1,6 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -7,21 +8,15 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
-# Add certificates for proxied networks
-COPY --from=ca-certs . /opt/ca-certs
-
-ENV SSL_CERT_FILE=/opt/ca-certs/cacerts.pem
-ENV REQUESTS_CA_BUNDLE=/opt/ca-certs/cacerts.pem
-ENV CURL_CA_BUNDLE=/opt/ca-certs/cacerts.pem
-
-# Install uv with trusted hosts
-RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org uv
-
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
+
+# Add certificates for proxied networks
+COPY --from=ca-certs ./*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
 
 WORKDIR /app
 
@@ -32,23 +27,11 @@ COPY --from=shared_libs . /shared_libs
 COPY pyproject.toml uv.lock ./
 
 # Install the project's dependencies using the lockfile and settings
-RUN SSL_CERT_FILE=/opt/ca-certs/cacerts.pem \
-    REQUESTS_CA_BUNDLE=/opt/ca-certs/cacerts.pem \
-    CURL_CA_BUNDLE=/opt/ca-certs/cacerts.pem \
-    uv sync --locked --no-install-project --no-dev \
-    --trusted-host pypi.org \
-    --trusted-host pypi.python.org \
-    --trusted-host files.pythonhosted.org
+RUN uv --native-tls sync --locked --no-install-project --no-dev
 
 # Copy the rest of the project source code and install it
 COPY hl7_server/ /app/hl7_server/
-RUN SSL_CERT_FILE=/opt/ca-certs/cacerts.pem \
-    REQUESTS_CA_BUNDLE=/opt/ca-certs/cacerts.pem \
-    CURL_CA_BUNDLE=/opt/ca-certs/cacerts.pem \
-    uv sync --locked --no-dev \
-    --trusted-host pypi.org \
-    --trusted-host pypi.python.org \
-    --trusted-host files.pythonhosted.org
+RUN uv sync --locked --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
Instead of using insecure connections add company trusted certs to system store Requires the ca-certs to be in files with .crt extensions.