### PR TITLE
INSE-540138: Fix __exit__ method params for message bus lib

### DIFF
--- a/hl7_server/hl7_server/hl7_server_application.py
+++ b/hl7_server/hl7_server/hl7_server_application.py
@@ -8,6 +8,7 @@ from health_check_lib.health_check_server import TCPHealthCheckServer
 from hl7apy.mllp import MLLPServer
 from message_bus_lib.audit_service_client import AuditServiceClient
 from message_bus_lib.connection_config import ConnectionConfig
+from message_bus_lib.message_sender_client import MessageSenderClient
 from message_bus_lib.servicebus_client_factory import ServiceBusClientFactory
 
 from hl7_server.hl7_validator import HL7Validator
@@ -25,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 class Hl7ServerApplication:
     def __init__(self) -> None:
-        self.sender_client = None
-        self.audit_client = None
+        self.sender_client: MessageSenderClient = None
+        self.audit_client: AuditServiceClient = None
         self._server_thread: threading.Thread | None = None
         self.health_check_server: TCPHealthCheckServer = None
         self.HOST = os.environ.get("HOST", "127.0.0.1")

--- a/shared_libs/health_check_lib/health_check_lib/health_check_server.py
+++ b/shared_libs/health_check_lib/health_check_lib/health_check_server.py
@@ -5,7 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 class TCPHealthCheckServer:
-    def __init__(self, host: str | None, port: int | None):
+    def __init__(self, host: str | None = None, port: int | None = None):
         self.host = host or "127.0.0.1"
         self.port = port or 9000
         self._server_socket = None

--- a/shared_libs/health_check_lib/tests/test_health_check_server.py
+++ b/shared_libs/health_check_lib/tests/test_health_check_server.py
@@ -29,6 +29,21 @@ class TestTCPHealthCheckServer(unittest.TestCase):
             # Try to connect after server has stopped
             socket.create_connection(("127.0.0.1", self.actual_port), timeout=1)
 
+    def test_default_parameters_constructor(self):
+        server = TCPHealthCheckServer()
+
+        self.assertEqual(server.host, "127.0.0.1")
+        self.assertEqual(server.port, 9000)
+
+    def test_custom_parameters_constructor(self):
+        host = "localhost"
+        port = 9876
+        server = TCPHealthCheckServer(host=host, port=port)
+
+        self.assertEqual(server.host, host)
+        self.assertEqual(server.port, port)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/shared_libs/message_bus_lib/message_bus_lib/audit_service_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/audit_service_client.py
@@ -80,10 +80,10 @@ class AuditServiceClient:
     def close(self) -> None:
         if self.sender_client:
             self.sender_client.close()
+            logger.debug("AuditServiceClient closed.")
 
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
-        logger.debug("AuditServiceClient closed.")

--- a/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
@@ -35,9 +35,12 @@ class MessageReceiverClient:
                 logger.error("Unexpected error processing message: %s", msg.message_id, exc_info=e)
                 self.receiver.abandon_message(msg)
 
+    def close(self):
+        self.receiver.close()
+        logger.debug("ServiceBusReceiverClient closed.")
+
     def __enter__(self):
         return self
 
-    def __exit__(self):
-        self.receiver.close()
-        logger.debug("ServiceBusReceiverClient closed.")
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()

--- a/shared_libs/message_bus_lib/message_bus_lib/message_sender_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/message_sender_client.py
@@ -22,9 +22,12 @@ class MessageSenderClient:
     def send_text_message(self, message_text: str, custom_properties: Optional[Dict[str, str]] = None):
         self.send_message(message_text.encode('utf-8'), custom_properties)
 
+    def close(self):
+        self.sender.close()
+        logger.debug("ServiceBusSenderClient closed.")
+
     def __enter__(self):
         return self
 
-    def __exit__(self):
-        self.sender.close()
-        logger.debug("ServiceBusSenderClient closed.")
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()

--- a/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
+++ b/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
@@ -103,12 +103,16 @@ class TestMessageReceiverClient(unittest.TestCase):
         self.service_bus_receiver_client.abandon_message.assert_called_once()
 
     def test_exit_service_bus_receiver_client_closed(self):
+        # Arrange
+        exc_type = ValueError
+        exc_value = ValueError("test error")
+        exc_traceback = None
+
         # Act
-        self.message_receiver_client.__exit__()
+        self.message_receiver_client.__exit__(exc_type, exc_value, exc_traceback)
 
         # Assert
         self.service_bus_receiver_client.close.assert_called_once()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/shared_libs/message_bus_lib/tests/test_MessageSenderClient.py
+++ b/shared_libs/message_bus_lib/tests/test_MessageSenderClient.py
@@ -22,8 +22,13 @@ class TestMessageSenderClient(unittest.TestCase):
         self.service_bus_sender_client.send_messages.assert_called_once()
 
     def test_exit_service_bus_sender_client_closed(self):
+        # Arrange
+        exc_type = ValueError
+        exc_value = ValueError("test error")
+        exc_traceback = None
+
         # Act
-        self.message_sender_client.__exit__()
+        self.message_sender_client.__exit__(exc_type, exc_value, exc_traceback)
 
         # Assert
         self.service_bus_sender_client.close.assert_called_once()

--- a/shared_libs/message_bus_lib/tests/test_audit_service_client.py
+++ b/shared_libs/message_bus_lib/tests/test_audit_service_client.py
@@ -113,8 +113,13 @@ class TestAuditServiceClient(unittest.TestCase):
         self.assertEqual(str(context.exception), "Network error")
 
     def test_close(self):
+        # Arrange
+        exc_type = ValueError
+        exc_value = ValueError("test error")
+        exc_traceback = None
+
         # Act
-        self.audit_client.close()
+        self.audit_client.__exit__(exc_type, exc_value, exc_traceback)
         
         # Assert
         self.sender_client.close.assert_called_once()


### PR DESCRIPTION
**Message bus lib**
- Change exit method params to match what context manager expects to call
- Update tests

**Health check**
- Add test for health check host and port setup