### PR TITLE
Update uv.lock files to version 0.12.0

### DIFF
--- a/hl7_mock_receiver/uv.lock
+++ b/hl7_mock_receiver/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -292,7 +292,7 @@ dev = [
     { name = "bandit", specifier = "==1.8.6" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "ruff", specifier = "==0.11.11" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.11.1" },
+    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "uv-secure"
-version = "0.11.1"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -773,9 +773,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a5/5352572db19d6e87986372e8dac00a7d428d1b098ae52f195624d84dabd6/uv_secure-0.11.1.tar.gz", hash = "sha256:2d8ca43214983e5a0480577b256e25ff04af2ab0fafa47fe70b21f0bca6979fa", size = 18569, upload-time = "2025-07-08T12:41:03.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/77/1ea26df112025d73af2cfae9fd1b12972e1da3bb779e236a64dcc71ebb20/uv_secure-0.12.0.tar.gz", hash = "sha256:34390723b24fce749c6a300132835607848c876744830c3f9ea7f5498d8ed350", size = 18977, upload-time = "2025-07-13T02:53:34.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/13/d373108c7b731e518e4bdc46c1e421293fefb65b460dd61ad0fa1a7577a7/uv_secure-0.11.1-py3-none-any.whl", hash = "sha256:1a8a8cd0a4f11365aeac3b909a1252653f9beaf221e1a35b78be429cba7fef26", size = 22727, upload-time = "2025-07-08T12:41:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e6/4080330a4edce09a04f3232719b70983ab352ac4e48061a35829b0610ddb/uv_secure-0.12.0-py3-none-any.whl", hash = "sha256:45ab260b92c7b04e45e608a629da151e0bf1b2c2ee66f8069269f5179c59ad30", size = 23169, upload-time = "2025-07-13T02:53:34.018Z" },
 ]
 
 [package.optional-dependencies]

--- a/hl7_sender/uv.lock
+++ b/hl7_sender/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -396,7 +396,7 @@ dev = [
     { name = "bandit", specifier = "==1.8.6" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "ruff", specifier = "==0.11.11" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.11.1" },
+    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -1170,7 +1170,7 @@ wheels = [
 
 [[package]]
 name = "uv-secure"
-version = "0.11.1"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a5/5352572db19d6e87986372e8dac00a7d428d1b098ae52f195624d84dabd6/uv_secure-0.11.1.tar.gz", hash = "sha256:2d8ca43214983e5a0480577b256e25ff04af2ab0fafa47fe70b21f0bca6979fa", size = 18569, upload-time = "2025-07-08T12:41:03.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/77/1ea26df112025d73af2cfae9fd1b12972e1da3bb779e236a64dcc71ebb20/uv_secure-0.12.0.tar.gz", hash = "sha256:34390723b24fce749c6a300132835607848c876744830c3f9ea7f5498d8ed350", size = 18977, upload-time = "2025-07-13T02:53:34.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/13/d373108c7b731e518e4bdc46c1e421293fefb65b460dd61ad0fa1a7577a7/uv_secure-0.11.1-py3-none-any.whl", hash = "sha256:1a8a8cd0a4f11365aeac3b909a1252653f9beaf221e1a35b78be429cba7fef26", size = 22727, upload-time = "2025-07-08T12:41:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e6/4080330a4edce09a04f3232719b70983ab352ac4e48061a35829b0610ddb/uv_secure-0.12.0-py3-none-any.whl", hash = "sha256:45ab260b92c7b04e45e608a629da151e0bf1b2c2ee66f8069269f5179c59ad30", size = 23169, upload-time = "2025-07-13T02:53:34.018Z" },
 ]
 
 [package.optional-dependencies]

--- a/hl7_server/uv.lock
+++ b/hl7_server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -403,7 +403,7 @@ dev = [
     { name = "bandit", specifier = "==1.8.6" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "ruff", specifier = "==0.11.11" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.11.1" },
+    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ dev = [
     { name = "bandit", specifier = "==1.8.6" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "ruff", specifier = "==0.11.11" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.11.1" },
+    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "uv-secure"
-version = "0.11.1"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1205,9 +1205,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a5/5352572db19d6e87986372e8dac00a7d428d1b098ae52f195624d84dabd6/uv_secure-0.11.1.tar.gz", hash = "sha256:2d8ca43214983e5a0480577b256e25ff04af2ab0fafa47fe70b21f0bca6979fa", size = 18569, upload-time = "2025-07-08T12:41:03.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/77/1ea26df112025d73af2cfae9fd1b12972e1da3bb779e236a64dcc71ebb20/uv_secure-0.12.0.tar.gz", hash = "sha256:34390723b24fce749c6a300132835607848c876744830c3f9ea7f5498d8ed350", size = 18977, upload-time = "2025-07-13T02:53:34.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/13/d373108c7b731e518e4bdc46c1e421293fefb65b460dd61ad0fa1a7577a7/uv_secure-0.11.1-py3-none-any.whl", hash = "sha256:1a8a8cd0a4f11365aeac3b909a1252653f9beaf221e1a35b78be429cba7fef26", size = 22727, upload-time = "2025-07-08T12:41:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e6/4080330a4edce09a04f3232719b70983ab352ac4e48061a35829b0610ddb/uv_secure-0.12.0-py3-none-any.whl", hash = "sha256:45ab260b92c7b04e45e608a629da151e0bf1b2c2ee66f8069269f5179c59ad30", size = 23169, upload-time = "2025-07-13T02:53:34.018Z" },
 ]
 
 [package.optional-dependencies]

--- a/shared_libs/hl7_validation/uv.lock
+++ b/shared_libs/hl7_validation/uv.lock
@@ -172,7 +172,7 @@ dev = [
     { name = "bandit", specifier = "==1.8.6" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "ruff", specifier = "==0.11.11" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.11.1" },
+    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "uv-secure"
-version = "0.11.1"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -513,9 +513,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a5/5352572db19d6e87986372e8dac00a7d428d1b098ae52f195624d84dabd6/uv_secure-0.11.1.tar.gz", hash = "sha256:2d8ca43214983e5a0480577b256e25ff04af2ab0fafa47fe70b21f0bca6979fa", size = 18569, upload-time = "2025-07-08T12:41:03.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/77/1ea26df112025d73af2cfae9fd1b12972e1da3bb779e236a64dcc71ebb20/uv_secure-0.12.0.tar.gz", hash = "sha256:34390723b24fce749c6a300132835607848c876744830c3f9ea7f5498d8ed350", size = 18977, upload-time = "2025-07-13T02:53:34.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/13/d373108c7b731e518e4bdc46c1e421293fefb65b460dd61ad0fa1a7577a7/uv_secure-0.11.1-py3-none-any.whl", hash = "sha256:1a8a8cd0a4f11365aeac3b909a1252653f9beaf221e1a35b78be429cba7fef26", size = 22727, upload-time = "2025-07-08T12:41:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e6/4080330a4edce09a04f3232719b70983ab352ac4e48061a35829b0610ddb/uv_secure-0.12.0-py3-none-any.whl", hash = "sha256:45ab260b92c7b04e45e608a629da151e0bf1b2c2ee66f8069269f5179c59ad30", size = 23169, upload-time = "2025-07-13T02:53:34.018Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
This includes updates to the development dependencies and source distributions for hl7_mock_receiver, hl7_sender, hl7_server, and shared_libs/hl7_validation.