### PR TITLE
Inthub 588006 refactor

### DIFF
--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -1,0 +1,345 @@
+# Consolidated Build Pipeline — build all (or selected) containers in one operation
+# Individual *-build.yml files remain for per-path CI triggers
+trigger: none
+pr: none
+
+parameters:
+  - name: SEMANTIC_VERSION
+    displayName: 'Semantic Version'
+    type: string
+    default: 'v0.1.0'
+
+  - name: buildApps
+    displayName: 'Apps to build (leave all checked for full build)'
+    type: object
+    default:
+      - hl7server
+      - hl7sender
+      - hl7mockreceiver
+      - hl7subscriptionsender
+      - hl7pimstransformer
+      - hl7phwtransformer
+      - hl7chemotransformer
+      - messagestoreservice
+      - messagereplayjob
+      - dashboard
+      - networktestapp
+
+variables:
+  acrName: 'uksdhcwihsharedcr'
+  azureServiceConnection: 'Azure - NHSWales-DHCW-IntegrationHub-Subscription'
+  POOL_NAME: 'UKS-DHCW-IH-DEV-ADOManagedPool'
+
+# ─── Standard apps (CodeQuality → Build, shared_libs + ca-certs) ─────────────
+stages:
+  # ── Code Quality ────────────────────────────────────────────────────────────
+  - stage: CodeQuality_hl7server
+    displayName: 'Code Quality — HL7 Server'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_server'
+          appDisplayName: 'HL7 Server'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7sender
+    displayName: 'Code Quality — HL7 Sender'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_sender'
+          appDisplayName: 'HL7 Sender'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7mockreceiver
+    displayName: 'Code Quality — HL7 Mock Receiver'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_mock_receiver'
+          appDisplayName: 'HL7 Mock Receiver'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7subscriptionsender
+    displayName: 'Code Quality — HL7 Subscription Sender'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_subscription_sender'
+          appDisplayName: 'HL7 Subscription Sender'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7pimstransformer
+    displayName: 'Code Quality — Pims HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_pims_transformer'
+          appDisplayName: 'Pims HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7phwtransformer
+    displayName: 'Code Quality — Phw HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_phw_transformer'
+          appDisplayName: 'Phw HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7chemotransformer
+    displayName: 'Code Quality — Chemocare HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_chemo_transformer'
+          appDisplayName: 'Chemocare HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_messagestoreservice
+    displayName: 'Code Quality — Message Store Service'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'message_store_service'
+          appDisplayName: 'Message Store Service'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_messagereplayjob
+    displayName: 'Code Quality — Message Replay Job'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'message_replay_job'
+          appDisplayName: 'Message Replay Job'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_dashboard
+    displayName: 'Code Quality — Dashboard'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'dashboard'
+          appDisplayName: 'Dashboard'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+          banditSourceDir: 'dashboard'
+          usePytest: true
+
+  # ── Build & Push ────────────────────────────────────────────────────────────
+  - stage: Build_hl7server
+    displayName: 'Build — HL7 Server'
+    dependsOn: CodeQuality_hl7server
+    condition: and(in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7Server'
+          displayName: 'Build and Push HL7 Server'
+          appName: 'hl7server'
+          dockerfilePath: 'hl7_server/Dockerfile'
+          buildContext: 'hl7_server'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7sender
+    displayName: 'Build — HL7 Sender'
+    dependsOn: CodeQuality_hl7sender
+    condition: and(in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7Sender'
+          displayName: 'Build and Push HL7 Sender'
+          appName: 'hl7sender'
+          dockerfilePath: 'hl7_sender/Dockerfile'
+          buildContext: 'hl7_sender'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7mockreceiver
+    displayName: 'Build — HL7 Mock Receiver'
+    dependsOn: CodeQuality_hl7mockreceiver
+    condition: and(in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7MockReceiver'
+          displayName: 'Build and Push HL7 Mock Receiver'
+          appName: 'hl7mockreceiver'
+          dockerfilePath: 'hl7_mock_receiver/Dockerfile'
+          buildContext: 'hl7_mock_receiver'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7subscriptionsender
+    displayName: 'Build — HL7 Subscription Sender'
+    dependsOn: CodeQuality_hl7subscriptionsender
+    condition: and(in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7SubscriptionSender'
+          displayName: 'Build and Push HL7 Subscription Sender'
+          appName: 'hl7subsndr'
+          dockerfilePath: 'hl7_subscription_sender/Dockerfile'
+          buildContext: 'hl7_subscription_sender'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7pimstransformer
+    displayName: 'Build — Pims HL7 Transformer'
+    dependsOn: CodeQuality_hl7pimstransformer
+    condition: and(in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushPimsHL7Transformer'
+          displayName: 'Build and Push Pims HL7 Transformer'
+          appName: 'pims-hl7transformer'
+          dockerfilePath: 'hl7_pims_transformer/Dockerfile'
+          buildContext: 'hl7_pims_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7phwtransformer
+    displayName: 'Build — Phw HL7 Transformer'
+    dependsOn: CodeQuality_hl7phwtransformer
+    condition: and(in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushPhwHL7Transformer'
+          displayName: 'Build and Push Phw HL7 Transformer'
+          appName: 'phw-hl7transformer'
+          dockerfilePath: 'hl7_phw_transformer/Dockerfile'
+          buildContext: 'hl7_phw_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7chemotransformer
+    displayName: 'Build — Chemocare HL7 Transformer'
+    dependsOn: CodeQuality_hl7chemotransformer
+    condition: and(in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushChemoHL7Transformer'
+          displayName: 'Build and Push Chemocare HL7 Transformer'
+          appName: 'chemo-hl7transformer'
+          dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
+          buildContext: 'hl7_chemo_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_messagestoreservice
+    displayName: 'Build — Message Store Service'
+    dependsOn: CodeQuality_messagestoreservice
+    condition: and(in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushMessageStoreService'
+          displayName: 'Build and Push Message Store Service'
+          appName: 'message-store-service'
+          dockerfilePath: 'message_store_service/Dockerfile'
+          buildContext: 'message_store_service'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_messagereplayjob
+    displayName: 'Build — Message Replay Job'
+    dependsOn: CodeQuality_messagereplayjob
+    condition: and(in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushMessageReplayJob'
+          displayName: 'Build and Push Message Replay Job'
+          appName: 'message-replay-job'
+          dockerfilePath: 'message_replay_job/Dockerfile'
+          buildContext: 'message_replay_job'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  # Dashboard uses a different service connection
+  - stage: Build_dashboard
+    displayName: 'Build — Dashboard'
+    dependsOn: CodeQuality_dashboard
+    condition: and(in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushDashboard'
+          displayName: 'Build and Push Dashboard'
+          appName: 'dashboard'
+          dockerfilePath: 'dashboard/Dockerfile'
+          buildContext: 'dashboard'
+          acrName: $(acrName)
+          azureServiceConnection: 'DEV-MonitoringDashboard'
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  # Network Test App has no code quality stage
+  - stage: Build_networktestapp
+    displayName: 'Build — Network Test App'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'networktestapp')
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushNetworkTestApp'
+          displayName: 'Build and Push Network Test App'
+          appName: 'networktestapp'
+          dockerfilePath: 'network_test_app/Dockerfile'
+          buildContext: 'network_test_app'
+          additionalContexts: 'ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}

--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -30,316 +30,327 @@ variables:
   azureServiceConnection: 'Azure - NHSWales-DHCW-IntegrationHub-Subscription'
   POOL_NAME: 'UKS-DHCW-IH-DEV-ADOManagedPool'
 
-# ─── Standard apps (CodeQuality → Build, shared_libs + ca-certs) ─────────────
+# All CodeQuality stages run in parallel; each Build stage depends only on its own CQ gate.
+# Stages are conditionally included at compile time based on the buildApps parameter.
 stages:
   # ── Code Quality ────────────────────────────────────────────────────────────
-  - stage: CodeQuality_hl7server
-    displayName: 'Code Quality — HL7 Server'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_server'
-          appDisplayName: 'HL7 Server'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7server') }}:
+    - stage: CodeQuality_hl7server
+      displayName: 'Code Quality — HL7 Server'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_server'
+            appDisplayName: 'HL7 Server'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7sender
-    displayName: 'Code Quality — HL7 Sender'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_sender'
-          appDisplayName: 'HL7 Sender'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7sender') }}:
+    - stage: CodeQuality_hl7sender
+      displayName: 'Code Quality — HL7 Sender'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_sender'
+            appDisplayName: 'HL7 Sender'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7mockreceiver
-    displayName: 'Code Quality — HL7 Mock Receiver'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_mock_receiver'
-          appDisplayName: 'HL7 Mock Receiver'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7mockreceiver') }}:
+    - stage: CodeQuality_hl7mockreceiver
+      displayName: 'Code Quality — HL7 Mock Receiver'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_mock_receiver'
+            appDisplayName: 'HL7 Mock Receiver'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7subscriptionsender
-    displayName: 'Code Quality — HL7 Subscription Sender'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_subscription_sender'
-          appDisplayName: 'HL7 Subscription Sender'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7subscriptionsender') }}:
+    - stage: CodeQuality_hl7subscriptionsender
+      displayName: 'Code Quality — HL7 Subscription Sender'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_subscription_sender'
+            appDisplayName: 'HL7 Subscription Sender'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7pimstransformer
-    displayName: 'Code Quality — Pims HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_pims_transformer'
-          appDisplayName: 'Pims HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7pimstransformer') }}:
+    - stage: CodeQuality_hl7pimstransformer
+      displayName: 'Code Quality — Pims HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_pims_transformer'
+            appDisplayName: 'Pims HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7phwtransformer
-    displayName: 'Code Quality — Phw HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_phw_transformer'
-          appDisplayName: 'Phw HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7phwtransformer') }}:
+    - stage: CodeQuality_hl7phwtransformer
+      displayName: 'Code Quality — Phw HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_phw_transformer'
+            appDisplayName: 'Phw HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7chemotransformer
-    displayName: 'Code Quality — Chemocare HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_chemo_transformer'
-          appDisplayName: 'Chemocare HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7chemotransformer') }}:
+    - stage: CodeQuality_hl7chemotransformer
+      displayName: 'Code Quality — Chemocare HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_chemo_transformer'
+            appDisplayName: 'Chemocare HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_messagestoreservice
-    displayName: 'Code Quality — Message Store Service'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_store_service'
-          appDisplayName: 'Message Store Service'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'messagestoreservice') }}:
+    - stage: CodeQuality_messagestoreservice
+      displayName: 'Code Quality — Message Store Service'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'message_store_service'
+            appDisplayName: 'Message Store Service'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_messagereplayjob
-    displayName: 'Code Quality — Message Replay Job'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_replay_job'
-          appDisplayName: 'Message Replay Job'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'messagereplayjob') }}:
+    - stage: CodeQuality_messagereplayjob
+      displayName: 'Code Quality — Message Replay Job'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'message_replay_job'
+            appDisplayName: 'Message Replay Job'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_dashboard
-    displayName: 'Code Quality — Dashboard'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'dashboard'
-          appDisplayName: 'Dashboard'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
-          banditSourceDir: 'dashboard'
-          usePytest: true
+  - ${{ if containsValue(parameters.buildApps, 'dashboard') }}:
+    - stage: CodeQuality_dashboard
+      displayName: 'Code Quality — Dashboard'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'dashboard'
+            appDisplayName: 'Dashboard'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
+            banditSourceDir: 'dashboard'
+            usePytest: true
 
   # ── Build & Push ────────────────────────────────────────────────────────────
-  - stage: Build_hl7server
-    displayName: 'Build — HL7 Server'
-    dependsOn: CodeQuality_hl7server
-    condition: and(in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7Server'
-          displayName: 'Build and Push HL7 Server'
-          appName: 'hl7server'
-          dockerfilePath: 'hl7_server/Dockerfile'
-          buildContext: 'hl7_server'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7server') }}:
+    - stage: Build_hl7server
+      displayName: 'Build — HL7 Server'
+      dependsOn: CodeQuality_hl7server
+      condition: in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7Server'
+            displayName: 'Build and Push HL7 Server'
+            appName: 'hl7server'
+            dockerfilePath: 'hl7_server/Dockerfile'
+            buildContext: 'hl7_server'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7sender
-    displayName: 'Build — HL7 Sender'
-    dependsOn: CodeQuality_hl7sender
-    condition: and(in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7Sender'
-          displayName: 'Build and Push HL7 Sender'
-          appName: 'hl7sender'
-          dockerfilePath: 'hl7_sender/Dockerfile'
-          buildContext: 'hl7_sender'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7sender') }}:
+    - stage: Build_hl7sender
+      displayName: 'Build — HL7 Sender'
+      dependsOn: CodeQuality_hl7sender
+      condition: in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7Sender'
+            displayName: 'Build and Push HL7 Sender'
+            appName: 'hl7sender'
+            dockerfilePath: 'hl7_sender/Dockerfile'
+            buildContext: 'hl7_sender'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7mockreceiver
-    displayName: 'Build — HL7 Mock Receiver'
-    dependsOn: CodeQuality_hl7mockreceiver
-    condition: and(in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7MockReceiver'
-          displayName: 'Build and Push HL7 Mock Receiver'
-          appName: 'hl7mockreceiver'
-          dockerfilePath: 'hl7_mock_receiver/Dockerfile'
-          buildContext: 'hl7_mock_receiver'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7mockreceiver') }}:
+    - stage: Build_hl7mockreceiver
+      displayName: 'Build — HL7 Mock Receiver'
+      dependsOn: CodeQuality_hl7mockreceiver
+      condition: in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7MockReceiver'
+            displayName: 'Build and Push HL7 Mock Receiver'
+            appName: 'hl7mockreceiver'
+            dockerfilePath: 'hl7_mock_receiver/Dockerfile'
+            buildContext: 'hl7_mock_receiver'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7subscriptionsender
-    displayName: 'Build — HL7 Subscription Sender'
-    dependsOn: CodeQuality_hl7subscriptionsender
-    condition: and(in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7SubscriptionSender'
-          displayName: 'Build and Push HL7 Subscription Sender'
-          appName: 'hl7subsndr'
-          dockerfilePath: 'hl7_subscription_sender/Dockerfile'
-          buildContext: 'hl7_subscription_sender'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7subscriptionsender') }}:
+    - stage: Build_hl7subscriptionsender
+      displayName: 'Build — HL7 Subscription Sender'
+      dependsOn: CodeQuality_hl7subscriptionsender
+      condition: in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7SubscriptionSender'
+            displayName: 'Build and Push HL7 Subscription Sender'
+            appName: 'hl7subsndr'
+            dockerfilePath: 'hl7_subscription_sender/Dockerfile'
+            buildContext: 'hl7_subscription_sender'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7pimstransformer
-    displayName: 'Build — Pims HL7 Transformer'
-    dependsOn: CodeQuality_hl7pimstransformer
-    condition: and(in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushPimsHL7Transformer'
-          displayName: 'Build and Push Pims HL7 Transformer'
-          appName: 'pims-hl7transformer'
-          dockerfilePath: 'hl7_pims_transformer/Dockerfile'
-          buildContext: 'hl7_pims_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7pimstransformer') }}:
+    - stage: Build_hl7pimstransformer
+      displayName: 'Build — Pims HL7 Transformer'
+      dependsOn: CodeQuality_hl7pimstransformer
+      condition: in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushPimsHL7Transformer'
+            displayName: 'Build and Push Pims HL7 Transformer'
+            appName: 'pims-hl7transformer'
+            dockerfilePath: 'hl7_pims_transformer/Dockerfile'
+            buildContext: 'hl7_pims_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7phwtransformer
-    displayName: 'Build — Phw HL7 Transformer'
-    dependsOn: CodeQuality_hl7phwtransformer
-    condition: and(in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushPhwHL7Transformer'
-          displayName: 'Build and Push Phw HL7 Transformer'
-          appName: 'phw-hl7transformer'
-          dockerfilePath: 'hl7_phw_transformer/Dockerfile'
-          buildContext: 'hl7_phw_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7phwtransformer') }}:
+    - stage: Build_hl7phwtransformer
+      displayName: 'Build — Phw HL7 Transformer'
+      dependsOn: CodeQuality_hl7phwtransformer
+      condition: in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushPhwHL7Transformer'
+            displayName: 'Build and Push Phw HL7 Transformer'
+            appName: 'phw-hl7transformer'
+            dockerfilePath: 'hl7_phw_transformer/Dockerfile'
+            buildContext: 'hl7_phw_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7chemotransformer
-    displayName: 'Build — Chemocare HL7 Transformer'
-    dependsOn: CodeQuality_hl7chemotransformer
-    condition: and(in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushChemoHL7Transformer'
-          displayName: 'Build and Push Chemocare HL7 Transformer'
-          appName: 'chemo-hl7transformer'
-          dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
-          buildContext: 'hl7_chemo_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7chemotransformer') }}:
+    - stage: Build_hl7chemotransformer
+      displayName: 'Build — Chemocare HL7 Transformer'
+      dependsOn: CodeQuality_hl7chemotransformer
+      condition: in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushChemoHL7Transformer'
+            displayName: 'Build and Push Chemocare HL7 Transformer'
+            appName: 'chemo-hl7transformer'
+            dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
+            buildContext: 'hl7_chemo_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_messagestoreservice
-    displayName: 'Build — Message Store Service'
-    dependsOn: CodeQuality_messagestoreservice
-    condition: and(in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushMessageStoreService'
-          displayName: 'Build and Push Message Store Service'
-          appName: 'message-store-service'
-          dockerfilePath: 'message_store_service/Dockerfile'
-          buildContext: 'message_store_service'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'messagestoreservice') }}:
+    - stage: Build_messagestoreservice
+      displayName: 'Build — Message Store Service'
+      dependsOn: CodeQuality_messagestoreservice
+      condition: in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushMessageStoreService'
+            displayName: 'Build and Push Message Store Service'
+            appName: 'message-store-service'
+            dockerfilePath: 'message_store_service/Dockerfile'
+            buildContext: 'message_store_service'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_messagereplayjob
-    displayName: 'Build — Message Replay Job'
-    dependsOn: CodeQuality_messagereplayjob
-    condition: and(in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushMessageReplayJob'
-          displayName: 'Build and Push Message Replay Job'
-          appName: 'message-replay-job'
-          dockerfilePath: 'message_replay_job/Dockerfile'
-          buildContext: 'message_replay_job'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'messagereplayjob') }}:
+    - stage: Build_messagereplayjob
+      displayName: 'Build — Message Replay Job'
+      dependsOn: CodeQuality_messagereplayjob
+      condition: in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushMessageReplayJob'
+            displayName: 'Build and Push Message Replay Job'
+            appName: 'message-replay-job'
+            dockerfilePath: 'message_replay_job/Dockerfile'
+            buildContext: 'message_replay_job'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
   # Dashboard uses a different service connection
-  - stage: Build_dashboard
-    displayName: 'Build — Dashboard'
-    dependsOn: CodeQuality_dashboard
-    condition: and(in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushDashboard'
-          displayName: 'Build and Push Dashboard'
-          appName: 'dashboard'
-          dockerfilePath: 'dashboard/Dockerfile'
-          buildContext: 'dashboard'
-          acrName: $(acrName)
-          azureServiceConnection: 'DEV-MonitoringDashboard'
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'dashboard') }}:
+    - stage: Build_dashboard
+      displayName: 'Build — Dashboard'
+      dependsOn: CodeQuality_dashboard
+      condition: in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushDashboard'
+            displayName: 'Build and Push Dashboard'
+            appName: 'dashboard'
+            dockerfilePath: 'dashboard/Dockerfile'
+            buildContext: 'dashboard'
+            acrName: $(acrName)
+            azureServiceConnection: 'DEV-MonitoringDashboard'
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
   # Network Test App has no code quality stage
-  - stage: Build_networktestapp
-    displayName: 'Build — Network Test App'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'networktestapp')
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushNetworkTestApp'
-          displayName: 'Build and Push Network Test App'
-          appName: 'networktestapp'
-          dockerfilePath: 'network_test_app/Dockerfile'
-          buildContext: 'network_test_app'
-          additionalContexts: 'ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'networktestapp') }}:
+    - stage: Build_networktestapp
+      displayName: 'Build — Network Test App'
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushNetworkTestApp'
+            displayName: 'Build and Push Network Test App'
+            appName: 'networktestapp'
+            dockerfilePath: 'network_test_app/Dockerfile'
+            buildContext: 'network_test_app'
+            additionalContexts: 'ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -1,5 +1,6 @@
-# PR Validation Pipeline using Templates
-# This pipeline validates code quality, security, and tests for all apps
+# PR Validation Pipeline — Single Job
+# Consolidates 16 code quality checks into one job to avoid 16× agent allocation overhead.
+# Tools and shared libs are installed once; checks loop through all apps sequentially.
 trigger: none
 
 pr:
@@ -30,131 +31,199 @@ stages:
   - stage: PRValidation
     displayName: 'PR Code Quality & Unit Tests'
     jobs:
-      # HL7 Server validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_server'
-          appDisplayName: 'HL7 Server'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+      - job: CodeQualityAll
+        displayName: 'Code Quality & Tests — All Apps'
+        pool:
+          name: ${{ variables.POOL_NAME_NON_PROD }}
+        timeoutInMinutes: 30
 
-      # HL7 Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_phw_transformer'
-          appDisplayName: 'HL7 Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+        steps:
+          - checkout: self
+            displayName: 'Checkout Repository'
+            fetchDepth: 1
 
-      # HL7 Sender validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_sender'
-          appDisplayName: 'HL7 Sender'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - task: UsePythonVersion@0
+            displayName: 'Use Python $(pythonVersion)'
+            inputs:
+              versionSpec: '$(pythonVersion)'
 
-      # HL7 Subscription Sender validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_subscription_sender'
-          appDisplayName: 'HL7 Subscription Sender'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - task: Cache@2
+            displayName: 'Cache UV tools and packages'
+            continueOnError: true
+            inputs:
+              key: 'uv-cache | "python-$(pythonVersion)" | "$(Agent.OS)" | "pr-validation"'
+              restoreKeys: |
+                uv-cache | "python-$(pythonVersion)" | "$(Agent.OS)"
+              path: $(Pipeline.Workspace)/.uv-cache
 
-      # HL7 Mock Receiver validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_mock_receiver'
-          appDisplayName: 'HL7 Mock Receiver'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              echo "##[group]Install UV and code quality tools"
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      # HL7 Chemo Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_chemo_transformer'
-          appDisplayName: 'HL7 Chemo Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              python -m pip install uv
+              uv tool install ruff
+              uv tool install bandit
+              uv tool install mypy
+              uv tool install pip-audit
 
-      # HL7 PIMS Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_pims_transformer'
-          appDisplayName: 'HL7 PIMS Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              uv --version
+              echo "✅ UV and tools installed"
+              echo "##[endgroup]"
+            displayName: 'Install UV and Code Quality Tools'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
-      # Message Store Service validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_store_service'
-          appDisplayName: 'Message Store Service'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              echo "##[group]Install Shared Dependencies"
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      # BusWatch validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'buswatch'
-          appDisplayName: 'BusWatch'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              uv pip install --system -e shared_libs/message_bus_lib/
+              uv pip install --system -e shared_libs/health_check_lib/
+              uv pip install --system -e shared_libs/processor_manager_lib/
+              uv pip install --system -e shared_libs/event_logger_lib/
+              uv pip install --system -e shared_libs/field_utils_lib/
+              uv pip install --system -e shared_libs/transformer_base_lib/
+              uv pip install --system -e shared_libs/hl7_validation/
 
-      # Shared Libraries validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/message_bus_lib'
-          appDisplayName: 'Message Bus Library'
-          banditSourceDir: 'message_bus_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              echo "✅ Shared libraries installed"
+              echo "##[endgroup]"
+            displayName: 'Install Shared Dependencies'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/event_logger_lib'
-          appDisplayName: 'Event Logger Library'
-          banditSourceDir: 'event_logger_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/health_check_lib'
-          appDisplayName: 'Health Check Library'
-          banditSourceDir: 'health_check_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              # Define all apps: "appDir|displayName|banditDir|testRunner"
+              # banditDir empty = use basename of appDir
+              # testRunner: unittest (default) or pytest
+              APPS=(
+                "hl7_server|HL7 Server||unittest"
+                "hl7_phw_transformer|PHW HL7 Transformer||unittest"
+                "hl7_sender|HL7 Sender||unittest"
+                "hl7_subscription_sender|HL7 Subscription Sender||unittest"
+                "hl7_mock_receiver|HL7 Mock Receiver||unittest"
+                "hl7_chemo_transformer|Chemo HL7 Transformer||unittest"
+                "hl7_pims_transformer|PIMS HL7 Transformer||unittest"
+                "message_store_service|Message Store Service||unittest"
+                "buswatch|BusWatch||unittest"
+                "shared_libs/message_bus_lib|Message Bus Library|message_bus_lib|unittest"
+                "shared_libs/event_logger_lib|Event Logger Library|event_logger_lib|unittest"
+                "shared_libs/health_check_lib|Health Check Library|health_check_lib|unittest"
+                "shared_libs/hl7_validation|HL7 Validation Library|hl7_validation|unittest"
+                "shared_libs/processor_manager_lib|Processor Manager Library|processor_manager_lib|unittest"
+                "shared_libs/transformer_base_lib|Transformer Base Library|transformer_base_lib|unittest"
+                "shared_libs/field_utils_lib|Field Utils Library|field_utils_lib|unittest"
+              )
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/hl7_validation'
-          appDisplayName: 'HL7 Validation Library'
-          banditSourceDir: 'hl7_validation'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              OVERALL_RESULT=0
+              FAILED_APPS=""
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/processor_manager_lib'
-          appDisplayName: 'Processor Manager Library'
-          banditSourceDir: 'processor_manager_lib'
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
-         
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/transformer_base_lib'
-          appDisplayName: 'Transformer Base Library'
-          banditSourceDir: 'transformer_base_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              for entry in "${APPS[@]}"; do
+                IFS='|' read -r APP_DIR DISPLAY_NAME BANDIT_DIR TEST_RUNNER <<< "$entry"
+                
+                # Default bandit dir to basename of app dir
+                if [ -z "$BANDIT_DIR" ]; then
+                  BANDIT_DIR=$(basename "$APP_DIR")
+                fi
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/field_utils_lib'
-          appDisplayName: 'Field Utils Library'
-          banditSourceDir: 'field_utils_lib'
+                echo ""
+                echo "╔══════════════════════════════════════════════════════════════╗"
+                echo "║  $DISPLAY_NAME"
+                echo "╚══════════════════════════════════════════════════════════════╝"
+                
+                APP_FAILED=0
 
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+                # Install app dependencies
+                echo "##[group]📦 Install $DISPLAY_NAME dependencies"
+                cd "$(Build.SourcesDirectory)/$APP_DIR"
+                uv pip install --system . 2>&1 || true
+                uv pip install --system --group dev . 2>&1 || echo "No dev dependencies"
+                echo "##[endgroup]"
+
+                # Ruff
+                echo "##[group]🔍 Ruff — $DISPLAY_NAME"
+                if ! uv tool run ruff check --output-format=github .; then
+                  echo "##[error]Ruff failed for $DISPLAY_NAME"
+                  APP_FAILED=1
+                fi
+                echo "##[endgroup]"
+
+                # Bandit
+                echo "##[group]🔒 Bandit — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if ! uv tool run bandit -r "$BANDIT_DIR" tests --severity-level medium; then
+                    echo "##[error]Bandit failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                else
+                  if ! uv tool run bandit -r "$BANDIT_DIR" --severity-level medium; then
+                    echo "##[error]Bandit failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                fi
+                echo "##[endgroup]"
+
+                # UV audit
+                echo "##[group]🛡️ UV Audit — $DISPLAY_NAME"
+                uv audit --ignore GHSA-5239-wwwm-4pmq 2>&1 || echo "##[warning]UV audit issues for $DISPLAY_NAME"
+                echo "##[endgroup]"
+
+                # MyPy
+                echo "##[group]🏷️ MyPy — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if ! uv tool run mypy "$BANDIT_DIR" tests --ignore-missing-imports; then
+                    echo "##[error]MyPy failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                else
+                  if ! uv tool run mypy "$BANDIT_DIR" --ignore-missing-imports; then
+                    echo "##[error]MyPy failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                fi
+                echo "##[endgroup]"
+
+                # Unit Tests
+                echo "##[group]🧪 Tests — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if [ "$TEST_RUNNER" = "pytest" ]; then
+                    if ! uv run --no-sync pytest tests -v; then
+                      echo "##[error]Tests failed for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  else
+                    if ! python -m unittest discover tests -v; then
+                      echo "##[error]Tests failed for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  fi
+                else
+                  echo "No tests directory found, skipping"
+                fi
+                echo "##[endgroup]"
+
+                if [ $APP_FAILED -eq 1 ]; then
+                  OVERALL_RESULT=1
+                  FAILED_APPS="$FAILED_APPS  ❌ $DISPLAY_NAME\n"
+                  echo "##[error]❌ $DISPLAY_NAME — FAILED"
+                else
+                  echo "✅ $DISPLAY_NAME — PASSED"
+                fi
+              done
+
+              echo ""
+              echo "════════════════════════════════════════════════════════════════"
+              if [ $OVERALL_RESULT -eq 0 ]; then
+                echo "✅ All 16 apps passed code quality and tests"
+              else
+                echo "##[error]Some apps failed:"
+                echo -e "$FAILED_APPS"
+                exit 1
+              fi
+            displayName: 'Run Code Quality & Tests — All Apps'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache

--- a/pipeline-ado/templates/code-quality-template.yml
+++ b/pipeline-ado/templates/code-quality-template.yml
@@ -45,9 +45,21 @@ jobs:
         inputs:
           versionSpec: '${{ parameters.pythonVersion }}'
 
+      - task: Cache@2
+        displayName: 'Cache UV tools and packages'
+        continueOnError: true
+        inputs:
+          key: 'uv-cache | "python-${{ parameters.pythonVersion }}" | "$(Agent.OS)" | ${{ parameters.appName }}/pyproject.toml'
+          restoreKeys: |
+            uv-cache | "python-${{ parameters.pythonVersion }}" | "$(Agent.OS)"
+          path: $(Pipeline.Workspace)/.uv-cache
+
       - script: |
           set -euo pipefail  # Bash strict mode
           echo "##[group]Install UV and code quality tools"
+
+          # Use pipeline cache directory
+          export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
           python -m pip install --upgrade pip
           python -m pip install uv
@@ -63,6 +75,8 @@ jobs:
           echo "✅ UV and global code quality tools installed"
           echo "##[endgroup]"
         displayName: 'Install UV and Code Quality Tools'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail
@@ -90,6 +104,8 @@ jobs:
 
           echo "##[endgroup]"
         displayName: 'Install Shared Dependencies'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail
@@ -106,6 +122,8 @@ jobs:
           echo "✅ Dependencies installed successfully"
           echo "##[endgroup]"
         displayName: 'Install ${{ parameters.appDisplayName }} Dependencies'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail

--- a/pipeline-ado/templates/docker-build-push-template.yml
+++ b/pipeline-ado/templates/docker-build-push-template.yml
@@ -133,6 +133,10 @@ jobs:
           BUILD_CMD="$BUILD_CMD --label \"org.opencontainers.image.source=$(Build.Repository.Uri)\""
           BUILD_CMD="$BUILD_CMD --file ${{ parameters.dockerfilePath }}"
           
+          # Registry-based layer caching — avoids rebuilding Python dependency layers
+          BUILD_CMD="$BUILD_CMD --cache-from type=registry,ref=$(DOCKER_REGISTRY)/$(IMAGE_NAME):buildcache"
+          BUILD_CMD="$BUILD_CMD --cache-to type=registry,ref=$(DOCKER_REGISTRY)/$(IMAGE_NAME):buildcache,mode=max"
+          
           # Add additional contexts if provided
           if [ -n "${{ parameters.additionalContexts }}" ]; then
             echo "Adding additional build contexts: ${{ parameters.additionalContexts }}"


### PR DESCRIPTION
 Pipeline Performance: Caching, Consolidated Builds & PR Speedup

  Problem

   - PR validation takes ~25 minutes despite each of the 16 code quality checks taking <1 minute — the bottleneck is 
  16× agent allocation overhead (~1.5 min each)
   - Docker builds rebuild all Python dependency layers from scratch every time — no layer caching
   - Building all containers requires triggering 11 separate pipelines individually
   - Code quality tool installs (uv, ruff, bandit, mypy, pip-audit) are repeated from scratch on every job

  Changes

  ⚡ PR Validation: 16 Jobs → 1 Job (pr-validation.yml)

   - Consolidates 16 separate code quality jobs into a single job with a loop
   - Agent allocation overhead drops from ~24 min to ~1.5 min
   - Tools (uv, ruff, bandit, mypy, pip-audit) and shared libraries installed once instead of 16 times
   - All 16 apps (9 services + 7 shared libs) checked sequentially with clear per-app pass/fail reporting
   - Expected PR time: ~5-7 min (down from ~25 min)

  🐳 Docker Layer Caching (docker-build-push-template.yml)

   - Adds --cache-from / --cache-to with type=registry to docker buildx build
   - Uses ACR as cache backend with a dedicated :buildcache tag per app
   - Warm builds skip Python dependency layer rebuild, saving ~2-4 min per build

  🔨 Consolidated Build Pipeline (build-apps.yml) — NEW

   - Manually-triggered pipeline that builds all 11 containers in one operation
   - All CodeQuality stages run in parallel; each Build stage gates on its own CQ result
   - Selectable apps via buildApps parameter — defaults to all, deselect for a subset
   - Uses compile-time ${{ if containsValue() }} for correct ADO template evaluation
   - Handles special cases: dashboard (different service connection, pytest), networktestapp (no CQ stage)
   - Individual *-build.yml files remain for per-path CI triggers

  📦 UV Tool & Package Caching (code-quality-template.yml)

   - Adds Cache@2 for UV tools/packages directory with continueOnError: true
   - Sets UV_CACHE_DIR on all uv-consuming steps
   - Cache key includes Python version, OS, and app-specific pyproject.toml

  Testing

   - Open a PR to trigger the consolidated PR validation pipeline and verify it completes in ~5-7 min
   - Register build-apps.yml as a new pipeline in ADO and trigger manually to test consolidated builds
   - Run an individual *-build.yml twice to verify Docker cache populates on first run and hits on second

  Notes

   - Docker cache will be cold on first run per app — subsequent builds benefit from layer reuse
   - Cache@2 may show Unable to find pipeline caching scopes on feature branches until main establishes the cache 
  scope — this is non-blocking
   - The code-quality-template.yml is still used by individual *-build.yml pipelines (unchanged); PR validation now 
  uses an inline equivalent for single-job efficiency