### PR TITLE
INSE-540138: fix health check __exit__ params

### DIFF
--- a/shared_libs/health_check_lib/health_check_lib/health_check_server.py
+++ b/shared_libs/health_check_lib/health_check_lib/health_check_server.py
@@ -40,6 +40,6 @@ class TCPHealthCheckServer:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, *args: object) -> None:
         self.stop()
         logger.debug("Health check server closed.")

--- a/shared_libs/health_check_lib/tests/test_health_check_server.py
+++ b/shared_libs/health_check_lib/tests/test_health_check_server.py
@@ -1,5 +1,6 @@
 import unittest
 import socket
+from unittest.mock import MagicMock
 
 from health_check_lib.health_check_server import TCPHealthCheckServer
 
@@ -43,6 +44,19 @@ class TestTCPHealthCheckServer(unittest.TestCase):
         self.assertEqual(server.host, host)
         self.assertEqual(server.port, port)
 
+    def test_exit_server_socket_closed(self):
+        # Arrange
+        exc_type = ValueError
+        exc_value = ValueError("test error")
+        exc_traceback = None
+        self.server._server_socket.close()
+        self.server._server_socket = MagicMock()
+
+        # Act
+        self.server.__exit__(exc_type, exc_value, exc_traceback)
+
+        # Assert
+        self.server._server_socket.close.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fix __exit__ method params to match context manager interface