### PR TITLE
INSE-553553: MPI - Deploy HL7 server

### DIFF
--- a/hl7_server/README.md
+++ b/hl7_server/README.md
@@ -47,6 +47,7 @@ To define host and port the server should bind to use environment variables conf
 - **SERVICE_BUS_CONNECTION_STRING** - service bus connection string (optional, required when SERVICE_BUS_NAMESPACE is empty)
 - **SERVICE_BUS_NAMESPACE** - service bus namespace (recommended, required when SERVICE_BUS_CONNECTION_STRING is empty)
 - **EGRESS_QUEUE_NAME** - service bus queue name to store received messages
+- **EGRESS_TOPIC_NAME** - service bus topic name to store received messages
 - **AUDIT_QUEUE_NAME** - service bus queue name for storing audit events
 - **WORKFLOW_ID** - workflow id (used for audit)
 - **MICROSERVICE_ID** - service id (used for audit)

--- a/hl7_server/hl7_server/app_config.py
+++ b/hl7_server/hl7_server/app_config.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 @dataclass
 class AppConfig:
     connection_string: str | None
-    egress_queue_name: str
+    egress_queue_name: str | None
+    egress_topic_name: str | None
     service_bus_namespace: str | None
     audit_queue_name: str
     workflow_id: str
@@ -20,9 +21,19 @@ class AppConfig:
 
     @staticmethod
     def read_env_config() -> AppConfig:
+        egress_queue_name = _read_env("EGRESS_QUEUE_NAME")
+        egress_topic_name = _read_env("EGRESS_TOPIC_NAME")
+
+        if not egress_queue_name and not egress_topic_name:
+            raise RuntimeError("Either EGRESS_QUEUE_NAME or EGRESS_TOPIC_NAME must be provided")
+
+        if egress_queue_name and egress_topic_name:
+            raise RuntimeError("Cannot specify both EGRESS_QUEUE_NAME and EGRESS_TOPIC_NAME.")
+
         return AppConfig(
             connection_string=_read_env("SERVICE_BUS_CONNECTION_STRING"),
-            egress_queue_name=_read_required_env("EGRESS_QUEUE_NAME"),
+            egress_queue_name=egress_queue_name,
+            egress_topic_name=egress_topic_name,
             service_bus_namespace=_read_env("SERVICE_BUS_NAMESPACE"),
             audit_queue_name=_read_required_env("AUDIT_QUEUE_NAME"),
             workflow_id=_read_required_env("WORKFLOW_ID"),

--- a/hl7_server/hl7_server/hl7_server_application.py
+++ b/hl7_server/hl7_server/hl7_server_application.py
@@ -47,7 +47,13 @@ class Hl7ServerApplication:
         client_config = ConnectionConfig(app_config.connection_string, app_config.service_bus_namespace)
         factory = ServiceBusClientFactory(client_config)
 
-        self.sender_client = factory.create_queue_sender_client(app_config.egress_queue_name)
+        if app_config.egress_topic_name:
+            self.sender_client = factory.create_topic_sender_client(app_config.egress_topic_name)
+            logger.info(f"Configured to send messages to topic: {app_config.egress_topic_name}")
+        else:
+            self.sender_client = factory.create_queue_sender_client(app_config.egress_queue_name)
+            logger.info(f"Configured to send messages to queue: {app_config.egress_queue_name}")
+
         self.event_logger = EventLogger(app_config.workflow_id, app_config.microservice_id)
         self.validator = HL7Validator(app_config.hl7_version, app_config.sending_app, app_config.hl7_validation_flow)
         self.health_check_server = TCPHealthCheckServer(app_config.health_check_hostname, app_config.health_check_port)

--- a/hl7_server/tests/test_hl7_server_application.py
+++ b/hl7_server/tests/test_hl7_server_application.py
@@ -8,7 +8,7 @@ from hl7apy.mllp import MLLPServer
 
 from hl7_server.hl7_server_application import Hl7ServerApplication
 
-ENV_VARS: Dict[str, str] = {
+ENV_VARS_QUEUE: Dict[str, str] = {
     "HOST": "127.0.0.1",
     "PORT": "2576",
     "EGRESS_QUEUE_NAME": "egress_queue",
@@ -20,13 +20,25 @@ ENV_VARS: Dict[str, str] = {
     "HEALTH_CHECK_PORT": "9000",
 }
 
+ENV_VARS_TOPIC: Dict[str, str] = {
+    "HOST": "127.0.0.1",
+    "PORT": "2576",
+    "EGRESS_TOPIC_NAME": "egress_topic",
+    "SERVICE_BUS_CONNECTION_STRING": "Endpoint=sb://localhost",
+    "AUDIT_QUEUE_NAME": "audit_queue",
+    "WORKFLOW_ID": "test-workflow",
+    "MICROSERVICE_ID": "test-service",
+    "HEALTH_CHECK_HOST": "127.0.0.1",
+    "HEALTH_CHECK_PORT": "9000",
+}
 
-@patch.dict(os.environ, ENV_VARS)
+
+@patch.dict(os.environ, ENV_VARS_QUEUE)
 @patch("hl7_server.hl7_server_application.TCPHealthCheckServer")
 @patch("hl7_server.hl7_server_application.MLLPServer")
 @patch("hl7_server.hl7_server_application.ServiceBusClientFactory")
 @patch("hl7_server.hl7_server_application.threading.Thread")
-class TestHl7ServerApplication(unittest.TestCase):
+class TestHl7ServerApplicationQueue(unittest.TestCase):
     def setUp(self) -> None:
         self.app = Hl7ServerApplication()
 
@@ -86,3 +98,62 @@ class TestHl7ServerApplication(unittest.TestCase):
 
         self.app.stop_server()
         self._assert_shutdown(server, thread, health_check)
+
+    def test_creates_queue_sender_client(self, mock_thread: MagicMock, mock_factory: MagicMock,
+                                         mock_mllp_server: MLLPServer, mock_health_check: MagicMock) -> None:
+        server, thread, health_check = self._setup_mocks(mock_thread, mock_mllp_server, mock_health_check)
+        mock_factory_instance = mock_factory.return_value
+
+        self.app.start_server()
+
+        mock_factory_instance.create_queue_sender_client.assert_called_once_with("egress_queue")
+        mock_factory_instance.create_topic_sender_client.assert_not_called()
+
+        self.app.stop_server()
+
+
+@patch.dict(os.environ, ENV_VARS_TOPIC)
+@patch("hl7_server.hl7_server_application.TCPHealthCheckServer")
+@patch("hl7_server.hl7_server_application.MLLPServer")
+@patch("hl7_server.hl7_server_application.ServiceBusClientFactory")
+@patch("hl7_server.hl7_server_application.threading.Thread")
+class TestHl7ServerApplicationTopic(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = Hl7ServerApplication()
+
+    def _setup_mocks(self, mock_thread: MagicMock, mock_mllp_server: MLLPServer, mock_health_check: MagicMock) -> tuple[
+        MagicMock, MagicMock, MagicMock]:
+        mock_server_instance = MagicMock()
+        mock_thread_instance = MagicMock()
+        mock_health_instance = MagicMock()
+        mock_mllp_server.return_value = mock_server_instance
+        mock_thread.return_value = mock_thread_instance
+        mock_health_check.return_value = mock_health_instance
+        return mock_server_instance, mock_thread_instance, mock_health_instance
+
+    def _assert_shutdown(self, server: MagicMock, thread: MagicMock, health_check: MagicMock) -> None:
+        server.shutdown.assert_called_once()
+        server.server_close.assert_called_once()
+        thread.join.assert_called_once()
+        health_check.stop.assert_called_once()
+
+    def test_server_initialization_with_topic(self, mock_thread: MagicMock, mock_factory: MagicMock,
+                                             mock_mllp_server: MLLPServer, mock_health_check: MagicMock) -> None:
+        server, thread, health_check = self._setup_mocks(mock_thread, mock_mllp_server, mock_health_check)
+
+        self.app.start_server()
+        self.app.stop_server()
+
+        self._assert_shutdown(server, thread, health_check)
+
+    def test_creates_topic_sender_client(self, mock_thread: MagicMock, mock_factory: MagicMock,
+                                        mock_mllp_server: MLLPServer, mock_health_check: MagicMock) -> None:
+        server, thread, health_check = self._setup_mocks(mock_thread, mock_mllp_server, mock_health_check)
+        mock_factory_instance = mock_factory.return_value
+
+        self.app.start_server()
+
+        mock_factory_instance.create_topic_sender_client.assert_called_once_with("egress_topic")
+        mock_factory_instance.create_queue_sender_client.assert_not_called()
+
+        self.app.stop_server()

--- a/local/mpi-hl7-server.env
+++ b/local/mpi-hl7-server.env
@@ -1,0 +1,10 @@
+SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://sb-emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+EGRESS_QUEUE_NAME="local-inthub-mpi-sender-ingress"
+HOST="0.0.0.0"
+PORT="2580"
+LOG_LEVEL=INFO
+AUDIT_QUEUE_NAME="audit-queue"
+MICROSERVICE_ID="mpi_hl7_server"
+HL7_VERSION="2.5"
+SENDING_APP="108"
+


### PR DESCRIPTION
- Added EGRESS_TOPIC_NAME to README.md and AppConfig for service bus topic configuration.
- Updated app initialization to create a topic sender client if EGRESS_TOPIC_NAME is provided, otherwise defaults to queue sender client.
- Introduced tests for both queue and topic sender client configurations to ensure correct behavior based on environment variables.