### PR TITLE
INSE-537349: Add handler for ADT^A40 message type in Hl7MockReceiver

### DIFF
--- a/hl7_mock_receiver/hl7_mock_receiver/hl7_mock_receiver_application.py
+++ b/hl7_mock_receiver/hl7_mock_receiver/hl7_mock_receiver_application.py
@@ -46,6 +46,7 @@ class Hl7MockReceiver:
         handlers = {
             "ADT^A31^ADT_A05": (GenericHandler, self.sender_client),
             "ADT^A28^ADT_A05": (GenericHandler, self.sender_client),
+            "ADT^A40^ADT_A39": (GenericHandler, self.sender_client),
             'ERR': (ErrorHandler,)
         }
 


### PR DESCRIPTION
Add handler for ADT^A40 message type in Hl7MockReceiver