### PR TITLE
feat: Store session ID in DB and use it for message replay

### DIFF
--- a/hl7_chemo_transformer/uv.lock
+++ b/hl7_chemo_transformer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/hl7_mock_receiver/uv.lock
+++ b/hl7_mock_receiver/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -723,7 +723,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -731,9 +731,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/hl7_phw_transformer/uv.lock
+++ b/hl7_phw_transformer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/hl7_pims_transformer/uv.lock
+++ b/hl7_pims_transformer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/hl7_sender/README.md
+++ b/hl7_sender/README.md
@@ -43,7 +43,7 @@ Destination host and port should be configured using environment variables confi
 - **SERVICE_BUS_CONNECTION_STRING** - service bus connection string (optional, required when SERVICE_BUS_NAMESPACE is empty)
 - **SERVICE_BUS_NAMESPACE** - service bus namespace (recommended, required when SERVICE_BUS_CONNECTION_STRING is empty)
 - **INGRESS_QUEUE_NAME** - service bus queue name to read messages from
-- **INGRESS_SESSION_ID** - service bus queue FIFO session name (optional, sessions not used if not set)
+- **INGRESS_SESSION_ID** - service bus queue FIFO session name (required — stored alongside each persisted message so the replay job can route replayed messages back through this sender)
 - **RECEIVER_MLLP_HOST** - HL7/mllp destination server host
 - **RECEIVER_MLLP_PORT** - HL7/mllp destination server port
 - **ACK_TIMEOUT_SECONDS** - time for message acklowledgement

--- a/hl7_sender/hl7_sender/app_config.py
+++ b/hl7_sender/hl7_sender/app_config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 class AppConfig:
     connection_string: str | None
     ingress_queue_name: str
-    ingress_session_id: str | None
+    ingress_session_id: str
     service_bus_namespace: str | None
     receiver_mllp_hostname: str
     receiver_mllp_port: int
@@ -27,7 +27,7 @@ class AppConfig:
         return AppConfig(
             connection_string=_read_env("SERVICE_BUS_CONNECTION_STRING"),
             ingress_queue_name=_read_required_env("INGRESS_QUEUE_NAME"),
-            ingress_session_id=_read_env("INGRESS_SESSION_ID"),
+            ingress_session_id=_read_required_env("INGRESS_SESSION_ID"),
             service_bus_namespace=_read_env("SERVICE_BUS_NAMESPACE"),
             receiver_mllp_hostname=_read_required_env("RECEIVER_MLLP_HOST"),
             receiver_mllp_port=_read_required_int_env("RECEIVER_MLLP_PORT"),

--- a/hl7_sender/hl7_sender/application.py
+++ b/hl7_sender/hl7_sender/application.py
@@ -101,7 +101,8 @@ def main() -> None:
             receiver_client.receive_messages(
                 batch_size,
                 lambda message: _process_message(
-                    message, hl7_sender_client, event_logger, metric_sender, throttler, message_store_client
+                    message, hl7_sender_client, event_logger, metric_sender, throttler, message_store_client,
+                    app_config.ingress_session_id,
                 ),
             )
 
@@ -113,6 +114,7 @@ def _process_message(
     metric_sender: MetricSender,
     throttler: MessageThrottler,
     message_store_client: MessageStoreClient,
+    session_id: str,
 ) -> bool:
     message_body = b"".join(message.body).decode("utf-8")
     metadata: dict[str, str] | None = extract_metadata(message)
@@ -137,7 +139,7 @@ def _process_message(
         logger.info(f"Message ID: {message_id}")
 
         if _is_first_delivery_attempt(message):
-            _send_to_message_store(message_store_client, event_logger, message_body, metadata)
+            _send_to_message_store(message_store_client, event_logger, message_body, metadata, session_id)
         else:
             logger.info(
                 "Skipping message store send on retry attempt - CorrelationId: %s, DeliveryCount: %s",
@@ -202,6 +204,7 @@ def _send_to_message_store(
     event_logger: EventLogger,
     message_body: str,
     metadata: dict[str, str] | None,
+    session_id: str,
 ) -> None:
     """Send a message to the message store queue with XML payload."""
     try:
@@ -225,6 +228,7 @@ def _send_to_message_store(
             correlation_id=incoming_metadata.get(CORRELATION_ID_KEY, ""),
             source_system=incoming_metadata.get(SOURCE_SYSTEM_KEY, ""),
             raw_payload=message_body,
+            session_id=session_id,
             xml_payload=xml_payload,
         )
     except Exception as e:

--- a/hl7_sender/tests/run_integration_test.py
+++ b/hl7_sender/tests/run_integration_test.py
@@ -14,7 +14,7 @@ Usage:
 """
 
 import re
-import subprocess
+import subprocess  # nosec B404 — integration test runner, subprocess calls use fixed commands
 import sys
 import time
 from datetime import datetime
@@ -31,7 +31,7 @@ EXPECTED_SERVICES = [
 def run_command(cmd: list[str], cwd: Optional[Path] = None) -> tuple[int, str, str]:
     """Run a command and return exit code, stdout, stderr."""
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607 — fixed command list, no shell, no user input
             cmd,
             cwd=cwd,
             capture_output=True,
@@ -50,7 +50,7 @@ def check_containers_running(services: list[str]) -> bool:
     print(f"Checking for running containers: {', '.join(services)}")
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607 — fixed command list, no shell, no user input
             ["docker", "ps", "--format", "table {{.Names}}"],
             capture_output=True,
             text=True,
@@ -77,7 +77,7 @@ def check_containers_running(services: list[str]) -> bool:
 
 def get_actual_timing_from_logs() -> dict:
     """Parse container logs to get actual message timing from the most recent test run."""
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603 B607 — fixed command list, no shell, no user input
         ["docker", "logs", "mpi-hl7-sender", "-t", "--since", "5m"],
         capture_output=True,
         text=True,

--- a/hl7_sender/tests/test_application.py
+++ b/hl7_sender/tests/test_application.py
@@ -36,6 +36,10 @@ def _setup() -> tuple[ServiceBusMessage, Message, str, MagicMock, MagicMock, Mag
     )
 
 
+# Default session ID used across tests — corresponds to INGRESS_SESSION_ID in env config.
+TEST_SESSION_ID = "test-session"
+
+
 class TestProcessMessage(unittest.TestCase):
     def _assert_error_handling(
         self,
@@ -73,6 +77,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         mock_parse_message.assert_called_once_with(hl7_string)
@@ -111,6 +116,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         mock_parse_message.assert_called_once_with(hl7_string)
@@ -151,6 +157,7 @@ class TestProcessMessage(unittest.TestCase):
                     mock_metric_sender,
                     mock_throttler,
                     mock_message_store,
+                    TEST_SESSION_ID,
                 )
 
                 self._assert_error_handling(result, mock_event_logger, mock_metric_sender)
@@ -177,6 +184,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         self._assert_error_handling(result, mock_event_logger, mock_metric_sender)
@@ -269,6 +277,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         mock_message_store.send_to_store.assert_called_once()
@@ -278,6 +287,7 @@ class TestProcessMessage(unittest.TestCase):
         self.assertEqual(call_kwargs["xml_payload"], "<xml>content</xml>")
         self.assertIn("message_received_at", call_kwargs)
         self.assertIn("correlation_id", call_kwargs)
+        self.assertEqual(call_kwargs["session_id"], TEST_SESSION_ID)
 
     @patch("hl7_sender.application.parse_message")
     @patch("hl7_sender.application.get_ack_result")
@@ -308,6 +318,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         self.assertTrue(result)
@@ -342,6 +353,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         mock_message_store.send_to_store.assert_called_once()
@@ -384,6 +396,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         self.assertTrue(result)
@@ -428,6 +441,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_metric_sender,
             mock_throttler,
             mock_message_store,
+            TEST_SESSION_ID,
         )
 
         mock_message_store.send_to_store.assert_called_once()
@@ -437,7 +451,7 @@ class TestProcessMessage(unittest.TestCase):
         self.assertEqual(call_kwargs["message_received_at"], original_timestamp)
         self.assertEqual(call_kwargs["correlation_id"], original_correlation_id)
         self.assertEqual(call_kwargs["source_system"], "PHW")
-
+        self.assertEqual(call_kwargs["session_id"], TEST_SESSION_ID)
 
 class TestBatchSizing(unittest.TestCase):
     def test_uses_max_batch_when_no_throttle(self) -> None:

--- a/hl7_sender/tests/test_throttling_local.py
+++ b/hl7_sender/tests/test_throttling_local.py
@@ -45,7 +45,7 @@ class TestMessageThrottlingIntegration(unittest.TestCase):
 
         # Narrow to a local variable — mypy cannot narrow instance attributes through assert.
         connection_string = self.connection_string
-        assert connection_string is not None, "SERVICE_BUS_CONNECTION_STRING must be set for integration tests"
+        assert connection_string is not None, "SERVICE_BUS_CONNECTION_STRING must be set for integration tests"  # nosec B101
 
         # Send all messages quickly using a single connection
         with ServiceBusClient.from_connection_string(connection_string) as client:

--- a/hl7_sender/uv.lock
+++ b/hl7_sender/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1214,9 +1214,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/hl7_server/README.md
+++ b/hl7_server/README.md
@@ -48,7 +48,7 @@ To define host and port the server should bind to use environment variables conf
 - **SERVICE_BUS_NAMESPACE** - service bus namespace (recommended, required when SERVICE_BUS_CONNECTION_STRING is empty)
 - **EGRESS_QUEUE_NAME** - service bus queue name to store received messages
 - **EGRESS_TOPIC_NAME** - service bus topic name to store received messages
-- **EGRESS_SESSION_ID** - service bus queue FIFO session name (optional, sessions not used if not set)
+- **EGRESS_SESSION_ID** - service bus queue FIFO session name (required for message replay — stored alongside each persisted message so the replay job can route it back to the correct downstream component)
 - **MESSAGE_STORE_QUEUE_NAME** - Message store service bus queue
 - **MESSAGE_STORE_ENABLED** - Set to `false` to disable message store persistence (optional, default `true` — enabled)
 - **WORKFLOW_ID** - workflow id (used for audit)

--- a/hl7_server/hl7_server/app_config.py
+++ b/hl7_server/hl7_server/app_config.py
@@ -11,7 +11,7 @@ class AppConfig:
     connection_string: str | None
     egress_queue_name: str | None
     egress_topic_name: str | None
-    egress_session_id: str | None
+    egress_session_id: str
     service_bus_namespace: str | None
     message_store_queue_name: str
     workflow_id: str
@@ -41,7 +41,7 @@ class AppConfig:
             connection_string=_read_env("SERVICE_BUS_CONNECTION_STRING"),
             egress_queue_name=egress_queue_name,
             egress_topic_name=egress_topic_name,
-            egress_session_id=_read_env("EGRESS_SESSION_ID"),
+            egress_session_id=_read_required_env("EGRESS_SESSION_ID"),
             service_bus_namespace=_read_env("SERVICE_BUS_NAMESPACE"),
             message_store_queue_name=_read_required_env("MESSAGE_STORE_QUEUE_NAME"),
             workflow_id=_read_required_env("WORKFLOW_ID"),

--- a/hl7_server/hl7_server/generic_handler.py
+++ b/hl7_server/hl7_server/generic_handler.py
@@ -41,6 +41,7 @@ class GenericHandler(AbstractHandler):
         workflow_id: str,
         sending_app: str | None,
         message_store_client: MessageStoreClient,
+        egress_session_id: str,
         flow_name: str | None = None,
         standard_version: str | None = None,
     ):
@@ -52,6 +53,7 @@ class GenericHandler(AbstractHandler):
         self.workflow_id = workflow_id
         self.sending_app = sending_app
         self.message_store_client = message_store_client
+        self.egress_session_id = egress_session_id
         self.flow_name: str | None = flow_name
         self.standard_version: str | None = standard_version
 
@@ -202,6 +204,7 @@ class GenericHandler(AbstractHandler):
                 correlation_id=tracking_metadata_properties.get(CORRELATION_ID_KEY, ""),
                 source_system=tracking_metadata_properties.get(SOURCE_SYSTEM_KEY, ""),
                 raw_payload=self.incoming_message,
+                session_id=self.egress_session_id,
                 xml_payload=xml_payload,
             )
         except Exception as e:

--- a/hl7_server/hl7_server/hl7_server_application.py
+++ b/hl7_server/hl7_server/hl7_server_application.py
@@ -92,6 +92,7 @@ class Hl7ServerApplication:
             app_config.workflow_id,
             app_config.sending_app,
             self.message_store_client,
+            app_config.egress_session_id,
             flow_name,
             standard_version,
         )

--- a/hl7_server/tests/test_app_config.py
+++ b/hl7_server/tests/test_app_config.py
@@ -12,6 +12,7 @@ class TestAppConfig(unittest.TestCase):
             values: Dict[str, str] = {
                 "SERVICE_BUS_CONNECTION_STRING": "conn_str",
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 "SERVICE_BUS_NAMESPACE": "namespace",
                 "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
                 "WORKFLOW_ID": "test-workflow",
@@ -34,6 +35,7 @@ class TestAppConfig(unittest.TestCase):
 
         self.assertEqual(config.connection_string, "conn_str")
         self.assertEqual(config.egress_queue_name, "egress_queue")
+        self.assertEqual(config.egress_session_id, "test-session")
         self.assertEqual(config.service_bus_namespace, "namespace")
         self.assertEqual(config.message_store_queue_name, "messagestore-queue")
         self.assertEqual(config.workflow_id, "test-workflow")
@@ -53,6 +55,7 @@ class TestAppConfig(unittest.TestCase):
         def getenv_side_effect(name: str) -> Optional[str]:
             values: Dict[str, str] = {
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
                 "WORKFLOW_ID": "test-workflow",
                 "MICROSERVICE_ID": "test-microservice",
@@ -72,6 +75,7 @@ class TestAppConfig(unittest.TestCase):
         def getenv_side_effect(name: str) -> Optional[str]:
             values: Dict[str, str] = {
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
                 "WORKFLOW_ID": "test-workflow",
                 "MICROSERVICE_ID": "test-microservice",
@@ -96,6 +100,7 @@ class TestAppConfig(unittest.TestCase):
         def getenv_side_effect(name: str) -> Optional[str]:
             values: Dict[str, str] = {
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
                 "WORKFLOW_ID": "test-workflow",
                 "MICROSERVICE_ID": "test-microservice",
@@ -115,6 +120,7 @@ class TestAppConfig(unittest.TestCase):
         def getenv_side_effect(name: str) -> Optional[str]:
             values: Dict[str, str] = {
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 # MESSAGE_STORE_QUEUE_NAME intentionally omitted to test required field validation
                 "WORKFLOW_ID": "test-workflow",
                 "MICROSERVICE_ID": "test-microservice",
@@ -135,6 +141,7 @@ class TestAppConfig(unittest.TestCase):
         def getenv_side_effect(name: str) -> Optional[str]:
             required_values: Dict[str, str] = {
                 "EGRESS_QUEUE_NAME": "egress_queue",
+                "EGRESS_SESSION_ID": "test-session",
                 "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
                 "WORKFLOW_ID": "test-workflow",
                 "MICROSERVICE_ID": "test-microservice",
@@ -149,6 +156,7 @@ class TestAppConfig(unittest.TestCase):
 
         # Verify required fields are loaded
         self.assertEqual(config.egress_queue_name, "egress_queue")
+        self.assertEqual(config.egress_session_id, "test-session")
         self.assertEqual(config.message_store_queue_name, "messagestore-queue")
         self.assertEqual(config.workflow_id, "test-workflow")
         self.assertEqual(config.microservice_id, "test-microservice")

--- a/hl7_server/tests/test_generic_handler.py
+++ b/hl7_server/tests/test_generic_handler.py
@@ -43,6 +43,7 @@ class TestGenericHandler(unittest.TestCase):
             workflow_id="test-workflow",
             sending_app="252",
             message_store_client=self.mock_message_store,
+            egress_session_id="test-session",
         )
 
     def test_valid_a28_message_returns_ack(self) -> None:
@@ -93,6 +94,7 @@ class TestGenericHandler(unittest.TestCase):
             workflow_id="test-workflow",
             sending_app="252",
             message_store_client=self.mock_message_store,
+            egress_session_id="test-session",
         )
 
         with self.assertRaises(ValidationException):
@@ -128,6 +130,7 @@ class TestGenericHandler(unittest.TestCase):
             workflow_id="test-workflow",
             sending_app="252",
             message_store_client=self.mock_message_store,
+            egress_session_id="test-session",
             flow_name="mpi",
         )
 
@@ -160,6 +163,7 @@ class TestGenericHandler(unittest.TestCase):
                 workflow_id="test-workflow",
                 sending_app="252",
                 message_store_client=self.mock_message_store,
+                egress_session_id="mpi-outbound",
                 flow_name="mpi",
             )
 
@@ -199,6 +203,7 @@ class TestGenericHandler(unittest.TestCase):
                     workflow_id="test-workflow",
                     sending_app="252",
                     message_store_client=self.mock_message_store,
+                    egress_session_id="test-session",
                     flow_name="mpi",
                 )
 
@@ -232,6 +237,7 @@ class TestGenericHandler(unittest.TestCase):
                 workflow_id="test-workflow",
                 sending_app="252",
                 message_store_client=self.mock_message_store,
+                egress_session_id="test-session",
                 standard_version="2.5",
             )
 
@@ -260,6 +266,7 @@ class TestGenericHandler(unittest.TestCase):
             workflow_id="test-workflow",
             sending_app="252",
             message_store_client=self.mock_message_store,
+            egress_session_id="test-session",
             standard_version="2.5",
         )
 
@@ -300,6 +307,7 @@ class TestGenericHandler(unittest.TestCase):
                 workflow_id="test-workflow",
                 sending_app="252",
                 message_store_client=self.mock_message_store,
+                egress_session_id="test-session",
                 flow_name="phw",
                 standard_version="2.5",
             )
@@ -326,6 +334,7 @@ class TestGenericHandler(unittest.TestCase):
                 workflow_id="test-workflow",
                 sending_app="252",
                 message_store_client=self.mock_message_store,
+                egress_session_id="test-session",
             )
 
             handler.reply()
@@ -341,6 +350,7 @@ class TestGenericHandler(unittest.TestCase):
         self.assertIn("message_received_at", call_kwargs.kwargs)
         self.assertIn("correlation_id", call_kwargs.kwargs)
         self.assertIn("source_system", call_kwargs.kwargs)
+        self.assertEqual(call_kwargs.kwargs["session_id"], "test-session")
 
     def test_message_stored_before_service_bus_send(self) -> None:
         message_stored = {"value": False}
@@ -419,6 +429,7 @@ class TestGenericHandler(unittest.TestCase):
             workflow_id="test-workflow",
             sending_app="252",
             message_store_client=self.mock_message_store,
+            egress_session_id="test-session",
             flow_name="phw",
         )
 

--- a/hl7_server/tests/test_hl7_server_application.py
+++ b/hl7_server/tests/test_hl7_server_application.py
@@ -11,6 +11,7 @@ ENV_VARS_QUEUE: Dict[str, str] = {
     "HOST": "127.0.0.1",
     "PORT": "2576",
     "EGRESS_QUEUE_NAME": "egress_queue",
+    "EGRESS_SESSION_ID": "test-session",
     "SERVICE_BUS_CONNECTION_STRING": "Endpoint=sb://localhost",
     "MESSAGE_STORE_QUEUE_NAME": "messagestore-queue",
     "WORKFLOW_ID": "test-workflow",
@@ -139,7 +140,7 @@ class TestHl7ServerApplicationQueue(unittest.TestCase):
 
         self.app.start_server()
 
-        mock_factory_instance.create_queue_sender_client.assert_called_once_with("egress_queue", None)
+        mock_factory_instance.create_queue_sender_client.assert_called_once_with("egress_queue", "test-session")
         mock_factory_instance.create_message_store_client.assert_called_once_with(
             "messagestore-queue", "test-service", "test-service"
         )

--- a/hl7_server/uv.lock
+++ b/hl7_server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1204,7 +1204,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1212,9 +1212,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/local/MESSAGE_REPLAY.md
+++ b/local/MESSAGE_REPLAY.md
@@ -219,7 +219,7 @@ INGRESS_QUEUE_NAME="local-inthub-priority-messagequeue"
 Leave `INGRESS_SESSION_ID` unchanged — each replayed message is automatically stamped with the `SessionId` stored in `monitoring.Message`, so the sender will pick up exactly the messages intended for it.
 
 > [!IMPORTANT]
-> Restart the sender container after changing the env file: `just restart <sender-service-name>`
+> Restart the profile which contains your desired sender after changing the env file: `just restart <profile>` (e.g. `just restart phw-to-mpi`)
 
 After the replay is complete, revert `INGRESS_QUEUE_NAME` to its original value and restart again.
 

--- a/local/MESSAGE_REPLAY.md
+++ b/local/MESSAGE_REPLAY.md
@@ -5,13 +5,17 @@
 
 The message replay job allows you to re-send messages from the Message Store to the Service Bus priority queue. This is useful for operational support when messages need to be reprocessed.
 
+The priority queue (`local-inthub-priority-messagequeue`) is **session-enabled**. Each replayed message is automatically stamped with the `SessionId` that was stored when the message was originally processed, so the consuming `hl7_sender` instance will pick it up without any session configuration change.
+
 ## Quick Start
 
 1. **Initialise database**: `just start phw-to-mpi` (starts SQL Server and seeds test messages)
 2. **Create replay batch**: Run `create-replay-batch.sql` in VS Code to get a `ReplayBatchId`
 3. **Configure job**: Set `REPLAY_BATCH_ID` in `message-replay-job.env`
-4. **Run job**: `just run replay` (builds and executes the replay job)
-5. **Verify**: Check logs with `just logs message-replay-job`
+4. **Redirect sender**: Update `INGRESS_QUEUE_NAME` in the relevant sender `.env` file to `local-inthub-priority-messagequeue`
+5. **Run job**: `just run replay` (builds and executes the replay job)
+6. **Verify**: Check logs with `just logs message-replay-job`
+7. **Revert sender**: Restore the original `INGRESS_QUEUE_NAME` in the sender `.env` file
 
 ## Quick Reference
 
@@ -203,6 +207,21 @@ REPLAY_BATCH_SIZE=100
 ```
 
 For more technical details, see [Message Replay Job README](../message_replay_job/README.md#replay_batch_size-explained).
+
+## Step 3b: Redirect the Consuming Service to the Priority Queue
+
+The priority queue is session-enabled. Before running the job, update **only** `INGRESS_QUEUE_NAME` in the relevant sender env file (e.g. `local/mpi-hl7-sender.env`) to point at the priority queue:
+
+```dotenv
+INGRESS_QUEUE_NAME="local-inthub-priority-messagequeue"
+```
+
+Leave `INGRESS_SESSION_ID` unchanged — each replayed message is automatically stamped with the `SessionId` stored in `monitoring.Message`, so the sender will pick up exactly the messages intended for it.
+
+> [!IMPORTANT]
+> Restart the sender container after changing the env file: `just restart <sender-service-name>`
+
+After the replay is complete, revert `INGRESS_QUEUE_NAME` to its original value and restart again.
 
 ## Step 4: Run the Replay Job
 

--- a/local/ServiceBusEmulatorConfig.json
+++ b/local/ServiceBusEmulatorConfig.json
@@ -113,7 +113,7 @@
               "LockDuration": "PT1M",
               "MaxDeliveryCount": 10,
               "RequiresDuplicateDetection": false,
-              "RequiresSession": false
+              "RequiresSession": true
             }
           }
         ],

--- a/local/sql-scripts/init-db.sql
+++ b/local/sql-scripts/init-db.sql
@@ -45,7 +45,9 @@ WHERE TABLE_SCHEMA = 'monitoring' AND TABLE_NAME = 'Message')
         TargetSystem NVARCHAR(100) NULL,
         -- Payloads
         RawPayload NVARCHAR(MAX) NOT NULL,
-        XmlPayload XML NULL
+        XmlPayload XML NULL,
+        -- Session routing (used by the message replay job)
+        SessionId NVARCHAR(128) NOT NULL
     );
 END;
 GO

--- a/local/sql-scripts/seed-messages.sql
+++ b/local/sql-scripts/seed-messages.sql
@@ -44,7 +44,8 @@ WITH
             WHEN RowNum <= 750 THEN DATEADD(SECOND, RowNum - 501, DATEADD(DAY, -1, CAST(@TodayUtc AS DATETIME2(3))))
             ELSE DATEADD(SECOND, RowNum - 751, CAST('2025-12-31T00:00:00.000' AS DATETIME2(3)))
         END AS ReceivedAt,
-            CAST(NEWID() AS NVARCHAR(100)) AS CorrelationId
+            CAST(NEWID() AS NVARCHAR(100)) AS CorrelationId,
+            N'mpi' AS SessionId
         FROM NumberedRows
     )
 INSERT INTO monitoring.Message
@@ -52,6 +53,7 @@ INSERT INTO monitoring.Message
     ReceivedAt,
     StoredAt,
     CorrelationId,
+    SessionId,
     SourceSystem,
     ProcessingComponent,
     TargetSystem,
@@ -62,6 +64,7 @@ SELECT
     s.ReceivedAt,
     s.ReceivedAt,
     s.CorrelationId,
+    s.SessionId,
     N'252',
     N'mpi_hl7_sender',
     N'MPI',

--- a/local/sql-scripts/seed-messages.sql
+++ b/local/sql-scripts/seed-messages.sql
@@ -1,6 +1,14 @@
--- This script seeds the monitoring.Message table with 1000 rows of test data based on a sample PHW HL7 message.
--- The ReceivedAt timestamps are distributed across three days (25% today, 25% yesterday, and 25% tomorrow)
--- with 25% of messages having a fixed timestamp of 2025-12-31 to allow testing of date range queries.
+/*
+   This script seeds the monitoring.Message table with 1000 rows of test data based on a sample PHW HL7 message.
+   The ReceivedAt timestamps are distributed across three days (25% today, 25% yesterday, and 25% tomorrow)
+   with 25% of messages having a fixed timestamp of 2025-12-31 to allow testing of date range queries.
+
+   The session ID stored in the DB and replayed is whichever was active when the message was written to the message
+   store (depends on which stage of the flow you're replaying). This can vary - for example, the PHW receiver and
+   MPI sender use different session IDs, same applies to the Paris flow. Since this mock DB is seeded with PHW messages
+   from the sender it exclusively uses that session ID.
+*/
+
 USE IntegrationHub;
 GO
 

--- a/message_replay_job/README.md
+++ b/message_replay_job/README.md
@@ -5,13 +5,30 @@ A containerised job that replays HL7 messages from SQL Server to an Azure Servic
 ## How It Works
 
 1. Reads the `REPLAY_BATCH_ID` (UUID) from environment variables to identify the replay batch. This should be passed in to the container app job as well when triggered.
-2. Fetches pending/failed rows from `monitoring.MessageReplayQueue` in configurable-sized batches (default 100), joined with `monitoring.Message` to retrieve the raw HL7 payload.
-3. Sends each batch to the configured Service Bus priority queue via `MessageSenderClient` from the shared lib.
-4. Marks each batch as `Loaded` in the database after successful send.
-5. Repeats until no pending rows remain, then exits.
+2. Fetches pending/failed rows from `monitoring.MessageReplayQueue` in configurable-sized batches (default 100), joined with `monitoring.Message` to retrieve the raw HL7 payload and `SessionId`.
+3. Builds a `ServiceBusMessage` for each record, adding the stored `SessionId` as the message session so the priority queue routes each message to the correct downstream consumer.
+4. Sends each batch to the configured Service Bus priority queue via `MessageSenderClient` from the shared lib.
+5. Marks each batch as `Loaded` in the database after successful send.
+6. Repeats until no pending rows remain, then exits.
 
 > [!IMPORTANT]
 > All database and Service Bus operations use a **retry-once** strategy: if the first attempt fails, a single retry is made before aborting (or marking the batch as `Failed` for send errors).
+
+## Triggering a Replay
+
+The priority queue (`PRIORITY_QUEUE_NAME`) is session-enabled. The downstream consumer (e.g. `hl7_sender`) must be temporarily redirected to it for the duration of the replay. Only **one** environment variable on the consuming service needs to change — the session ID is preserved automatically from the stored value.
+
+### Steps
+
+1. **Create a replay batch** in the database (see [local/MESSAGE_REPLAY.md](../local/MESSAGE_REPLAY.md)).
+2. **Update the consuming service** (e.g. `hl7_sender`):
+   - Set `INGRESS_QUEUE_NAME` → the priority queue name (e.g. `inthub-priority-messagequeue`).
+   - `INGRESS_SESSION_ID` stays unchanged — the replay job stamps the same session value that was stored when the message was originally processed.
+3. **Run the replay job** with the correct `REPLAY_BATCH_ID`.
+4. **Revert** `INGRESS_QUEUE_NAME` on the consuming service once the replay is complete.
+
+> [!NOTE]
+> The `SessionId` stored in `monitoring.Message` reflects the session of the component that originally stored the message (`EGRESS_SESSION_ID` for `hl7_server`, `INGRESS_SESSION_ID` for `hl7_sender`).
 
 ## Configuration
 

--- a/message_replay_job/message_replay_job/db_client.py
+++ b/message_replay_job/message_replay_job/db_client.py
@@ -24,7 +24,7 @@ WITH Batch AS (
     AND ReplayBatchId = ?
     ORDER BY ReplayId
 )
-SELECT b.ReplayId, m.Id AS MessageId, m.RawPayload, m.CorrelationId
+SELECT b.ReplayId, m.Id AS MessageId, m.RawPayload, m.CorrelationId, m.SessionId
 FROM Batch b
 JOIN monitoring.Message m ON m.Id = b.MessageId
 ORDER BY b.ReplayId;
@@ -102,6 +102,7 @@ class DatabaseClient:
                     message_id=row.MessageId,
                     raw_payload=row.RawPayload,
                     correlation_id=row.CorrelationId,
+                    session_id=row.SessionId,
                 )
                 for row in rows
             ]

--- a/message_replay_job/message_replay_job/message_replay_job.py
+++ b/message_replay_job/message_replay_job/message_replay_job.py
@@ -160,10 +160,11 @@ class MessageReplayJob:
 
     @staticmethod
     def _build_messages(records: List[ReplayRecord]) -> List[ServiceBusMessage]:
-        """Build ServiceBusMessage objects from replay records."""
+        """Build ServiceBusMessages from replay records."""
         return [
             ServiceBusMessage(
                 body=record.raw_payload,
+                session_id=record.session_id,
                 application_properties={
                     "CorrelationId": record.correlation_id,
                     "ReplayId": str(record.replay_id),

--- a/message_replay_job/message_replay_job/replay_record.py
+++ b/message_replay_job/message_replay_job/replay_record.py
@@ -9,6 +9,7 @@ class ReplayRecord:
     message_id: int
     raw_payload: str
     correlation_id: str
+    session_id: str
 
 
 __all__ = ["ReplayRecord"]

--- a/message_replay_job/tests/test_db_client.py
+++ b/message_replay_job/tests/test_db_client.py
@@ -38,6 +38,7 @@ class TestDatabaseClient(unittest.TestCase):
         mock_row.MessageId = 100
         mock_row.RawPayload = "MSH|^~\\&|..."
         mock_row.CorrelationId = "corr-1"
+        mock_row.SessionId = "mpi"
         mock_cursor.fetchall.return_value = [mock_row]
 
         result = self.client.fetch_batch("a1b2c3d4-e5f6-7890-abcd-ef1234567890", batch_size=100)
@@ -48,6 +49,7 @@ class TestDatabaseClient(unittest.TestCase):
         self.assertEqual(result[0].message_id, 100)
         self.assertEqual(result[0].raw_payload, "MSH|^~\\&|...")
         self.assertEqual(result[0].correlation_id, "corr-1")
+        self.assertEqual(result[0].session_id, "mpi")
 
     @patch("message_replay_job.db_client.pyodbc")
     def test_fetch_batch_returns_empty_list_when_no_rows(self, mock_pyodbc: MagicMock) -> None:

--- a/message_replay_job/tests/test_message_replay_job.py
+++ b/message_replay_job/tests/test_message_replay_job.py
@@ -8,13 +8,14 @@ from message_replay_job.replay_record import ReplayRecord
 from message_replay_job.replay_status import ReplayStatus
 
 
-def _make_record(replay_id: int = 1, message_id: int = 100) -> ReplayRecord:
+def _make_record(replay_id: int = 1, message_id: int = 100, session_id: str = "test-session") -> ReplayRecord:
     """Helper to create a ReplayRecord with sensible defaults."""
     return ReplayRecord(
         replay_id=replay_id,
         message_id=message_id,
         raw_payload=f"MSH|^~\\&|payload-{replay_id}",
         correlation_id=f"corr-{replay_id}",
+        session_id=session_id,
     )
 
 
@@ -141,6 +142,7 @@ class TestMessageReplayJobRun(unittest.TestCase):
         self.assertEqual(messages[0].application_properties["CorrelationId"], "corr-1")
         self.assertEqual(messages[0].application_properties["ReplayId"], "1")
         self.assertEqual(messages[0].application_properties["MessageId"], "100")
+        self.assertEqual(messages[0].session_id, "test-session")
 
     @patch("message_replay_job.message_replay_job.ServiceBusClientFactory")
     @patch("message_replay_job.message_replay_job.DatabaseClient")

--- a/message_replay_job/tests/test_replay_record.py
+++ b/message_replay_job/tests/test_replay_record.py
@@ -10,11 +10,14 @@ class TestReplayRecord(unittest.TestCase):
             message_id=100,
             raw_payload="MSH|^~\\&|...",
             correlation_id="corr-1",
+            session_id="mpi",
         )
         self.assertEqual(record.replay_id, 1)
         self.assertEqual(record.message_id, 100)
         self.assertEqual(record.raw_payload, "MSH|^~\\&|...")
         self.assertEqual(record.correlation_id, "corr-1")
+        self.assertEqual(record.session_id, "mpi")
+
 
     def test_replay_record_is_frozen(self) -> None:
         record = ReplayRecord(
@@ -22,18 +25,21 @@ class TestReplayRecord(unittest.TestCase):
             message_id=100,
             raw_payload="MSH|^~\\&|...",
             correlation_id="corr-1",
+            session_id="mpi",
         )
         with self.assertRaises(AttributeError):
             record.replay_id = 999  # type: ignore[misc]
 
     def test_replay_record_equality(self) -> None:
-        record_a = ReplayRecord(replay_id=1, message_id=100, raw_payload="payload", correlation_id="corr")
-        record_b = ReplayRecord(replay_id=1, message_id=100, raw_payload="payload", correlation_id="corr")
+        kwargs = dict(replay_id=1, message_id=100, raw_payload="payload", correlation_id="corr", session_id="mpi")
+        record_a = ReplayRecord(**kwargs)
+        record_b = ReplayRecord(**kwargs)
         self.assertEqual(record_a, record_b)
 
     def test_replay_record_inequality(self) -> None:
-        record_a = ReplayRecord(replay_id=1, message_id=100, raw_payload="payload", correlation_id="corr")
-        record_b = ReplayRecord(replay_id=2, message_id=100, raw_payload="payload", correlation_id="corr")
+        shared = dict(message_id=100, raw_payload="payload", correlation_id="corr", session_id="mpi")
+        record_a = ReplayRecord(replay_id=1, **shared)
+        record_b = ReplayRecord(replay_id=2, **shared)
         self.assertNotEqual(record_a, record_b)
 
 

--- a/message_replay_job/uv.lock
+++ b/message_replay_job/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1185,7 +1185,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1193,9 +1193,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/message_store_service/README.md
+++ b/message_store_service/README.md
@@ -18,16 +18,17 @@ batch.
 
 ### Database table — `monitoring.Message`
 
-| Column                | Type            | Required | Description                                      |
-| --------------------- | --------------- | -------- | ------------------------------------------------ |
-| `ReceivedAt`          | `datetime`      | ✅       | Timestamp the message was originally received    |
-| `StoredAt`            | `datetime`      | ✅       | Timestamp the record was written to the database |
-| `CorrelationId`       | `nvarchar`      | ✅       | Unique identifier for tracing the message        |
-| `SourceSystem`        | `nvarchar`      | ✅       | System that originated the message               |
-| `ProcessingComponent` | `nvarchar`      | ✅       | Microservice that processed the message          |
-| `TargetSystem`        | `nvarchar`      | ❌       | Destination system (if known)                    |
-| `RawPayload`          | `nvarchar(max)` | ✅       | Original HL7 raw message payload                 |
-| `XmlPayload`          | `nvarchar(max)` | ❌       | XML-transformed payload (if available)           |
+| Column                | Type            | Required | Description                                       |
+| --------------------- | --------------- | -------- |---------------------------------------------------|
+| `ReceivedAt`          | `datetime`      | ✅       | Timestamp the message was originally received     |
+| `StoredAt`            | `datetime`      | ✅       | Timestamp the record was written to the database  |
+| `CorrelationId`       | `nvarchar`      | ✅       | Unique identifier for tracing the message         |
+| `SourceSystem`        | `nvarchar`      | ✅       | System that originated the message                |
+| `ProcessingComponent` | `nvarchar`      | ✅       | Microservice that processed the message           |
+| `TargetSystem`        | `nvarchar`      | ❌       | Destination system (if known)                     |
+| `RawPayload`          | `nvarchar(max)` | ✅       | Original HL7 raw message payload                  |
+| `XmlPayload`          | `nvarchar(max)` | ❌       | XML-transformed payload (if available)            |
+| `SessionId`           | `nvarchar(128)` | ✅       | Service Bus session ID of the storing component   |
 
 ### Service Bus message format
 
@@ -41,11 +42,13 @@ Each Service Bus message body must be a JSON object with the following fields:
   "ProcessingComponent": "hl7_pims_transformer",
   "RawPayload": "MSH|...",
   "TargetSystem": "MPI",
-  "XmlPayload": "<ClinicalDocument>...</ClinicalDocument>"
+  "XmlPayload": "<ClinicalDocument>...</ClinicalDocument>",
+  "SessionId": "pims-to-mpi"
 }
 ```
 
-> `TargetSystem` and `XmlPayload` are optional.
+> `TargetSystem` and `XmlPayload` are optional. `SessionId` is required and is set by the producing component
+> (`EGRESS_SESSION_ID` for `hl7_server`, `INGRESS_SESSION_ID` for `hl7_sender`).
 
 ## Development
 

--- a/message_store_service/message_store_service/db_client.py
+++ b/message_store_service/message_store_service/db_client.py
@@ -24,9 +24,10 @@ INSERT INTO monitoring.Message (
     ProcessingComponent,
     TargetSystem,
     RawPayload,
-    XmlPayload
+    XmlPayload,
+    SessionId
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 
@@ -125,6 +126,7 @@ class DatabaseClient:
                     msg.target_system,
                     msg.raw_payload,
                     msg.xml_payload,
+                    msg.session_id,
                 )
                 for msg in messages
             ]

--- a/message_store_service/message_store_service/message_record.py
+++ b/message_store_service/message_store_service/message_record.py
@@ -14,6 +14,7 @@ class MessageRecord:
     target_system: Optional[str]
     raw_payload: str
     xml_payload: Optional[str]
+    session_id: str
 
 
 __all__ = ["MessageRecord"]

--- a/message_store_service/message_store_service/message_record_builder.py
+++ b/message_store_service/message_store_service/message_record_builder.py
@@ -27,6 +27,7 @@ def build_message_record(message: ServiceBusMessage) -> MessageRecord:
         source_system = data["SourceSystem"]
         processing_component = data["ProcessingComponent"]
         raw_payload = data["RawPayload"]
+        session_id = data["SessionId"]
     except KeyError as e:
         logger.exception(
             "Missing required field in message body - CorrelationId: %s",
@@ -66,6 +67,7 @@ def build_message_record(message: ServiceBusMessage) -> MessageRecord:
         target_system=target_system,
         raw_payload=raw_payload,
         xml_payload=xml_payload,
+        session_id=session_id,
     )
 
 

--- a/message_store_service/tests/test_app_config.py
+++ b/message_store_service/tests/test_app_config.py
@@ -19,7 +19,7 @@ class TestAppConfig(unittest.TestCase):
                 "SQL_SERVER": "localhost,1433",
                 "SQL_DATABASE": "IntegrationHub",
                 "SQL_USERNAME": "sa",
-                "MSSQL_SA_PASSWORD": "secret",
+                "MSSQL_SA_PASSWORD": "secret",  # nosec B105 — test fixture, not real password
                 "SQL_ENCRYPT": "No",
                 "SQL_TRUST_SERVER_CERTIFICATE": "Yes",
                 "MANAGED_IDENTITY_CLIENT_ID": "my-mi-client-id",

--- a/message_store_service/tests/test_db_client.py
+++ b/message_store_service/tests/test_db_client.py
@@ -15,6 +15,7 @@ def _make_record(
     target_system: Optional[str] = None,
     raw_payload: str = "MSH|...",
     xml_payload: Optional[str] = None,
+    session_id: str = "test-session",
 ) -> MessageRecord:
     """Helper to create a MessageRecord with sensible defaults."""
     return MessageRecord(
@@ -25,6 +26,7 @@ def _make_record(
         target_system=target_system,
         raw_payload=raw_payload,
         xml_payload=xml_payload,
+        session_id=session_id,
     )
 
 
@@ -36,7 +38,7 @@ class TestDatabaseClient(unittest.TestCase):
             sql_server="localhost,1433",
             sql_database="IntegrationHub",
             sql_username="sa",
-            sql_password="secret",
+            sql_password="secret",  # nosec B106 — test fixture, not real password
             sql_encrypt="yes",
             sql_trust_server_certificate="yes",
         )
@@ -101,6 +103,7 @@ class TestDatabaseClient(unittest.TestCase):
                 target_system=f"tgt-{i}" if i % 2 == 0 else None,
                 raw_payload=f"MSH|payload-{i}",
                 xml_payload=f"<msg id='{i}'/>" if i % 2 == 0 else None,
+                session_id=f"session-{i}",
             )
             for i in range(5)
         ]
@@ -121,6 +124,7 @@ class TestDatabaseClient(unittest.TestCase):
             self.assertEqual(row[5], record.target_system, f"row {i}: target_system mismatch")
             self.assertEqual(row[6], record.raw_payload, f"row {i}: raw_payload mismatch")
             self.assertEqual(row[7], record.xml_payload, f"row {i}: xml_payload mismatch")
+            self.assertEqual(row[8], record.session_id, f"row {i}: session_id mismatch")
 
     # ------------------------------------------------------------------
     # Connection reuse
@@ -402,14 +406,17 @@ class TestDatabaseClient(unittest.TestCase):
             target_system="tgt",
             raw_payload="raw",
             xml_payload="<xml/>",
+            session_id="test-session",
         )
 
         self.client.store_messages([record])
 
         row = mock_cursor.executemany.call_args[0][1][0]
         # Column order: ReceivedAt, StoredAt, CorrelationId, SourceSystem,
-        #               ProcessingComponent, TargetSystem, RawPayload, XmlPayload
-        self.assertEqual(row, (received_at, fixed_stored_at, "cid", "src", "comp", "tgt", "raw", "<xml/>"))
+        #               ProcessingComponent, TargetSystem, RawPayload, XmlPayload, SessionId
+        self.assertEqual(
+            row, (received_at, fixed_stored_at, "cid", "src", "comp", "tgt", "raw", "<xml/>", "test-session")
+        )
 
     # ------------------------------------------------------------------
     # Context manager

--- a/message_store_service/tests/test_message_record.py
+++ b/message_store_service/tests/test_message_record.py
@@ -19,6 +19,7 @@ class TestMessageRecord(unittest.TestCase):
             target_system="MPI",
             raw_payload="MSH|^~\\&|SENDING|FAC||",
             xml_payload="<message/>",
+            session_id="paris-to-mpi",
         )
 
         self.assertEqual(record.received_at, received_at)
@@ -28,6 +29,7 @@ class TestMessageRecord(unittest.TestCase):
         self.assertEqual(record.target_system, "MPI")
         self.assertEqual(record.raw_payload, "MSH|^~\\&|SENDING|FAC||")
         self.assertEqual(record.xml_payload, "<message/>")
+        self.assertEqual(record.session_id, "paris-to-mpi")
 
     def test_construction_with_optional_fields_none(self) -> None:
         """Verify optional fields (target_system, xml_payload) accept None."""
@@ -39,10 +41,12 @@ class TestMessageRecord(unittest.TestCase):
             target_system=None,
             raw_payload="MSH|^~\\&|SENDING|FAC||",
             xml_payload=None,
+            session_id="phw-to-mpi",
         )
 
         self.assertIsNone(record.target_system)
         self.assertIsNone(record.xml_payload)
+        self.assertEqual(record.session_id, "phw-to-mpi")
 
 
 if __name__ == "__main__":

--- a/message_store_service/tests/test_message_record_builder.py
+++ b/message_store_service/tests/test_message_record_builder.py
@@ -18,18 +18,22 @@ class TestBuildMessageRecord(unittest.TestCase):
         msg.body = [json.dumps(data).encode("utf-8")]
         return msg
 
-    def test_build_message_record_parses_json_with_all_fields(self) -> None:
-        received_at = "2025-06-01T09:59:00+00:00"
-
-        data = {
-            "MessageReceivedAt": received_at,
+    def _base_data(self) -> dict:  # type: ignore[type-arg]
+        """Minimal valid JSON payload including all required fields."""
+        return {
+            "MessageReceivedAt": "2025-06-01T09:59:00+00:00",
             "CorrelationId": "corr-123",
             "SourceSystem": "PARIS",
             "ProcessingComponent": "message_store_service",
             "TargetSystem": "MPI",
             "RawPayload": "MSH|^~\\&|PARIS|FAC|MPI|RECEIVING|...",
             "XmlPayload": "<message/>",
+            "SessionId": "paris-to-mpi",
         }
+
+    def test_build_message_record_parses_json_with_all_fields(self) -> None:
+        received_at = "2025-06-01T09:59:00+00:00"
+        data = self._base_data()
         msg = self._make_message_with_json_body(data)
 
         record = build_message_record(msg)
@@ -42,6 +46,7 @@ class TestBuildMessageRecord(unittest.TestCase):
         self.assertEqual(record.target_system, "MPI")
         self.assertEqual(record.raw_payload, "MSH|^~\\&|PARIS|FAC|MPI|RECEIVING|...")
         self.assertEqual(record.xml_payload, "<message/>")
+        self.assertEqual(record.session_id, "paris-to-mpi")
 
     def test_build_message_record_with_optional_fields_missing(self) -> None:
         """When optional fields (TargetSystem, XmlPayload) are missing, they default to None."""
@@ -51,6 +56,7 @@ class TestBuildMessageRecord(unittest.TestCase):
             "SourceSystem": "PHW",
             "ProcessingComponent": "hl7_phw_transformer",
             "RawPayload": "MSH|^~\\&|PHW|...",
+            "SessionId": "phw-to-mpi",
         }
         msg = self._make_message_with_json_body(data)
 
@@ -61,6 +67,7 @@ class TestBuildMessageRecord(unittest.TestCase):
         self.assertEqual(record.processing_component, "hl7_phw_transformer")
         self.assertIsNone(record.target_system)
         self.assertIsNone(record.xml_payload)
+        self.assertEqual(record.session_id, "phw-to-mpi")
 
     def test_build_message_record_raises_on_invalid_json(self) -> None:
         """If the message body is not valid JSON, ValueError should be raised."""
@@ -77,7 +84,7 @@ class TestBuildMessageRecord(unittest.TestCase):
         data = {
             "MessageReceivedAt": "2025-06-01T09:59:00+00:00",
             "CorrelationId": "corr-789",
-            # Missing SourceSystem, ProcessingComponent and RawPayload
+            # Missing SourceSystem, ProcessingComponent, RawPayload, and SessionId
         }
         msg = self._make_message_with_json_body(data)
 
@@ -95,13 +102,8 @@ class TestBuildMessageRecord(unittest.TestCase):
             build_message_record(msg)
 
     def test_build_message_record_raises_on_invalid_received_at_format(self) -> None:
-        data = {
-            "MessageReceivedAt": "not-a-datetime",
-            "CorrelationId": "corr-000",
-            "SourceSystem": "SRC",
-            "ProcessingComponent": "svc",
-            "RawPayload": "MSH|...",
-        }
+        data = self._base_data()
+        data["MessageReceivedAt"] = "not-a-datetime"
         msg = self._make_message_with_json_body(data)
 
         with self.assertRaises(ValueError) as ctx:
@@ -111,15 +113,9 @@ class TestBuildMessageRecord(unittest.TestCase):
 
     def test_build_message_record_with_empty_optional_fields(self) -> None:
         """When optional fields are present but empty strings, they are preserved."""
-        data = {
-            "MessageReceivedAt": "2025-06-01T09:59:00+00:00",
-            "CorrelationId": "corr-111",
-            "SourceSystem": "SYS",
-            "ProcessingComponent": "test_service",
-            "TargetSystem": "",
-            "RawPayload": "MSH|...",
-            "XmlPayload": "",
-        }
+        data = self._base_data()
+        data["TargetSystem"] = ""
+        data["XmlPayload"] = ""
         msg = self._make_message_with_json_body(data)
 
         record = build_message_record(msg)
@@ -144,6 +140,7 @@ class TestBuildMessageRecords(unittest.TestCase):
                 "SourceSystem": "S1",
                 "ProcessingComponent": "svc1",
                 "RawPayload": "body1",
+                "SessionId": "session-1",
             }),
             self._make_message({
                 "MessageReceivedAt": "2025-06-01T09:59:01+00:00",
@@ -151,6 +148,7 @@ class TestBuildMessageRecords(unittest.TestCase):
                 "SourceSystem": "S2",
                 "ProcessingComponent": "svc2",
                 "RawPayload": "body2",
+                "SessionId": "session-2",
             }),
         ]
 

--- a/message_store_service/tests/test_message_store_service.py
+++ b/message_store_service/tests/test_message_store_service.py
@@ -21,7 +21,7 @@ class TestMessageStoreServiceInit(unittest.TestCase):
         mock_config.sql_server = "localhost,1433"
         mock_config.sql_database = "IntegrationHub"
         mock_config.sql_username = "sa"
-        mock_config.sql_password = "secret"
+        mock_config.sql_password = "secret"  # nosec B105 — test fixture, not real password
         mock_config.sql_encrypt = "yes"
         mock_config.sql_trust_server_certificate = "yes"
         mock_config.managed_identity_client_id = None
@@ -39,7 +39,7 @@ class TestMessageStoreServiceInit(unittest.TestCase):
             sql_server="localhost,1433",
             sql_database="IntegrationHub",
             sql_username="sa",
-            sql_password="secret",
+            sql_password="secret",  # nosec B106 — test fixture, not real password
             sql_encrypt="yes",
             sql_trust_server_certificate="yes",
             managed_identity_client_id=None,

--- a/message_store_service/uv.lock
+++ b/message_store_service/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1219,7 +1219,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1227,9 +1227,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/pipeline-ado/templates/code-quality-template.yml
+++ b/pipeline-ado/templates/code-quality-template.yml
@@ -110,7 +110,8 @@ jobs:
           cd ${{ parameters.appName }}
           
           echo "🔐 Running pip-audit for dependency vulnerability scanning..."
-          uv tool run pip-audit --desc
+          # Temporary ignore for no-fix advisory on transitive Pygments; review periodically.
+          uv tool run pip-audit --desc --ignore-vuln GHSA-5239-wwwm-4pmq
           
           echo "✅ Dependency scan completed"
           echo "##[endgroup]"
@@ -151,7 +152,8 @@ jobs:
           echo ""
           
           echo "🛡️ Running UV-Secure dependency security scan..."
-          if ! uv tool run uv-secure; then
+          # Temporary ignore for no-fix advisory on transitive Pygments; review periodically.
+          if ! uv tool run uv-secure --ignore-vulns GHSA-5239-wwwm-4pmq; then
             echo "##[error]UV-Secure found dependency security issues!"
             VALIDATION_FAILED=1
           fi

--- a/shared_libs/event_logger_lib/uv.lock
+++ b/shared_libs/event_logger_lib/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -623,7 +623,7 @@ crypto = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -631,9 +631,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/shared_libs/message_bus_lib/message_bus_lib/message_store_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/message_store_client.py
@@ -30,6 +30,7 @@ class MessageStoreClient:
         correlation_id: str,
         source_system: str,
         raw_payload: str,
+        session_id: str,
         xml_payload: str | None = None,
         target_system: str | None = None,
     ) -> None:
@@ -40,6 +41,7 @@ class MessageStoreClient:
             correlation_id: Unique ID to track the message through the Integration Hub.
             source_system: The system that sent the message (MSH.3).
             raw_payload: The raw HL7 message.
+            session_id: The Service Bus session ID of the component that stored the message.
             xml_payload: XML representation of the HL7 message (optional).
             target_system: The target system. Defaults to peer_service if not provided.
         """
@@ -56,6 +58,7 @@ class MessageStoreClient:
             "TargetSystem": target_system if target_system is not None else self.peer_service,
             "RawPayload": raw_payload,
             "XmlPayload": xml_payload,
+            "SessionId": session_id,
         }
         try:
             self.sender_client.send_text_message(json.dumps(store_event))

--- a/shared_libs/message_bus_lib/tests/test_message_store_client.py
+++ b/shared_libs/message_bus_lib/tests/test_message_store_client.py
@@ -16,6 +16,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="test-uuid",
             source_system="252",
             raw_payload="MSH|^~\\&|...",
+            session_id="test-session",
         )
 
         self.mock_sender.send_text_message.assert_called_once()
@@ -29,6 +30,7 @@ class TestMessageStoreClient(unittest.TestCase):
         self.assertEqual(sent_data["TargetSystem"], "test-peer")
         self.assertEqual(sent_data["RawPayload"], "MSH|^~\\&|...")
         self.assertIsNone(sent_data["XmlPayload"])
+        self.assertEqual(sent_data["SessionId"], "test-session")
 
     def test_send_to_store_with_xml_payload(self) -> None:
         self.client.send_to_store(
@@ -36,6 +38,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="test-uuid",
             source_system="252",
             raw_payload="MSH|^~\\&|...",
+            session_id="test-session",
             xml_payload="<xml>message</xml>",
         )
 
@@ -50,6 +53,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="test-uuid",
             source_system="252",
             raw_payload="MSH|^~\\&|...",
+            session_id="test-session",
             target_system="custom-target",
         )
 
@@ -67,6 +71,7 @@ class TestMessageStoreClient(unittest.TestCase):
                 correlation_id="test-uuid",
                 source_system="252",
                 raw_payload="MSH|^~\\&|...",
+                session_id="test-session",
             )
 
         self.assertIn("Service Bus error", str(context.exception))
@@ -78,6 +83,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="test-uuid",
             source_system="252",
             raw_payload="MSH|^~\\&|...",
+            session_id="test-session",
         )
 
         mock_logger.info.assert_called_once_with("Message store event sent - CorrelationId: %s", "test-uuid")
@@ -92,6 +98,7 @@ class TestMessageStoreClient(unittest.TestCase):
                 correlation_id="test-uuid",
                 source_system="252",
                 raw_payload="MSH|^~\\&|...",
+                session_id="test-session",
             )
 
         mock_logger.error.assert_called_once()
@@ -113,6 +120,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="abc-123",
             source_system="SRC",
             raw_payload="RAW_DATA",
+            session_id="phw-to-mpi",
             xml_payload="<xml/>",
             target_system="TGT",
         )
@@ -128,6 +136,7 @@ class TestMessageStoreClient(unittest.TestCase):
             "TargetSystem",
             "RawPayload",
             "XmlPayload",
+            "SessionId",
         }
         self.assertEqual(set(sent_data.keys()), expected_keys)
 
@@ -142,6 +151,7 @@ class TestMessageStoreClient(unittest.TestCase):
             correlation_id="disabled-uuid",
             source_system="252",
             raw_payload="MSH|^~\\&|...",
+            session_id="test-session",
         )
 
         mock_logger.debug.assert_called_once_with(

--- a/shared_libs/message_bus_lib/uv.lock
+++ b/shared_libs/message_bus_lib/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -681,9 +681,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/shared_libs/metric_sender_lib/uv.lock
+++ b/shared_libs/metric_sender_lib/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -780,9 +780,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]

--- a/shared_libs/transformer_base_lib/uv.lock
+++ b/shared_libs/transformer_base_lib/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -848,9 +848,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Update AppConfig for hl7_server and hl7_sender to enforce required session IDs for ingress and egress
- Modify message processing to include session IDs in message store operations
- Enhance database schema to support session ID storage for replay functionality