### PR TITLE
Inthub 588006 refactor

### DIFF
--- a/PIPELINE_IMPROVEMENTS.md
+++ b/PIPELINE_IMPROVEMENTS.md
@@ -1,0 +1,202 @@
+# Integration-Hub-Beta — Pipeline Improvement Plan
+
+> **Date:** 2026-05-11
+> **Branch:** INTHUB-588006-REFACTOR
+> **Status:** Items 1–4 completed, remaining items listed below
+
+---
+
+## Completed Improvements ✅
+
+| # | Improvement | Commit |
+|---|-------------|--------|
+| ✅ | Docker layer caching (`--cache-from`/`--cache-to` in docker-build-push-template.yml) | `b47d311` |
+| ✅ | UV tool & package caching (`Cache@2` in code-quality-template.yml) | `b47d311` |
+| ✅ | Consolidated `build-apps.yml` — all 11 containers in one pipeline | `5f17ad9`, `1fff070` |
+| ✅ | PR validation consolidated from 16 jobs → 1 job (~25 min → ~5-7 min) | `ef4a643` |
+
+---
+
+## Remaining Improvements
+
+### 🔴 Critical
+
+#### 1. Release Pipeline Missing 2 Apps
+**File:** `pipeline-ado/release-apps.yml`
+**Impact:** HIGH | **Effort:** SMALL
+
+`messagestoreservice` and `messagereplayjob` both have build pipelines and are included in `build-apps.yml` and PR validation, but are **not configured in the release pipeline**. These apps can be built but never released.
+
+**Fix:**
+- Add both apps to the `resources.pipelines` section
+- Add corresponding entries to `appConfig` in the dynamic stages template
+- Verify the `appImageName` matches the Docker image name used in the build pipeline
+
+---
+
+#### 2. Network Test App Missing CodeQuality Stage
+**File:** `pipeline-ado/networktestapp-build.yml`
+**Impact:** HIGH | **Effort:** SMALL
+
+The only app without a CodeQuality stage in its individual build pipeline. All other 10 apps run code quality checks before building. Code quality IS checked in `build-apps.yml` and `pr-validation.yml`, but the individual pipeline bypasses it entirely.
+
+**Fix:**
+- Add a CodeQuality stage before the BuildAndPush stage, following the pattern from other `*-build.yml` files
+
+---
+
+### 🟠 High Priority
+
+#### 3. BusWatch — Orphan in PR Validation
+**File:** `pipeline-ado/pr-validation.yml`
+**Impact:** MEDIUM | **Effort:** SMALL
+
+`buswatch` is included in PR validation (code quality + tests run) but has **no build pipeline** and is **not in the release pipeline**. Code is validated but never built or released.
+
+**Action Required:**
+- Confirm with the team: is BusWatch still maintained?
+- If yes → create `buswatch-build.yml` and add to `release-apps.yml`
+- If no → remove from `pr-validation.yml` and path triggers
+
+---
+
+#### 4. Trivy Scanning is Non-Blocking
+**File:** `pipeline-ado/templates/docker-build-push-template.yml` (line ~168)
+**Impact:** MEDIUM | **Effort:** SMALL
+
+The Trivy container vulnerability scan uses `continueOnError: true` and `--exit-code 0`, meaning vulnerabilities **never block a build**. Critical vulnerabilities can be pushed to ACR undetected.
+
+**Recommendation:**
+- Add a template parameter `blockOnCriticalVulnerabilities` (default: `true`)
+- When enabled, use `--exit-code 1 --severity CRITICAL` so builds fail on critical CVEs
+- Keep `continueOnError: true` for non-critical severities
+
+---
+
+#### 5. Trivy Version Not Pinned
+**File:** `pipeline-ado/templates/docker-build-push-template.yml` (line ~81)
+**Impact:** MEDIUM | **Effort:** SMALL
+
+Trivy is installed via `sudo apt-get install -y trivy` which always pulls the latest version. This makes builds non-deterministic — scanning behaviour can change without any code changes.
+
+**Fix:**
+- Pin to a specific version: `sudo apt-get install -y trivy=0.XX.X`
+- Or use a versioned container: `docker run aquasec/trivy:0.XX.X`
+
+---
+
+### 🟡 Medium Priority
+
+#### 6. No Test Result Publishing
+**Files:** All pipeline files with test steps
+**Impact:** MEDIUM | **Effort:** MEDIUM
+
+Unit tests run (pytest/unittest) but results are **not published to ADO**. Test results are only visible in raw logs, not in the ADO Tests tab. No coverage reports are generated or tracked.
+
+**Fix:**
+- Add `--junitxml=test-results.xml` to pytest / use `xmlrunner` for unittest
+- Add `PublishTestResults@2` task after test execution
+- Optionally add `PublishCodeCoverageResults@2` for coverage tracking
+
+---
+
+#### 7. No Scheduled Security Scans
+**Files:** None (missing capability)
+**Impact:** MEDIUM | **Effort:** MEDIUM
+
+Trivy scans only run during builds. Released container images in ACR are **never re-scanned** for newly discovered vulnerabilities. Dependency audits (`pip-audit`, `uv audit`) also only run during builds.
+
+**Recommendation:**
+- Create `nightly-security-scan.yml` with a cron schedule
+- Scan all released images in ACR for CRITICAL/HIGH vulnerabilities
+- Send notifications on new findings
+
+---
+
+#### 8. ACR Cleanup Could Be Optimised
+**File:** `pipeline-ado/templates/docker-build-push-template.yml` (lines ~218-248)
+**Impact:** MEDIUM | **Effort:** SMALL
+
+Current cleanup retains 50 images and deletes excess tags one-at-a-time. Issues:
+- Sequential deletion is slow for large image sets
+- No check whether a tag is currently deployed in production
+- The `buildcache` tag accumulates and is never cleaned
+
+**Recommendations:**
+- Batch-delete old tags instead of looping
+- Query Container Apps to exclude currently-deployed tags
+- Add periodic `buildcache` tag cleanup
+
+---
+
+#### 9. No Timeouts on Build Stages
+**Files:** `pipeline-ado/build-apps.yml`, individual `*-build.yml` files
+**Impact:** MEDIUM | **Effort:** SMALL
+
+PR validation has `timeoutInMinutes: 30` but build stages have **no explicit timeout**. A hung Docker build could block the pipeline indefinitely.
+
+**Fix:**
+- Add `timeoutInMinutes: 45` to all build jobs
+- Add `cancelTimeoutInMinutes: 5` for cleanup
+
+---
+
+#### 10. build-apps.yml Parallel CQ Stages Duplicate Work
+**File:** `pipeline-ado/build-apps.yml`
+**Impact:** MEDIUM | **Effort:** SMALL
+
+When building all apps, 10 CodeQuality stages run in parallel — each independently installs Python, uv, ruff, bandit, mypy, pip-audit, and all 7 shared libraries. That's 10× the same setup work.
+
+**Recommendation:**
+- Add a shared `Prerequisites` stage that installs tools and caches them
+- Make all CodeQuality stages `dependsOn: Prerequisites`
+- Or consolidate CQ into a single job (like pr-validation.yml) with a loop
+
+---
+
+### 🟢 Low Priority
+
+#### 11. No Test-Only Pipeline
+**Files:** None (missing capability)
+**Impact:** LOW | **Effort:** SMALL
+
+To run just code quality and tests without building Docker images, developers must use the PR pipeline or modify `build-apps.yml`. A dedicated test-only pipeline would provide faster feedback (~3-5 min vs ~20+ min).
+
+---
+
+#### 12. Individual `*-build.yml` Files Are Redundant
+**Files:** 10 individual `*-build.yml` files
+**Impact:** LOW | **Effort:** LARGE
+
+With `build-apps.yml` now available, the 10 individual build files are partially redundant. They remain useful for per-path CI triggers (auto-build on push to specific app directories), but maintaining 10 near-identical files is a burden.
+
+**Options:**
+1. Keep as-is for per-path CI triggers (current state)
+2. Set all to `trigger: none` and use only `build-apps.yml`
+3. Deprecate gradually as team adopts consolidated pipeline
+
+---
+
+#### 13. Variable Naming Inconsistency
+**Files:** Multiple pipeline and template files
+**Impact:** LOW | **Effort:** SMALL
+
+The `appName` parameter means different things in different contexts:
+- In `code-quality-template.yml`: directory name (e.g., `hl7_server`)
+- In `docker-build-push-template.yml`: Docker image name (e.g., `hl7server`)
+
+This works but is confusing. Consider renaming to `appDirName` and `appImageName` for clarity.
+
+---
+
+## Already Optimised ✓
+
+| Area | Status |
+|------|--------|
+| Python version (3.13) | Consistent across all pipelines |
+| Pool names | Consistent (`UKS-DHCW-IH-DEV-ADOManagedPool`) |
+| fetchDepth | Set to 1 (shallow clone) everywhere |
+| Dashboard service connection | Intentionally different (`DEV-MonitoringDashboard`) |
+| Docker layer caching | Implemented via ACR registry cache |
+| UV tool caching | Implemented via Cache@2 |
+| PR validation speed | Consolidated to single job |

--- a/PIPELINE_IMPROVEMENTS.md
+++ b/PIPELINE_IMPROVEMENTS.md
@@ -104,7 +104,7 @@ Unit tests run (pytest/unittest) but results are **not published to ADO**. Test 
 **Files:** None (missing capability)
 **Impact:** MEDIUM | **Effort:** MEDIUM
 
-Trivy scans only run during builds. Released container images in ACR are **never re-scanned** for newly discovered vulnerabilities. Dependency audits (`uv audit`, plus `pip-audit` in the per-app code-quality template) also only run during builds.
+Trivy scans only run during builds. Released container images in ACR are **never re-scanned** for newly discovered vulnerabilities. Dependency audits (`uv audit`) also only run during builds.
 
 **Recommendation:**
 - Create `nightly-security-scan.yml` with a cron schedule

--- a/PIPELINE_IMPROVEMENTS.md
+++ b/PIPELINE_IMPROVEMENTS.md
@@ -104,7 +104,7 @@ Unit tests run (pytest/unittest) but results are **not published to ADO**. Test 
 **Files:** None (missing capability)
 **Impact:** MEDIUM | **Effort:** MEDIUM
 
-Trivy scans only run during builds. Released container images in ACR are **never re-scanned** for newly discovered vulnerabilities. Dependency audits (`pip-audit`, `uv audit`) also only run during builds.
+Trivy scans only run during builds. Released container images in ACR are **never re-scanned** for newly discovered vulnerabilities. Dependency audits (`uv audit`, plus `pip-audit` in the per-app code-quality template) also only run during builds.
 
 **Recommendation:**
 - Create `nightly-security-scan.yml` with a cron schedule

--- a/buswatch/uv.lock
+++ b/buswatch/uv.lock
@@ -579,11 +579,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/dashboard/uv.lock
+++ b/dashboard/uv.lock
@@ -940,11 +940,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_chemo_transformer/uv.lock
+++ b/hl7_chemo_transformer/uv.lock
@@ -1063,11 +1063,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_mock_receiver/uv.lock
+++ b/hl7_mock_receiver/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -13,6 +22,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
+]
+
+[[package]]
+name = "azure-core-tracing-opentelemetry"
+version = "1.0.0b13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ab/a937e4af8afec9d437d55252f2a3a4419fc3fc7d5e5d54022622bd11b2b6/azure_core_tracing_opentelemetry-1.0.0b13.tar.gz", hash = "sha256:6cb2f8dfd5dee6c11843db0205fc92e2434e1a272c169c953afe92483aafc7eb", size = 25832, upload-time = "2026-05-01T00:59:57.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/01/8898c2506cae6a57c1b76d930d2af94764a65354bc863feb2684235851ce/azure_core_tracing_opentelemetry-1.0.0b13-py3-none-any.whl", hash = "sha256:4dacd3a9f117f11f98e89305e161c951b8df85b984f3b56130614de9cd9887f9", size = 12112, upload-time = "2026-05-01T00:59:59.149Z" },
 ]
 
 [[package]]
@@ -29,6 +51,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/52/458c1be17a5d3796570ae2ed3c6b7b55b134b22d5ef8132b4f97046a9051/azure_identity-1.23.0.tar.gz", hash = "sha256:d9cdcad39adb49d4bb2953a217f62aec1f65bbb3c63c9076da2be2a47e53dde4", size = 265280, upload-time = "2025-05-14T00:18:30.408Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/16/a51d47780f41e4b87bb2d454df6aea90a44a346e918ac189d3700f3d728d/azure_identity-1.23.0-py3-none-any.whl", hash = "sha256:dbbeb64b8e5eaa81c44c565f264b519ff2de7ff0e02271c49f3cb492762a50b0", size = 186097, upload-time = "2025-05-14T00:18:32.734Z" },
+]
+
+[[package]]
+name = "azure-monitor-opentelemetry"
+version = "1.6.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-core-tracing-opentelemetry" },
+    { name = "azure-monitor-opentelemetry-exporter" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-flask" },
+    { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-instrumentation-urllib" },
+    { name = "opentelemetry-instrumentation-urllib3" },
+    { name = "opentelemetry-resource-detector-azure" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/ff3afb3b8b05d59cab2f26690360816b7f8339e5873e6c68517e6aed2d54/azure_monitor_opentelemetry-1.6.13.tar.gz", hash = "sha256:59b1b01e64318d78f0d2909c8fa9b3008dbf88e7ea6e491d2042afa5bbe94971", size = 49963, upload-time = "2025-07-29T22:15:01.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/0d/16522e6cf83337e30b197d207ca8b436aa03372f0438251f3f43c3b5b1eb/azure_monitor_opentelemetry-1.6.13-py3-none-any.whl", hash = "sha256:c6a5b0b73b5639054675aec2a8f215cdb6b7d1e5cb21d93188bbdd55673eca30", size = 25522, upload-time = "2025-07-29T22:15:02.719Z" },
+]
+
+[[package]]
+name = "azure-monitor-opentelemetry-exporter"
+version = "1.0.0b45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-identity" },
+    { name = "msrest" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/02/a4f6d50ee43a25680b46f82d985c0920c5f8422b0fb9b408efc484b498f8/azure_monitor_opentelemetry_exporter-1.0.0b45.tar.gz", hash = "sha256:b2d495b318710c521d6611cfb9cb4b36d990e3d613cf10ebdaa957099ddbe351", size = 277588, upload-time = "2025-11-13T23:12:01.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/05/4007d55d7fa88992bf70cdfdf9e7c4ec0734fd853c4c548da9fd36623892/azure_monitor_opentelemetry_exporter-1.0.0b45-py2.py3-none-any.whl", hash = "sha256:10d6363ac971fb4530511df464898fe69c0499e85841febad800572d1e8e8ec6", size = 200419, upload-time = "2025-11-13T23:12:02.7Z" },
 ]
 
 [[package]]
@@ -273,6 +335,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -310,6 +384,7 @@ dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },
     { name = "azure-servicebus" },
+    { name = "otel-lib" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
@@ -319,6 +394,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "==1.23.0" },
     { name = "azure-servicebus", specifier = "==7.14.3" },
+    { name = "otel-lib", directory = "../shared_libs/otel_lib" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -357,6 +433,22 @@ wheels = [
 ]
 
 [[package]]
+name = "msrest"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "certifi" },
+    { name = "isodate" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.18.2"
 source = { registry = "https://pypi.org/simple" }
@@ -392,6 +484,283 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/d2/c782c88b8afbf961d6972428821c302bd1e9e7bc361352172f0ca31296e2/opentelemetry_api-1.36.0.tar.gz", hash = "sha256:9a72572b9c416d004d492cbc6e61962c0501eaf945ece9b5a0f56597d8348aa0", size = 64780, upload-time = "2025-07-29T15:12:06.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/ee/6b08dde0a022c463b88f55ae81149584b125a42183407dc1045c486cc870/opentelemetry_api-1.36.0-py3-none-any.whl", hash = "sha256:02f20bcacf666e1333b6b1f04e647dc1d5111f86b8e510238fcc56d7762cda8c", size = 65564, upload-time = "2025-07-29T15:11:47.998Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/37/cf17cf28f945a3aca5a038cfbb45ee01317d4f7f3a0e5209920883fe9b08/opentelemetry_instrumentation-0.57b0.tar.gz", hash = "sha256:f2a30135ba77cdea2b0e1df272f4163c154e978f57214795d72f40befd4fcf05", size = 30807, upload-time = "2025-07-29T15:42:44.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/6f/f20cd1542959f43fb26a5bf9bb18cd81a1ea0700e8870c8f369bd07f5c65/opentelemetry_instrumentation-0.57b0-py3-none-any.whl", hash = "sha256:9109280f44882e07cec2850db28210b90600ae9110b42824d196de357cbddf7e", size = 32460, upload-time = "2025-07-29T15:41:40.883Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/10/7ba59b586eb099fa0155521b387d857de476687c670096597f618d889323/opentelemetry_instrumentation_asgi-0.57b0.tar.gz", hash = "sha256:a6f880b5d1838f65688fc992c65fbb1d3571f319d370990c32e759d3160e510b", size = 24654, upload-time = "2025-07-29T15:42:48.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/07/ab97dd7e8bc680b479203f7d3b2771b7a097468135a669a38da3208f96cb/opentelemetry_instrumentation_asgi-0.57b0-py3-none-any.whl", hash = "sha256:47debbde6af066a7e8e911f7193730d5e40d62effc1ac2e1119908347790a3ea", size = 16599, upload-time = "2025-07-29T15:41:48.332Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/dc/5a17b2fb593901ba5257278073b28d0ed31497e56985990c26046e4da2d9/opentelemetry_instrumentation_dbapi-0.57b0.tar.gz", hash = "sha256:7ad9e39c91f6212f118435fd6fab842a1f78b2cbad1167f228c025bba2a8fc2d", size = 14176, upload-time = "2025-07-29T15:42:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/71/21a7e862dead70267b7c7bd5aa4e0b61fbc9fa9b4be57f4e183766abbad9/opentelemetry_instrumentation_dbapi-0.57b0-py3-none-any.whl", hash = "sha256:c1b110a5e86ec9b52b970460917523f47afa0c73f131e7f03c6a7c1921822dc4", size = 12466, upload-time = "2025-07-29T15:41:59.775Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/88/d88268c37aabbd2bcc54f4f868394316fa6fdfd3b91e011d229617d862d3/opentelemetry_instrumentation_django-0.57b0.tar.gz", hash = "sha256:df4116d2ea2c6bbbbf8853b843deb74d66bd0d573ddd372ec84fd60adaf977c6", size = 25005, upload-time = "2025-07-29T15:42:56.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/f0/1d5022f2fe16d50b79d9f1f5b70bd08d0e59819e0f6b237cff82c3dbda0f/opentelemetry_instrumentation_django-0.57b0-py3-none-any.whl", hash = "sha256:3d702d79a9ec0c836ccf733becf34630c6afb3c86c25c330c5b7601debe1e7c5", size = 19597, upload-time = "2025-07-29T15:42:00.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/a8/7c22a33ff5986523a7f9afcb5f4d749533842c3cc77ef55b46727580edd0/opentelemetry_instrumentation_fastapi-0.57b0.tar.gz", hash = "sha256:73ac22f3c472a8f9cb21d1fbe5a4bf2797690c295fff4a1c040e9b1b1688a105", size = 20277, upload-time = "2025-07-29T15:42:58.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/df/f20fc21c88c7af5311bfefc15fc4e606bab5edb7c193aa8c73c354904c35/opentelemetry_instrumentation_fastapi-0.57b0-py3-none-any.whl", hash = "sha256:61e6402749ffe0bfec582e58155e0d81dd38723cd9bc4562bca1acca80334006", size = 12712, upload-time = "2025-07-29T15:42:03.332Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-flask"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/98/8a8fa41f624069ac2912141b65bd528fd345d65e14a359c4d896fc3dc291/opentelemetry_instrumentation_flask-0.57b0.tar.gz", hash = "sha256:c5244a40b03664db966d844a32f43c900181431b77929be62a68d4907e86ed25", size = 19381, upload-time = "2025-07-29T15:42:59.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/3f/79b6c9a240221f5614a143eab6a0ecacdcb23b93cc35ff2b78234f68804f/opentelemetry_instrumentation_flask-0.57b0-py3-none-any.whl", hash = "sha256:5ecd614f194825725b61ee9ba8e37dcd4d3f9b5d40fef759df8650d6a91b1cb9", size = 14688, upload-time = "2025-07-29T15:42:04.162Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg2"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/66/f2004cde131663810e62b47bb48b684660632876f120c6b1d400a04ccb06/opentelemetry_instrumentation_psycopg2-0.57b0.tar.gz", hash = "sha256:4e9d05d661c50985f0a5d7f090a7f399d453b467c9912c7611fcef693d15b038", size = 10722, upload-time = "2025-07-29T15:43:05.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/40/00f9c1334fb0c9d74c99d37c4a730cbe6dc941eea5fae6f9bc36e5a53d19/opentelemetry_instrumentation_psycopg2-0.57b0-py3-none-any.whl", hash = "sha256:94fdde02b7451c8e85d43b4b9dd13a34fee96ffd43324d1b3567f47d2903b99f", size = 10721, upload-time = "2025-07-29T15:42:15.698Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/e1/01f5c28a60ffbc4c04946ad35bc8bf16382d333e41afaa042b31c35364b9/opentelemetry_instrumentation_requests-0.57b0.tar.gz", hash = "sha256:193bd3fd1f14737721876fb1952dffc7d43795586118df633a91ecd9057446ff", size = 15182, upload-time = "2025-07-29T15:43:11.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/7d/40144701fa22521e3b3fce23e2f0a5684a9385c90b119b70e7598b3cb607/opentelemetry_instrumentation_requests-0.57b0-py3-none-any.whl", hash = "sha256:66a576ac8080724ddc8a14c39d16bb5f430991bd504fdbea844c7a063f555971", size = 12966, upload-time = "2025-07-29T15:42:24.608Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/a5/9d400dd978ac5e81356fe8435ca264e140a7d4cf77a88db43791d62311d5/opentelemetry_instrumentation_urllib-0.57b0.tar.gz", hash = "sha256:657225ceae8bb52b67bd5c26dcb8a33f0efb041f1baea4c59dbd1adbc63a4162", size = 13929, upload-time = "2025-07-29T15:43:16.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/47/3c9535a68b9dd125eb6a25c086984e5cee7285e4f36bfa37eeb40e95d2b5/opentelemetry_instrumentation_urllib-0.57b0-py3-none-any.whl", hash = "sha256:bb3a01172109a6f56bfcc38ea83b9d4a61c4c2cac6b9a190e757063daadf545c", size = 12671, upload-time = "2025-07-29T15:42:34.561Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib3"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/2d/c241e9716c94704dbddf64e2c7367b57642425455befdbc622936bec78e9/opentelemetry_instrumentation_urllib3-0.57b0.tar.gz", hash = "sha256:f49d8c3d1d81ae56304a08b14a7f564d250733ed75cd2210ccef815b5af2eea1", size = 15790, upload-time = "2025-07-29T15:43:17.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0e/a5467ab57d815caa58cbabb3a7f3906c3718c599221ac770482d13187306/opentelemetry_instrumentation_urllib3-0.57b0-py3-none-any.whl", hash = "sha256:337ecac6df3ff92026b51c64df7dd4a3fff52f2dc96036ea9371670243bf83c6", size = 13186, upload-time = "2025-07-29T15:42:35.775Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3f/d1ab49d68f2f6ebbe3c2fa5ff609ee5603a9cc68915203c454afb3a38d5b/opentelemetry_instrumentation_wsgi-0.57b0.tar.gz", hash = "sha256:d7e16b3b87930c30fc4c1bbc8b58c5dd6eefade493a3a5e7343bc24d572bc5b7", size = 18376, upload-time = "2025-07-29T15:43:17.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/0c/7760f9e14f4f8128e4880b4fd5f232ef4eb00cb29ee560c972dbf7801369/opentelemetry_instrumentation_wsgi-0.57b0-py3-none-any.whl", hash = "sha256:b9cf0c6e61489f7503fc17ef04d169bd214e7a825650ee492f5d2b4d73b17b54", size = 14450, upload-time = "2025-07-29T15:42:37.351Z" },
+]
+
+[[package]]
+name = "opentelemetry-resource-detector-azure"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e4/0d359d48d03d447225b30c3dd889d5d454e3b413763ff721f9b0e4ac2e59/opentelemetry_resource_detector_azure-0.1.5.tar.gz", hash = "sha256:e0ba658a87c69eebc806e75398cd0e9f68a8898ea62de99bc1b7083136403710", size = 11503, upload-time = "2024-05-16T21:54:58.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ae/c26d8da88ba2e438e9653a408b0c2ad6f17267801250a8f3cc6405a93a72/opentelemetry_resource_detector_azure-0.1.5-py3-none-any.whl", hash = "sha256:4dcc5d54ab5c3b11226af39509bc98979a8b9e0f8a24c1b888783755d3bf00eb", size = 14252, upload-time = "2024-05-16T21:54:57.208Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/85/8567a966b85a2d3f971c4d42f781c305b2b91c043724fa08fd37d158e9dc/opentelemetry_sdk-1.36.0.tar.gz", hash = "sha256:19c8c81599f51b71670661ff7495c905d8fdf6976e41622d5245b791b06fa581", size = 162557, upload-time = "2025-07-29T15:12:16.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/59/7bed362ad1137ba5886dac8439e84cd2df6d087be7c09574ece47ae9b22c/opentelemetry_sdk-1.36.0-py3-none-any.whl", hash = "sha256:19fe048b42e98c5c1ffe85b569b7073576ad4ce0bcb6e9b4c6a39e890a6c45fb", size = 119995, upload-time = "2025-07-29T15:12:03.181Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", hash = "sha256:609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32", size = 124225, upload-time = "2025-07-29T15:12:17.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", hash = "sha256:757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78", size = 201627, upload-time = "2025-07-29T15:12:04.174Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/1b/6229c45445e08e798fa825f5376f6d6a4211d29052a4088eed6d577fa653/opentelemetry_util_http-0.57b0.tar.gz", hash = "sha256:f7417595ead0eb42ed1863ec9b2f839fc740368cd7bbbfc1d0a47bc1ab0aba11", size = 9405, upload-time = "2025-07-29T15:43:19.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a6/b98d508d189b9c208f5978d0906141747d7e6df7c7cafec03657ed1ed559/opentelemetry_util_http-0.57b0-py3-none-any.whl", hash = "sha256:e54c0df5543951e471c3d694f85474977cd5765a3b7654398c83bab3d2ffb8e9", size = 7643, upload-time = "2025-07-29T15:42:41.744Z" },
+]
+
+[[package]]
+name = "otel-lib"
+version = "0.1.0"
+source = { directory = "../shared_libs/otel_lib" }
+dependencies = [
+    { name = "azure-monitor-opentelemetry" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "setuptools" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
+    { name = "setuptools", specifier = ">=82.0.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = "==1.9.2" },
+    { name = "mypy", specifier = "==1.18.2" },
+    { name = "ruff", specifier = "==0.15.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +779,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/d2/510cc0d218e753ba62a1bc1434651db3cd797a9716a0a66cc714cb4f0935/pbr-6.1.1.tar.gz", hash = "sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b", size = 125702, upload-time = "2025-02-04T14:28:06.514Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/ac/684d71315abc7b1214d59304e23a982472967f6bf4bde5a98f1503f648dc/pbr-6.1.1-py2.py3-none-any.whl", hash = "sha256:38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76", size = 108997, upload-time = "2025-02-04T14:28:03.168Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -474,6 +871,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -547,9 +957,57 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]

--- a/hl7_phw_transformer/uv.lock
+++ b/hl7_phw_transformer/uv.lock
@@ -1065,11 +1065,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_pims_transformer/uv.lock
+++ b/hl7_pims_transformer/uv.lock
@@ -1063,11 +1063,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_sender/uv.lock
+++ b/hl7_sender/uv.lock
@@ -1088,11 +1088,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_server/uv.lock
+++ b/hl7_server/uv.lock
@@ -1129,11 +1129,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/hl7_subscription_sender/uv.lock
+++ b/hl7_subscription_sender/uv.lock
@@ -441,6 +441,7 @@ dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },
     { name = "azure-servicebus" },
+    { name = "otel-lib" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
@@ -450,6 +451,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "==1.23.0" },
     { name = "azure-servicebus", specifier = "==7.14.3" },
+    { name = "otel-lib", directory = "../shared_libs/otel_lib" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -807,6 +809,34 @@ wheels = [
 ]
 
 [[package]]
+name = "otel-lib"
+version = "0.1.0"
+source = { directory = "../shared_libs/otel_lib" }
+dependencies = [
+    { name = "azure-monitor-opentelemetry" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "setuptools" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
+    { name = "setuptools", specifier = ">=82.0.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = "==1.9.2" },
+    { name = "mypy", specifier = "==1.18.2" },
+    { name = "ruff", specifier = "==0.15.0" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -829,15 +859,20 @@ name = "processor-manager-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/processor_manager_lib" }
 dependencies = [
+    { name = "opentelemetry-api" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "otel-lib", directory = "../shared_libs/otel_lib" }]
 
 [[package]]
 name = "psutil"
@@ -1031,11 +1066,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/message_replay_job/uv.lock
+++ b/message_replay_job/uv.lock
@@ -406,6 +406,7 @@ dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },
     { name = "azure-servicebus" },
+    { name = "otel-lib" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
@@ -415,6 +416,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "==1.23.0" },
     { name = "azure-servicebus", specifier = "==7.14.3" },
+    { name = "otel-lib", directory = "../shared_libs/otel_lib" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -784,6 +786,34 @@ wheels = [
 ]
 
 [[package]]
+name = "otel-lib"
+version = "0.1.0"
+source = { directory = "../shared_libs/otel_lib" }
+dependencies = [
+    { name = "azure-monitor-opentelemetry" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "setuptools" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
+    { name = "setuptools", specifier = ">=82.0.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = "==1.9.2" },
+    { name = "mypy", specifier = "==1.18.2" },
+    { name = "ruff", specifier = "==0.15.0" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,11 +1057,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/message_store_service/uv.lock
+++ b/message_store_service/uv.lock
@@ -421,6 +421,7 @@ dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },
     { name = "azure-servicebus" },
+    { name = "otel-lib" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
@@ -430,6 +431,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "==1.23.0" },
     { name = "azure-servicebus", specifier = "==7.14.3" },
+    { name = "otel-lib", directory = "../shared_libs/otel_lib" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -801,6 +803,34 @@ wheels = [
 ]
 
 [[package]]
+name = "otel-lib"
+version = "0.1.0"
+source = { directory = "../shared_libs/otel_lib" }
+dependencies = [
+    { name = "azure-monitor-opentelemetry" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "setuptools" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
+    { name = "setuptools", specifier = ">=82.0.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = "==1.9.2" },
+    { name = "mypy", specifier = "==1.18.2" },
+    { name = "ruff", specifier = "==0.15.0" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -823,15 +853,20 @@ name = "processor-manager-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/processor_manager_lib" }
 dependencies = [
+    { name = "opentelemetry-api" },
     { name = "setuptools" },
     { name = "urllib3" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "setuptools", specifier = ">=82.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "otel-lib", directory = "../shared_libs/otel_lib" }]
 
 [[package]]
 name = "psutil"
@@ -1059,11 +1094,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -1,0 +1,345 @@
+# Consolidated Build Pipeline — build all (or selected) containers in one operation
+# Individual *-build.yml files remain for per-path CI triggers
+trigger: none
+pr: none
+
+parameters:
+  - name: SEMANTIC_VERSION
+    displayName: 'Semantic Version'
+    type: string
+    default: 'v0.1.0'
+
+  - name: buildApps
+    displayName: 'Apps to build (leave all checked for full build)'
+    type: object
+    default:
+      - hl7server
+      - hl7sender
+      - hl7mockreceiver
+      - hl7subscriptionsender
+      - hl7pimstransformer
+      - hl7phwtransformer
+      - hl7chemotransformer
+      - messagestoreservice
+      - messagereplayjob
+      - dashboard
+      - networktestapp
+
+variables:
+  acrName: 'uksdhcwihsharedcr'
+  azureServiceConnection: 'Azure - NHSWales-DHCW-IntegrationHub-Subscription'
+  POOL_NAME: 'UKS-DHCW-IH-DEV-ADOManagedPool'
+
+# ─── Standard apps (CodeQuality → Build, shared_libs + ca-certs) ─────────────
+stages:
+  # ── Code Quality ────────────────────────────────────────────────────────────
+  - stage: CodeQuality_hl7server
+    displayName: 'Code Quality — HL7 Server'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_server'
+          appDisplayName: 'HL7 Server'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7sender
+    displayName: 'Code Quality — HL7 Sender'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_sender'
+          appDisplayName: 'HL7 Sender'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7mockreceiver
+    displayName: 'Code Quality — HL7 Mock Receiver'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_mock_receiver'
+          appDisplayName: 'HL7 Mock Receiver'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7subscriptionsender
+    displayName: 'Code Quality — HL7 Subscription Sender'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_subscription_sender'
+          appDisplayName: 'HL7 Subscription Sender'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7pimstransformer
+    displayName: 'Code Quality — Pims HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_pims_transformer'
+          appDisplayName: 'Pims HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7phwtransformer
+    displayName: 'Code Quality — Phw HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_phw_transformer'
+          appDisplayName: 'Phw HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_hl7chemotransformer
+    displayName: 'Code Quality — Chemocare HL7 Transformer'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'hl7_chemo_transformer'
+          appDisplayName: 'Chemocare HL7 Transformer'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_messagestoreservice
+    displayName: 'Code Quality — Message Store Service'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'message_store_service'
+          appDisplayName: 'Message Store Service'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_messagereplayjob
+    displayName: 'Code Quality — Message Replay Job'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'message_replay_job'
+          appDisplayName: 'Message Replay Job'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: CodeQuality_dashboard
+    displayName: 'Code Quality — Dashboard'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard')
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'dashboard'
+          appDisplayName: 'Dashboard'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+          banditSourceDir: 'dashboard'
+          usePytest: true
+
+  # ── Build & Push ────────────────────────────────────────────────────────────
+  - stage: Build_hl7server
+    displayName: 'Build — HL7 Server'
+    dependsOn: CodeQuality_hl7server
+    condition: and(in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7Server'
+          displayName: 'Build and Push HL7 Server'
+          appName: 'hl7server'
+          dockerfilePath: 'hl7_server/Dockerfile'
+          buildContext: 'hl7_server'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7sender
+    displayName: 'Build — HL7 Sender'
+    dependsOn: CodeQuality_hl7sender
+    condition: and(in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7Sender'
+          displayName: 'Build and Push HL7 Sender'
+          appName: 'hl7sender'
+          dockerfilePath: 'hl7_sender/Dockerfile'
+          buildContext: 'hl7_sender'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7mockreceiver
+    displayName: 'Build — HL7 Mock Receiver'
+    dependsOn: CodeQuality_hl7mockreceiver
+    condition: and(in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7MockReceiver'
+          displayName: 'Build and Push HL7 Mock Receiver'
+          appName: 'hl7mockreceiver'
+          dockerfilePath: 'hl7_mock_receiver/Dockerfile'
+          buildContext: 'hl7_mock_receiver'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7subscriptionsender
+    displayName: 'Build — HL7 Subscription Sender'
+    dependsOn: CodeQuality_hl7subscriptionsender
+    condition: and(in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushHL7SubscriptionSender'
+          displayName: 'Build and Push HL7 Subscription Sender'
+          appName: 'hl7subsndr'
+          dockerfilePath: 'hl7_subscription_sender/Dockerfile'
+          buildContext: 'hl7_subscription_sender'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7pimstransformer
+    displayName: 'Build — Pims HL7 Transformer'
+    dependsOn: CodeQuality_hl7pimstransformer
+    condition: and(in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushPimsHL7Transformer'
+          displayName: 'Build and Push Pims HL7 Transformer'
+          appName: 'pims-hl7transformer'
+          dockerfilePath: 'hl7_pims_transformer/Dockerfile'
+          buildContext: 'hl7_pims_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7phwtransformer
+    displayName: 'Build — Phw HL7 Transformer'
+    dependsOn: CodeQuality_hl7phwtransformer
+    condition: and(in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushPhwHL7Transformer'
+          displayName: 'Build and Push Phw HL7 Transformer'
+          appName: 'phw-hl7transformer'
+          dockerfilePath: 'hl7_phw_transformer/Dockerfile'
+          buildContext: 'hl7_phw_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_hl7chemotransformer
+    displayName: 'Build — Chemocare HL7 Transformer'
+    dependsOn: CodeQuality_hl7chemotransformer
+    condition: and(in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushChemoHL7Transformer'
+          displayName: 'Build and Push Chemocare HL7 Transformer'
+          appName: 'chemo-hl7transformer'
+          dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
+          buildContext: 'hl7_chemo_transformer'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_messagestoreservice
+    displayName: 'Build — Message Store Service'
+    dependsOn: CodeQuality_messagestoreservice
+    condition: and(in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushMessageStoreService'
+          displayName: 'Build and Push Message Store Service'
+          appName: 'message-store-service'
+          dockerfilePath: 'message_store_service/Dockerfile'
+          buildContext: 'message_store_service'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - stage: Build_messagereplayjob
+    displayName: 'Build — Message Replay Job'
+    dependsOn: CodeQuality_messagereplayjob
+    condition: and(in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushMessageReplayJob'
+          displayName: 'Build and Push Message Replay Job'
+          appName: 'message-replay-job'
+          dockerfilePath: 'message_replay_job/Dockerfile'
+          buildContext: 'message_replay_job'
+          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  # Dashboard uses a different service connection
+  - stage: Build_dashboard
+    displayName: 'Build — Dashboard'
+    dependsOn: CodeQuality_dashboard
+    condition: and(in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard'))
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushDashboard'
+          displayName: 'Build and Push Dashboard'
+          appName: 'dashboard'
+          dockerfilePath: 'dashboard/Dockerfile'
+          buildContext: 'dashboard'
+          acrName: $(acrName)
+          azureServiceConnection: 'DEV-MonitoringDashboard'
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  # Network Test App has no code quality stage
+  - stage: Build_networktestapp
+    displayName: 'Build — Network Test App'
+    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'networktestapp')
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushNetworkTestApp'
+          displayName: 'Build and Push Network Test App'
+          appName: 'networktestapp'
+          dockerfilePath: 'network_test_app/Dockerfile'
+          buildContext: 'network_test_app'
+          additionalContexts: 'ca-certs=ca-certs'
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}

--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -30,316 +30,327 @@ variables:
   azureServiceConnection: 'Azure - NHSWales-DHCW-IntegrationHub-Subscription'
   POOL_NAME: 'UKS-DHCW-IH-DEV-ADOManagedPool'
 
-# ─── Standard apps (CodeQuality → Build, shared_libs + ca-certs) ─────────────
+# All CodeQuality stages run in parallel; each Build stage depends only on its own CQ gate.
+# Stages are conditionally included at compile time based on the buildApps parameter.
 stages:
   # ── Code Quality ────────────────────────────────────────────────────────────
-  - stage: CodeQuality_hl7server
-    displayName: 'Code Quality — HL7 Server'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_server'
-          appDisplayName: 'HL7 Server'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7server') }}:
+    - stage: CodeQuality_hl7server
+      displayName: 'Code Quality — HL7 Server'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_server'
+            appDisplayName: 'HL7 Server'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7sender
-    displayName: 'Code Quality — HL7 Sender'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_sender'
-          appDisplayName: 'HL7 Sender'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7sender') }}:
+    - stage: CodeQuality_hl7sender
+      displayName: 'Code Quality — HL7 Sender'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_sender'
+            appDisplayName: 'HL7 Sender'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7mockreceiver
-    displayName: 'Code Quality — HL7 Mock Receiver'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_mock_receiver'
-          appDisplayName: 'HL7 Mock Receiver'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7mockreceiver') }}:
+    - stage: CodeQuality_hl7mockreceiver
+      displayName: 'Code Quality — HL7 Mock Receiver'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_mock_receiver'
+            appDisplayName: 'HL7 Mock Receiver'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7subscriptionsender
-    displayName: 'Code Quality — HL7 Subscription Sender'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_subscription_sender'
-          appDisplayName: 'HL7 Subscription Sender'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7subscriptionsender') }}:
+    - stage: CodeQuality_hl7subscriptionsender
+      displayName: 'Code Quality — HL7 Subscription Sender'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_subscription_sender'
+            appDisplayName: 'HL7 Subscription Sender'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7pimstransformer
-    displayName: 'Code Quality — Pims HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_pims_transformer'
-          appDisplayName: 'Pims HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7pimstransformer') }}:
+    - stage: CodeQuality_hl7pimstransformer
+      displayName: 'Code Quality — Pims HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_pims_transformer'
+            appDisplayName: 'Pims HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7phwtransformer
-    displayName: 'Code Quality — Phw HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_phw_transformer'
-          appDisplayName: 'Phw HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7phwtransformer') }}:
+    - stage: CodeQuality_hl7phwtransformer
+      displayName: 'Code Quality — Phw HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_phw_transformer'
+            appDisplayName: 'Phw HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_hl7chemotransformer
-    displayName: 'Code Quality — Chemocare HL7 Transformer'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_chemo_transformer'
-          appDisplayName: 'Chemocare HL7 Transformer'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7chemotransformer') }}:
+    - stage: CodeQuality_hl7chemotransformer
+      displayName: 'Code Quality — Chemocare HL7 Transformer'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'hl7_chemo_transformer'
+            appDisplayName: 'Chemocare HL7 Transformer'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_messagestoreservice
-    displayName: 'Code Quality — Message Store Service'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_store_service'
-          appDisplayName: 'Message Store Service'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'messagestoreservice') }}:
+    - stage: CodeQuality_messagestoreservice
+      displayName: 'Code Quality — Message Store Service'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'message_store_service'
+            appDisplayName: 'Message Store Service'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_messagereplayjob
-    displayName: 'Code Quality — Message Replay Job'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_replay_job'
-          appDisplayName: 'Message Replay Job'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
+  - ${{ if containsValue(parameters.buildApps, 'messagereplayjob') }}:
+    - stage: CodeQuality_messagereplayjob
+      displayName: 'Code Quality — Message Replay Job'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'message_replay_job'
+            appDisplayName: 'Message Replay Job'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
 
-  - stage: CodeQuality_dashboard
-    displayName: 'Code Quality — Dashboard'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard')
-    jobs:
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'dashboard'
-          appDisplayName: 'Dashboard'
-          pythonVersion: '3.13'
-          poolName: ${{ variables.POOL_NAME }}
-          banditSourceDir: 'dashboard'
-          usePytest: true
+  - ${{ if containsValue(parameters.buildApps, 'dashboard') }}:
+    - stage: CodeQuality_dashboard
+      displayName: 'Code Quality — Dashboard'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'dashboard'
+            appDisplayName: 'Dashboard'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
+            banditSourceDir: 'dashboard'
+            usePytest: true
 
   # ── Build & Push ────────────────────────────────────────────────────────────
-  - stage: Build_hl7server
-    displayName: 'Build — HL7 Server'
-    dependsOn: CodeQuality_hl7server
-    condition: and(in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7server'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7Server'
-          displayName: 'Build and Push HL7 Server'
-          appName: 'hl7server'
-          dockerfilePath: 'hl7_server/Dockerfile'
-          buildContext: 'hl7_server'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7server') }}:
+    - stage: Build_hl7server
+      displayName: 'Build — HL7 Server'
+      dependsOn: CodeQuality_hl7server
+      condition: in(dependencies.CodeQuality_hl7server.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7Server'
+            displayName: 'Build and Push HL7 Server'
+            appName: 'hl7server'
+            dockerfilePath: 'hl7_server/Dockerfile'
+            buildContext: 'hl7_server'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7sender
-    displayName: 'Build — HL7 Sender'
-    dependsOn: CodeQuality_hl7sender
-    condition: and(in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7sender'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7Sender'
-          displayName: 'Build and Push HL7 Sender'
-          appName: 'hl7sender'
-          dockerfilePath: 'hl7_sender/Dockerfile'
-          buildContext: 'hl7_sender'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7sender') }}:
+    - stage: Build_hl7sender
+      displayName: 'Build — HL7 Sender'
+      dependsOn: CodeQuality_hl7sender
+      condition: in(dependencies.CodeQuality_hl7sender.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7Sender'
+            displayName: 'Build and Push HL7 Sender'
+            appName: 'hl7sender'
+            dockerfilePath: 'hl7_sender/Dockerfile'
+            buildContext: 'hl7_sender'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7mockreceiver
-    displayName: 'Build — HL7 Mock Receiver'
-    dependsOn: CodeQuality_hl7mockreceiver
-    condition: and(in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7mockreceiver'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7MockReceiver'
-          displayName: 'Build and Push HL7 Mock Receiver'
-          appName: 'hl7mockreceiver'
-          dockerfilePath: 'hl7_mock_receiver/Dockerfile'
-          buildContext: 'hl7_mock_receiver'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7mockreceiver') }}:
+    - stage: Build_hl7mockreceiver
+      displayName: 'Build — HL7 Mock Receiver'
+      dependsOn: CodeQuality_hl7mockreceiver
+      condition: in(dependencies.CodeQuality_hl7mockreceiver.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7MockReceiver'
+            displayName: 'Build and Push HL7 Mock Receiver'
+            appName: 'hl7mockreceiver'
+            dockerfilePath: 'hl7_mock_receiver/Dockerfile'
+            buildContext: 'hl7_mock_receiver'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7subscriptionsender
-    displayName: 'Build — HL7 Subscription Sender'
-    dependsOn: CodeQuality_hl7subscriptionsender
-    condition: and(in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7subscriptionsender'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushHL7SubscriptionSender'
-          displayName: 'Build and Push HL7 Subscription Sender'
-          appName: 'hl7subsndr'
-          dockerfilePath: 'hl7_subscription_sender/Dockerfile'
-          buildContext: 'hl7_subscription_sender'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7subscriptionsender') }}:
+    - stage: Build_hl7subscriptionsender
+      displayName: 'Build — HL7 Subscription Sender'
+      dependsOn: CodeQuality_hl7subscriptionsender
+      condition: in(dependencies.CodeQuality_hl7subscriptionsender.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushHL7SubscriptionSender'
+            displayName: 'Build and Push HL7 Subscription Sender'
+            appName: 'hl7subsndr'
+            dockerfilePath: 'hl7_subscription_sender/Dockerfile'
+            buildContext: 'hl7_subscription_sender'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7pimstransformer
-    displayName: 'Build — Pims HL7 Transformer'
-    dependsOn: CodeQuality_hl7pimstransformer
-    condition: and(in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7pimstransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushPimsHL7Transformer'
-          displayName: 'Build and Push Pims HL7 Transformer'
-          appName: 'pims-hl7transformer'
-          dockerfilePath: 'hl7_pims_transformer/Dockerfile'
-          buildContext: 'hl7_pims_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7pimstransformer') }}:
+    - stage: Build_hl7pimstransformer
+      displayName: 'Build — Pims HL7 Transformer'
+      dependsOn: CodeQuality_hl7pimstransformer
+      condition: in(dependencies.CodeQuality_hl7pimstransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushPimsHL7Transformer'
+            displayName: 'Build and Push Pims HL7 Transformer'
+            appName: 'pims-hl7transformer'
+            dockerfilePath: 'hl7_pims_transformer/Dockerfile'
+            buildContext: 'hl7_pims_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7phwtransformer
-    displayName: 'Build — Phw HL7 Transformer'
-    dependsOn: CodeQuality_hl7phwtransformer
-    condition: and(in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7phwtransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushPhwHL7Transformer'
-          displayName: 'Build and Push Phw HL7 Transformer'
-          appName: 'phw-hl7transformer'
-          dockerfilePath: 'hl7_phw_transformer/Dockerfile'
-          buildContext: 'hl7_phw_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7phwtransformer') }}:
+    - stage: Build_hl7phwtransformer
+      displayName: 'Build — Phw HL7 Transformer'
+      dependsOn: CodeQuality_hl7phwtransformer
+      condition: in(dependencies.CodeQuality_hl7phwtransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushPhwHL7Transformer'
+            displayName: 'Build and Push Phw HL7 Transformer'
+            appName: 'phw-hl7transformer'
+            dockerfilePath: 'hl7_phw_transformer/Dockerfile'
+            buildContext: 'hl7_phw_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_hl7chemotransformer
-    displayName: 'Build — Chemocare HL7 Transformer'
-    dependsOn: CodeQuality_hl7chemotransformer
-    condition: and(in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'hl7chemotransformer'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushChemoHL7Transformer'
-          displayName: 'Build and Push Chemocare HL7 Transformer'
-          appName: 'chemo-hl7transformer'
-          dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
-          buildContext: 'hl7_chemo_transformer'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'hl7chemotransformer') }}:
+    - stage: Build_hl7chemotransformer
+      displayName: 'Build — Chemocare HL7 Transformer'
+      dependsOn: CodeQuality_hl7chemotransformer
+      condition: in(dependencies.CodeQuality_hl7chemotransformer.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushChemoHL7Transformer'
+            displayName: 'Build and Push Chemocare HL7 Transformer'
+            appName: 'chemo-hl7transformer'
+            dockerfilePath: 'hl7_chemo_transformer/Dockerfile'
+            buildContext: 'hl7_chemo_transformer'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_messagestoreservice
-    displayName: 'Build — Message Store Service'
-    dependsOn: CodeQuality_messagestoreservice
-    condition: and(in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagestoreservice'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushMessageStoreService'
-          displayName: 'Build and Push Message Store Service'
-          appName: 'message-store-service'
-          dockerfilePath: 'message_store_service/Dockerfile'
-          buildContext: 'message_store_service'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'messagestoreservice') }}:
+    - stage: Build_messagestoreservice
+      displayName: 'Build — Message Store Service'
+      dependsOn: CodeQuality_messagestoreservice
+      condition: in(dependencies.CodeQuality_messagestoreservice.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushMessageStoreService'
+            displayName: 'Build and Push Message Store Service'
+            appName: 'message-store-service'
+            dockerfilePath: 'message_store_service/Dockerfile'
+            buildContext: 'message_store_service'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
-  - stage: Build_messagereplayjob
-    displayName: 'Build — Message Replay Job'
-    dependsOn: CodeQuality_messagereplayjob
-    condition: and(in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'messagereplayjob'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushMessageReplayJob'
-          displayName: 'Build and Push Message Replay Job'
-          appName: 'message-replay-job'
-          dockerfilePath: 'message_replay_job/Dockerfile'
-          buildContext: 'message_replay_job'
-          additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'messagereplayjob') }}:
+    - stage: Build_messagereplayjob
+      displayName: 'Build — Message Replay Job'
+      dependsOn: CodeQuality_messagereplayjob
+      condition: in(dependencies.CodeQuality_messagereplayjob.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushMessageReplayJob'
+            displayName: 'Build and Push Message Replay Job'
+            appName: 'message-replay-job'
+            dockerfilePath: 'message_replay_job/Dockerfile'
+            buildContext: 'message_replay_job'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
   # Dashboard uses a different service connection
-  - stage: Build_dashboard
-    displayName: 'Build — Dashboard'
-    dependsOn: CodeQuality_dashboard
-    condition: and(in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues'), containsValue('${{ join('','', parameters.buildApps) }}', 'dashboard'))
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushDashboard'
-          displayName: 'Build and Push Dashboard'
-          appName: 'dashboard'
-          dockerfilePath: 'dashboard/Dockerfile'
-          buildContext: 'dashboard'
-          acrName: $(acrName)
-          azureServiceConnection: 'DEV-MonitoringDashboard'
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'dashboard') }}:
+    - stage: Build_dashboard
+      displayName: 'Build — Dashboard'
+      dependsOn: CodeQuality_dashboard
+      condition: in(dependencies.CodeQuality_dashboard.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushDashboard'
+            displayName: 'Build and Push Dashboard'
+            appName: 'dashboard'
+            dockerfilePath: 'dashboard/Dockerfile'
+            buildContext: 'dashboard'
+            acrName: $(acrName)
+            azureServiceConnection: 'DEV-MonitoringDashboard'
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
 
   # Network Test App has no code quality stage
-  - stage: Build_networktestapp
-    displayName: 'Build — Network Test App'
-    condition: containsValue('${{ join('','', parameters.buildApps) }}', 'networktestapp')
-    jobs:
-      - template: templates/docker-build-push-template.yml
-        parameters:
-          jobName: 'BuildPushNetworkTestApp'
-          displayName: 'Build and Push Network Test App'
-          appName: 'networktestapp'
-          dockerfilePath: 'network_test_app/Dockerfile'
-          buildContext: 'network_test_app'
-          additionalContexts: 'ca-certs=ca-certs'
-          acrName: $(acrName)
-          azureServiceConnection: $(azureServiceConnection)
-          POOL_NAME: ${{ variables.POOL_NAME }}
-          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+  - ${{ if containsValue(parameters.buildApps, 'networktestapp') }}:
+    - stage: Build_networktestapp
+      displayName: 'Build — Network Test App'
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushNetworkTestApp'
+            displayName: 'Build and Push Network Test App'
+            appName: 'networktestapp'
+            dockerfilePath: 'network_test_app/Dockerfile'
+            buildContext: 'network_test_app'
+            additionalContexts: 'ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -137,7 +137,6 @@ stages:
                   echo "##[error]Failed to create isolated environment for $DISPLAY_NAME"
                   APP_FAILED=1
                 else
-                  # shellcheck disable=SC1091
                   source "$APP_ENV/bin/activate"
                   set +e
                   has_dev_dependency_group

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -139,11 +139,10 @@ stages:
                 else
                   # shellcheck disable=SC1091
                   source "$APP_ENV/bin/activate"
-                  if has_dev_dependency_group; then
-                    DEV_GROUP_STATUS=0
-                  else
-                    DEV_GROUP_STATUS=$?
-                  fi
+                  set +e
+                  has_dev_dependency_group
+                  DEV_GROUP_STATUS=$?
+                  set -e
 
                   if [ $DEV_GROUP_STATUS -eq 0 ]; then
                     if ! uv sync --active --locked --group dev; then
@@ -218,6 +217,7 @@ stages:
 
                 # Unit Tests
                 echo "##[group]🧪 Tests — $DISPLAY_NAME"
+                # Tests run inside the per-app virtual environment activated during dependency installation.
                 if [ -d "tests" ]; then
                   if [ $APP_ENV_READY -eq 0 ]; then
                     echo "##[error]Skipping tests for $DISPLAY_NAME because dependency installation failed"

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -140,22 +140,25 @@ stages:
                   # shellcheck disable=SC1091
                   source "$APP_ENV/bin/activate"
                   if has_dev_dependency_group; then
+                    DEV_GROUP_STATUS=0
+                  else
+                    DEV_GROUP_STATUS=$?
+                  fi
+
+                  if [ $DEV_GROUP_STATUS -eq 0 ]; then
                     if ! uv sync --active --locked --group dev; then
                       echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
                       APP_FAILED=1
                     fi
-                  else
-                    DEV_GROUP_STATUS=$?
-                    if [ $DEV_GROUP_STATUS -eq 1 ]; then
-                      echo "No dev dependency group defined"
-                      if ! uv sync --active --locked --no-dev; then
-                        echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
-                        APP_FAILED=1
-                      fi
-                    else
-                      echo "##[error]Unable to inspect dependency groups for $DISPLAY_NAME"
+                  elif [ $DEV_GROUP_STATUS -eq 1 ]; then
+                    echo "No dev dependency group defined"
+                    if ! uv sync --active --locked --no-dev; then
+                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
                       APP_FAILED=1
                     fi
+                  else
+                    echo "##[error]Unable to inspect dependency groups for $DISPLAY_NAME"
+                    APP_FAILED=1
                   fi
 
                   if [ $APP_FAILED -eq 0 ]; then

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -75,26 +75,11 @@ stages:
 
           - script: |
               set -euo pipefail
-              echo "##[group]Install Shared Dependencies"
               export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-              uv pip install --system -e shared_libs/message_bus_lib/
-              uv pip install --system -e shared_libs/health_check_lib/
-              uv pip install --system -e shared_libs/processor_manager_lib/
-              uv pip install --system -e shared_libs/event_logger_lib/
-              uv pip install --system -e shared_libs/field_utils_lib/
-              uv pip install --system -e shared_libs/transformer_base_lib/
-              uv pip install --system -e shared_libs/hl7_validation/
-
-              echo "✅ Shared libraries installed"
-              echo "##[endgroup]"
-            displayName: 'Install Shared Dependencies'
-            env:
-              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
-
-          - script: |
-              set -euo pipefail
-              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
+              has_dev_dependency_group() {
+                python -c 'import pathlib, sys, tomllib; data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8")); sys.exit(0 if data.get("dependency-groups", {}).get("dev") else 1)'
+              }
 
               # Define all apps: "appDir|displayName|banditDir|testRunner"
               # banditDir empty = use basename of appDir
@@ -120,6 +105,10 @@ stages:
 
               OVERALL_RESULT=0
               FAILED_APPS=""
+              VENV_ROOT="$(Pipeline.Workspace)/.pr-validation-envs"
+
+              rm -rf "$VENV_ROOT"
+              mkdir -p "$VENV_ROOT"
 
               for entry in "${APPS[@]}"; do
                 IFS='|' read -r APP_DIR DISPLAY_NAME BANDIT_DIR TEST_RUNNER <<< "$entry"
@@ -135,39 +124,38 @@ stages:
                 echo "╚══════════════════════════════════════════════════════════════╝"
                 
                 APP_FAILED=0
+                APP_ENV_READY=0
+                APP_ENV="$VENV_ROOT/$(echo "$APP_DIR" | tr '/.' '__')"
 
                 # Install app dependencies
                 echo "##[group]📦 Install $DISPLAY_NAME dependencies"
                 cd "$(Build.SourcesDirectory)/$APP_DIR"
-
-                if ! uv pip install --system . 2>&1; then
-                  echo "##[error]Dependency install failed for $DISPLAY_NAME"
+                rm -rf "$APP_ENV"
+                if ! uv venv "$APP_ENV"; then
+                  echo "##[error]Failed to create isolated environment for $DISPLAY_NAME"
                   APP_FAILED=1
-                fi
-
-                if python - <<'PY'
-import pathlib
-import tomllib
-
-pyproject_path = pathlib.Path("pyproject.toml")
-if not pyproject_path.exists():
-    raise SystemExit(1)
-
-with pyproject_path.open("rb") as pyproject_file:
-    data = tomllib.load(pyproject_file)
-
-dependency_groups = data.get("dependency-groups", {})
-raise SystemExit(0 if "dev" in dependency_groups else 1)
-PY
-                then
-                  if ! uv pip install --system --group dev . 2>&1; then
-                    echo "##[error]Dev dependency install failed for $DISPLAY_NAME"
-                    APP_FAILED=1
-                  fi
                 else
-                  echo "No dev dependency group defined"
-                fi
+                  # shellcheck disable=SC1091
+                  source "$APP_ENV/bin/activate"
+                  if has_dev_dependency_group; then
+                    if ! uv sync --active --locked --group dev; then
+                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  else
+                    echo "No dev dependency group defined"
+                    if ! uv sync --active --locked --no-dev; then
+                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  fi
 
+                  if [ $APP_FAILED -eq 0 ]; then
+                    APP_ENV_READY=1
+                  else
+                    deactivate >/dev/null 2>&1 || true
+                  fi
+                fi
                 echo "##[endgroup]"
 
                 # Ruff
@@ -195,7 +183,7 @@ PY
 
                 # UV audit
                 echo "##[group]🛡️ UV Audit — $DISPLAY_NAME"
-                if ! uv audit --ignore GHSA-5239-wwwm-4pmq 2>&1; then
+                if ! uv audit --locked --ignore GHSA-5239-wwwm-4pmq; then
                   echo "##[error]UV audit failed for $DISPLAY_NAME"
                   APP_FAILED=1
                 fi
@@ -219,21 +207,30 @@ PY
                 # Unit Tests
                 echo "##[group]🧪 Tests — $DISPLAY_NAME"
                 if [ -d "tests" ]; then
-                  if [ "$TEST_RUNNER" = "pytest" ]; then
-                    if ! uv run --no-sync pytest tests -v; then
-                      echo "##[error]Tests failed for $DISPLAY_NAME"
-                      APP_FAILED=1
-                    fi
+                  if [ $APP_ENV_READY -eq 0 ]; then
+                    echo "##[error]Skipping tests for $DISPLAY_NAME because dependency installation failed"
+                    APP_FAILED=1
                   else
-                    if ! python -m unittest discover tests -v; then
-                      echo "##[error]Tests failed for $DISPLAY_NAME"
-                      APP_FAILED=1
+                    if [ "$TEST_RUNNER" = "pytest" ]; then
+                      if ! python -m pytest tests -v; then
+                        echo "##[error]Tests failed for $DISPLAY_NAME"
+                        APP_FAILED=1
+                      fi
+                    else
+                      if ! python -m unittest discover tests -v; then
+                        echo "##[error]Tests failed for $DISPLAY_NAME"
+                        APP_FAILED=1
+                      fi
                     fi
                   fi
                 else
                   echo "No tests directory found, skipping"
                 fi
                 echo "##[endgroup]"
+
+                if [ $APP_ENV_READY -eq 1 ]; then
+                  deactivate >/dev/null 2>&1 || true
+                fi
 
                 if [ $APP_FAILED -eq 1 ]; then
                   OVERALL_RESULT=1

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -78,7 +78,9 @@ stages:
               export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
               has_dev_dependency_group() {
-                python -c 'import pathlib, sys, tomllib; data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8")); sys.exit(0 if data.get("dependency-groups", {}).get("dev") else 1)'
+                local python_script
+                python_script=$'import pathlib\nimport sys\nimport tomllib\n\npyproject_path = pathlib.Path("pyproject.toml")\nif not pyproject_path.is_file():\n    print("##[error]pyproject.toml is missing", file=sys.stderr)\n    raise SystemExit(2)\n\ntry:\n    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))\nexcept tomllib.TOMLDecodeError as exc:\n    print(f"##[error]Failed to parse pyproject.toml: {exc}", file=sys.stderr)\n    raise SystemExit(2)\n\nraise SystemExit(0 if data.get("dependency-groups", {}).get("dev") else 1)\n'
+                python -c "$python_script"
               }
 
               # Define all apps: "appDir|displayName|banditDir|testRunner"
@@ -143,9 +145,15 @@ stages:
                       APP_FAILED=1
                     fi
                   else
-                    echo "No dev dependency group defined"
-                    if ! uv sync --active --locked --no-dev; then
-                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                    DEV_GROUP_STATUS=$?
+                    if [ $DEV_GROUP_STATUS -eq 1 ]; then
+                      echo "No dev dependency group defined"
+                      if ! uv sync --active --locked --no-dev; then
+                        echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                        APP_FAILED=1
+                      fi
+                    else
+                      echo "##[error]Unable to inspect dependency groups for $DISPLAY_NAME"
                       APP_FAILED=1
                     fi
                   fi
@@ -183,6 +191,7 @@ stages:
 
                 # UV audit
                 echo "##[group]🛡️ UV Audit — $DISPLAY_NAME"
+                # Temporary ignore for no-fix advisory on transitive Pygments; review periodically.
                 if ! uv audit --locked --ignore GHSA-5239-wwwm-4pmq; then
                   echo "##[error]UV audit failed for $DISPLAY_NAME"
                   APP_FAILED=1

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -137,26 +137,30 @@ stages:
                   echo "##[error]Failed to create isolated environment for $DISPLAY_NAME"
                   APP_FAILED=1
                 else
-                  source "$APP_ENV/bin/activate"
-                  set +e
-                  has_dev_dependency_group
-                  DEV_GROUP_STATUS=$?
-                  set -e
-
-                  if [ $DEV_GROUP_STATUS -eq 0 ]; then
-                    if ! uv sync --active --locked --group dev; then
-                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
-                      APP_FAILED=1
-                    fi
-                  elif [ $DEV_GROUP_STATUS -eq 1 ]; then
-                    echo "No dev dependency group defined"
-                    if ! uv sync --active --locked --no-dev; then
-                      echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
-                      APP_FAILED=1
-                    fi
-                  else
-                    echo "##[error]Unable to inspect dependency groups for $DISPLAY_NAME"
+                  if ! source "$APP_ENV/bin/activate"; then
+                    echo "##[error]Failed to activate isolated environment for $DISPLAY_NAME"
                     APP_FAILED=1
+                  else
+                    set +e
+                    has_dev_dependency_group
+                    DEV_GROUP_STATUS=$?
+                    set -e
+
+                    if [ $DEV_GROUP_STATUS -eq 0 ]; then
+                      if ! uv sync --active --locked --group dev; then
+                        echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                        APP_FAILED=1
+                      fi
+                    elif [ $DEV_GROUP_STATUS -eq 1 ]; then
+                      echo "No dev dependency group defined"
+                      if ! uv sync --active --locked --no-dev; then
+                        echo "##[error]Failed to install dependencies for $DISPLAY_NAME"
+                        APP_FAILED=1
+                      fi
+                    else
+                      echo "##[error]Unable to inspect dependency groups for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
                   fi
 
                   if [ $APP_FAILED -eq 0 ]; then

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -140,8 +140,35 @@ stages:
                 # Install app dependencies
                 echo "##[group]📦 Install $DISPLAY_NAME dependencies"
                 cd "$(Build.SourcesDirectory)/$APP_DIR"
-                uv pip install --system . 2>&1 || true
-                uv pip install --system --group dev . 2>&1 || echo "No dev dependencies"
+
+                if ! uv pip install --system . 2>&1; then
+                  echo "##[error]Dependency install failed for $DISPLAY_NAME"
+                  APP_FAILED=1
+                fi
+
+                if python - <<'PY'
+import pathlib
+import tomllib
+
+pyproject_path = pathlib.Path("pyproject.toml")
+if not pyproject_path.exists():
+    raise SystemExit(1)
+
+with pyproject_path.open("rb") as pyproject_file:
+    data = tomllib.load(pyproject_file)
+
+dependency_groups = data.get("dependency-groups", {})
+raise SystemExit(0 if "dev" in dependency_groups else 1)
+PY
+                then
+                  if ! uv pip install --system --group dev . 2>&1; then
+                    echo "##[error]Dev dependency install failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                else
+                  echo "No dev dependency group defined"
+                fi
+
                 echo "##[endgroup]"
 
                 # Ruff

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -1,5 +1,6 @@
-# PR Validation Pipeline using Templates
-# This pipeline validates code quality, security, and tests for all apps
+# PR Validation Pipeline — Single Job
+# Consolidates 16 code quality checks into one job to avoid 16× agent allocation overhead.
+# Tools and shared libs are installed once; checks loop through all apps sequentially.
 trigger: none
 
 pr:
@@ -30,131 +31,199 @@ stages:
   - stage: PRValidation
     displayName: 'PR Code Quality & Unit Tests'
     jobs:
-      # HL7 Server validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_server'
-          appDisplayName: 'HL7 Server'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+      - job: CodeQualityAll
+        displayName: 'Code Quality & Tests — All Apps'
+        pool:
+          name: ${{ variables.POOL_NAME_NON_PROD }}
+        timeoutInMinutes: 30
 
-      # HL7 Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_phw_transformer'
-          appDisplayName: 'HL7 Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+        steps:
+          - checkout: self
+            displayName: 'Checkout Repository'
+            fetchDepth: 1
 
-      # HL7 Sender validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_sender'
-          appDisplayName: 'HL7 Sender'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - task: UsePythonVersion@0
+            displayName: 'Use Python $(pythonVersion)'
+            inputs:
+              versionSpec: '$(pythonVersion)'
 
-      # HL7 Subscription Sender validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_subscription_sender'
-          appDisplayName: 'HL7 Subscription Sender'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - task: Cache@2
+            displayName: 'Cache UV tools and packages'
+            continueOnError: true
+            inputs:
+              key: 'uv-cache | "python-$(pythonVersion)" | "$(Agent.OS)" | "pr-validation"'
+              restoreKeys: |
+                uv-cache | "python-$(pythonVersion)" | "$(Agent.OS)"
+              path: $(Pipeline.Workspace)/.uv-cache
 
-      # HL7 Mock Receiver validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_mock_receiver'
-          appDisplayName: 'HL7 Mock Receiver'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              echo "##[group]Install UV and code quality tools"
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      # HL7 Chemo Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_chemo_transformer'
-          appDisplayName: 'HL7 Chemo Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              python -m pip install uv
+              uv tool install ruff
+              uv tool install bandit
+              uv tool install mypy
+              uv tool install pip-audit
 
-      # HL7 PIMS Transformer validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'hl7_pims_transformer'
-          appDisplayName: 'HL7 PIMS Transformer'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              uv --version
+              echo "✅ UV and tools installed"
+              echo "##[endgroup]"
+            displayName: 'Install UV and Code Quality Tools'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
-      # Message Store Service validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'message_store_service'
-          appDisplayName: 'Message Store Service'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              echo "##[group]Install Shared Dependencies"
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      # BusWatch validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'buswatch'
-          appDisplayName: 'BusWatch'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              uv pip install --system -e shared_libs/message_bus_lib/
+              uv pip install --system -e shared_libs/health_check_lib/
+              uv pip install --system -e shared_libs/processor_manager_lib/
+              uv pip install --system -e shared_libs/event_logger_lib/
+              uv pip install --system -e shared_libs/field_utils_lib/
+              uv pip install --system -e shared_libs/transformer_base_lib/
+              uv pip install --system -e shared_libs/hl7_validation/
 
-      # Shared Libraries validation
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/message_bus_lib'
-          appDisplayName: 'Message Bus Library'
-          banditSourceDir: 'message_bus_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              echo "✅ Shared libraries installed"
+              echo "##[endgroup]"
+            displayName: 'Install Shared Dependencies'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/event_logger_lib'
-          appDisplayName: 'Event Logger Library'
-          banditSourceDir: 'event_logger_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+          - script: |
+              set -euo pipefail
+              export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/health_check_lib'
-          appDisplayName: 'Health Check Library'
-          banditSourceDir: 'health_check_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              # Define all apps: "appDir|displayName|banditDir|testRunner"
+              # banditDir empty = use basename of appDir
+              # testRunner: unittest (default) or pytest
+              APPS=(
+                "hl7_server|HL7 Server||unittest"
+                "hl7_phw_transformer|PHW HL7 Transformer||unittest"
+                "hl7_sender|HL7 Sender||unittest"
+                "hl7_subscription_sender|HL7 Subscription Sender||unittest"
+                "hl7_mock_receiver|HL7 Mock Receiver||unittest"
+                "hl7_chemo_transformer|Chemo HL7 Transformer||unittest"
+                "hl7_pims_transformer|PIMS HL7 Transformer||unittest"
+                "message_store_service|Message Store Service||unittest"
+                "buswatch|BusWatch||unittest"
+                "shared_libs/message_bus_lib|Message Bus Library|message_bus_lib|unittest"
+                "shared_libs/event_logger_lib|Event Logger Library|event_logger_lib|unittest"
+                "shared_libs/health_check_lib|Health Check Library|health_check_lib|unittest"
+                "shared_libs/hl7_validation|HL7 Validation Library|hl7_validation|unittest"
+                "shared_libs/processor_manager_lib|Processor Manager Library|processor_manager_lib|unittest"
+                "shared_libs/transformer_base_lib|Transformer Base Library|transformer_base_lib|unittest"
+                "shared_libs/field_utils_lib|Field Utils Library|field_utils_lib|unittest"
+              )
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/hl7_validation'
-          appDisplayName: 'HL7 Validation Library'
-          banditSourceDir: 'hl7_validation'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              OVERALL_RESULT=0
+              FAILED_APPS=""
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/processor_manager_lib'
-          appDisplayName: 'Processor Manager Library'
-          banditSourceDir: 'processor_manager_lib'
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
-         
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/transformer_base_lib'
-          appDisplayName: 'Transformer Base Library'
-          banditSourceDir: 'transformer_base_lib'
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+              for entry in "${APPS[@]}"; do
+                IFS='|' read -r APP_DIR DISPLAY_NAME BANDIT_DIR TEST_RUNNER <<< "$entry"
+                
+                # Default bandit dir to basename of app dir
+                if [ -z "$BANDIT_DIR" ]; then
+                  BANDIT_DIR=$(basename "$APP_DIR")
+                fi
 
-      - template: templates/code-quality-template.yml
-        parameters:
-          appName: 'shared_libs/field_utils_lib'
-          appDisplayName: 'Field Utils Library'
-          banditSourceDir: 'field_utils_lib'
+                echo ""
+                echo "╔══════════════════════════════════════════════════════════════╗"
+                echo "║  $DISPLAY_NAME"
+                echo "╚══════════════════════════════════════════════════════════════╝"
+                
+                APP_FAILED=0
 
-          pythonVersion: $(pythonVersion)
-          poolName: ${{ variables.POOL_NAME_NON_PROD }}
+                # Install app dependencies
+                echo "##[group]📦 Install $DISPLAY_NAME dependencies"
+                cd "$(Build.SourcesDirectory)/$APP_DIR"
+                uv pip install --system . 2>&1 || true
+                uv pip install --system --group dev . 2>&1 || echo "No dev dependencies"
+                echo "##[endgroup]"
+
+                # Ruff
+                echo "##[group]🔍 Ruff — $DISPLAY_NAME"
+                if ! uv tool run ruff check --output-format=github .; then
+                  echo "##[error]Ruff failed for $DISPLAY_NAME"
+                  APP_FAILED=1
+                fi
+                echo "##[endgroup]"
+
+                # Bandit
+                echo "##[group]🔒 Bandit — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if ! uv tool run bandit -r "$BANDIT_DIR" tests --severity-level medium; then
+                    echo "##[error]Bandit failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                else
+                  if ! uv tool run bandit -r "$BANDIT_DIR" --severity-level medium; then
+                    echo "##[error]Bandit failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                fi
+                echo "##[endgroup]"
+
+                # UV audit
+                echo "##[group]🛡️ UV Audit — $DISPLAY_NAME"
+                uv audit --ignore GHSA-5239-wwwm-4pmq 2>&1 || echo "##[warning]UV audit issues for $DISPLAY_NAME"
+                echo "##[endgroup]"
+
+                # MyPy
+                echo "##[group]🏷️ MyPy — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if ! uv tool run mypy "$BANDIT_DIR" tests --ignore-missing-imports; then
+                    echo "##[error]MyPy failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                else
+                  if ! uv tool run mypy "$BANDIT_DIR" --ignore-missing-imports; then
+                    echo "##[error]MyPy failed for $DISPLAY_NAME"
+                    APP_FAILED=1
+                  fi
+                fi
+                echo "##[endgroup]"
+
+                # Unit Tests
+                echo "##[group]🧪 Tests — $DISPLAY_NAME"
+                if [ -d "tests" ]; then
+                  if [ "$TEST_RUNNER" = "pytest" ]; then
+                    if ! uv run --no-sync pytest tests -v; then
+                      echo "##[error]Tests failed for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  else
+                    if ! python -m unittest discover tests -v; then
+                      echo "##[error]Tests failed for $DISPLAY_NAME"
+                      APP_FAILED=1
+                    fi
+                  fi
+                else
+                  echo "No tests directory found, skipping"
+                fi
+                echo "##[endgroup]"
+
+                if [ $APP_FAILED -eq 1 ]; then
+                  OVERALL_RESULT=1
+                  FAILED_APPS="$FAILED_APPS  ❌ $DISPLAY_NAME\n"
+                  echo "##[error]❌ $DISPLAY_NAME — FAILED"
+                else
+                  echo "✅ $DISPLAY_NAME — PASSED"
+                fi
+              done
+
+              echo ""
+              echo "════════════════════════════════════════════════════════════════"
+              if [ $OVERALL_RESULT -eq 0 ]; then
+                echo "✅ All 16 apps passed code quality and tests"
+              else
+                echo "##[error]Some apps failed:"
+                echo -e "$FAILED_APPS"
+                exit 1
+              fi
+            displayName: 'Run Code Quality & Tests — All Apps'
+            env:
+              UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -65,7 +65,6 @@ stages:
               uv tool install ruff
               uv tool install bandit
               uv tool install mypy
-              uv tool install pip-audit
 
               uv --version
               echo "✅ UV and tools installed"

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -196,7 +196,10 @@ PY
 
                 # UV audit
                 echo "##[group]🛡️ UV Audit — $DISPLAY_NAME"
-                uv audit --ignore GHSA-5239-wwwm-4pmq 2>&1 || echo "##[warning]UV audit issues for $DISPLAY_NAME"
+                if ! uv audit --ignore GHSA-5239-wwwm-4pmq 2>&1; then
+                  echo "##[error]UV audit failed for $DISPLAY_NAME"
+                  APP_FAILED=1
+                fi
                 echo "##[endgroup]"
 
                 # MyPy

--- a/pipeline-ado/templates/code-quality-template.yml
+++ b/pipeline-ado/templates/code-quality-template.yml
@@ -45,9 +45,21 @@ jobs:
         inputs:
           versionSpec: '${{ parameters.pythonVersion }}'
 
+      - task: Cache@2
+        displayName: 'Cache UV tools and packages'
+        continueOnError: true
+        inputs:
+          key: 'uv-cache | "python-${{ parameters.pythonVersion }}" | "$(Agent.OS)" | ${{ parameters.appName }}/pyproject.toml'
+          restoreKeys: |
+            uv-cache | "python-${{ parameters.pythonVersion }}" | "$(Agent.OS)"
+          path: $(Pipeline.Workspace)/.uv-cache
+
       - script: |
           set -euo pipefail  # Bash strict mode
           echo "##[group]Install UV and code quality tools"
+
+          # Use pipeline cache directory
+          export UV_CACHE_DIR="$(Pipeline.Workspace)/.uv-cache"
 
           python -m pip install --upgrade pip
           python -m pip install uv
@@ -63,6 +75,8 @@ jobs:
           echo "✅ UV and global code quality tools installed"
           echo "##[endgroup]"
         displayName: 'Install UV and Code Quality Tools'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail
@@ -90,6 +104,8 @@ jobs:
 
           echo "##[endgroup]"
         displayName: 'Install Shared Dependencies'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail
@@ -106,6 +122,8 @@ jobs:
           echo "✅ Dependencies installed successfully"
           echo "##[endgroup]"
         displayName: 'Install ${{ parameters.appDisplayName }} Dependencies'
+        env:
+          UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
 
       - script: |
           set -euo pipefail

--- a/pipeline-ado/templates/docker-build-push-template.yml
+++ b/pipeline-ado/templates/docker-build-push-template.yml
@@ -133,6 +133,10 @@ jobs:
           BUILD_CMD="$BUILD_CMD --label \"org.opencontainers.image.source=$(Build.Repository.Uri)\""
           BUILD_CMD="$BUILD_CMD --file ${{ parameters.dockerfilePath }}"
           
+          # Registry-based layer caching — avoids rebuilding Python dependency layers
+          BUILD_CMD="$BUILD_CMD --cache-from type=registry,ref=$(DOCKER_REGISTRY)/$(IMAGE_NAME):buildcache"
+          BUILD_CMD="$BUILD_CMD --cache-to type=registry,ref=$(DOCKER_REGISTRY)/$(IMAGE_NAME):buildcache,mode=max"
+          
           # Add additional contexts if provided
           if [ -n "${{ parameters.additionalContexts }}" ]; then
             echo "Adding additional build contexts: ${{ parameters.additionalContexts }}"

--- a/shared_libs/event_logger_lib/uv.lock
+++ b/shared_libs/event_logger_lib/uv.lock
@@ -669,11 +669,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/field_utils_lib/uv.lock
+++ b/shared_libs/field_utils_lib/uv.lock
@@ -233,9 +233,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/shared_libs/health_check_lib/uv.lock
+++ b/shared_libs/health_check_lib/uv.lock
@@ -28,9 +28,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/shared_libs/hl7_validation/uv.lock
+++ b/shared_libs/hl7_validation/uv.lock
@@ -3,52 +3,6 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "sniffio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
-]
-
-[[package]]
-name = "anysqlite"
-version = "0.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4b/cd5d66b9f87e773bc71344a368b9472987e33514e6627e28342b9c3e7c43/anysqlite-0.0.5.tar.gz", hash = "sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce", size = 3432, upload-time = "2023-10-02T13:49:25.135Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/31/349eae2bc9d9331dd8951684cf94528d91efaa71129dc30822ac111dfc66/anysqlite-0.0.5-py3-none-any.whl", hash = "sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7", size = 3907, upload-time = "2023-10-02T13:49:26.943Z" },
-]
-
-[[package]]
-name = "asyncer"
-version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
-]
-
-[[package]]
 name = "bandit"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -61,27 +15,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/72/f704a97aac430aeb704fa16435dfa24fbeaf087d46724d0965eb1f756a2c/bandit-1.9.2.tar.gz", hash = "sha256:32410415cd93bf9c8b91972159d5cf1e7f063a9146d70345641cd3877de348ce", size = 4241659, upload-time = "2025-11-23T21:36:18.722Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/1a/5b0320642cca53a473e79c7d273071b5a9a8578f9e370b74da5daa2768d7/bandit-1.9.2-py3-none-any.whl", hash = "sha256:bda8d68610fc33a6e10b7a8f1d61d92c8f6c004051d5e946406be1fb1b16a868", size = 134377, upload-time = "2025-11-23T21:36:17.39Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2025.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -103,62 +36,12 @@ wheels = [
 ]
 
 [[package]]
-name = "dnspython"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
-]
-
-[[package]]
 name = "elementpath"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/41/afdd82534c80e9675d1c51dc21d0889b72d023bfe395a2f5a44d751d3a73/elementpath-4.8.0.tar.gz", hash = "sha256:5822a2560d99e2633d95f78694c7ff9646adaa187db520da200a8e9479dc46ae", size = 358528, upload-time = "2025-03-03T20:51:08.397Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/95/615af832e7f507fe5ce4562b4be1bd2fec080c4ff6da88dcd0c2dbfca582/elementpath-4.8.0-py3-none-any.whl", hash = "sha256:5393191f84969bcf8033b05ec4593ef940e58622ea13cefe60ecefbbf09d58d9", size = 243271, upload-time = "2025-03-03T20:51:03.027Z" },
-]
-
-[[package]]
-name = "email-validator"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "hishel"
-version = "1.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/45/cf/4e1d09cc81c48ff7498398fd82c87fb21800c85e631d03831703d8594506/hishel-1.1.7.tar.gz", hash = "sha256:32c625be581e94dc50b773a8cfb9a65cba487660561950fe976ae49945455179", size = 61473, upload-time = "2025-12-03T09:32:28.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/2a/8134de761e4fd9d0a3b301b897b8c5ce9ccb17af7f846d66c676d8c03fd8/hishel-1.1.7-py3-none-any.whl", hash = "sha256:436c2a5a62d705528e581cbeba85b10d130c47c861906b21262a07ac02463a9f", size = 70569, upload-time = "2025-12-03T09:32:27.144Z" },
-]
-
-[package.optional-dependencies]
-async = [
-    { name = "anyio" },
-    { name = "anysqlite" },
 ]
 
 [[package]]
@@ -177,7 +60,6 @@ dev = [
     { name = "bandit" },
     { name = "mypy" },
     { name = "ruff" },
-    { name = "uv-secure", extra = ["faster-async"] },
 ]
 
 [package.metadata]
@@ -193,7 +75,6 @@ dev = [
     { name = "bandit", specifier = "==1.9.2" },
     { name = "mypy", specifier = "==1.18.2" },
     { name = "ruff", specifier = "==0.14.9" },
-    { name = "uv-secure", extras = ["faster-async"], specifier = "==0.14.4" },
 ]
 
 [[package]]
@@ -203,65 +84,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/68/c200fbbdb320703046af1be1b9da6b9ff2e596e5081393180d25fa04b294/hl7apy-1.3.5.tar.gz", hash = "sha256:4ed02ae574ddcf9084b389bfcaf1e9023c4b2f4dfa2ce4ab42c430c4180a03fe", size = 959807, upload-time = "2024-03-13T11:34:28.128Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/f7/1150f6d878a05272858a9a2dedd5466e06003a02dd7c555b51f299656178/hl7apy-1.3.5-py2.py3-none-any.whl", hash = "sha256:c8b80ff5ad020bf9c1e68a6395cf45cb78db621f65569d1798c46eb1b657e27b", size = 974708, upload-time = "2024-03-13T11:34:16.213Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "humanize"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/1d/3062fcc89ee05a715c0b9bfe6490c00c576314f27ffee3a704122c6fd259/humanize-4.13.0.tar.gz", hash = "sha256:78f79e68f76f0b04d711c4e55d32bebef5be387148862cb1ef83d2b58e7935a0", size = 81884, upload-time = "2025-08-25T09:39:20.04Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c7/316e7ca04d26695ef0635dc81683d628350810eb8e9b2299fc08ba49f366/humanize-4.13.0-py3-none-any.whl", hash = "sha256:b810820b31891813b1673e8fec7f1ed3312061eab2f26e3fa192c393d11ed25f", size = 128869, upload-time = "2025-08-25T09:39:18.54Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "inflect"
-version = "7.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
 ]
 
 [[package]]
@@ -283,50 +105,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
-    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
-    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -365,69 +143,12 @@ wheels = [
 ]
 
 [[package]]
-name = "packaging"
-version = "25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "pydantic"
-version = "2.11.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.33.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
 ]
 
 [[package]]
@@ -496,78 +217,12 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "stamina"
-version = "25.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tenacity" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/b7/8064b246b3d684720080ee8ffbf1dde5caabe852eb9cb53655eb97992af2/stamina-25.2.0.tar.gz", hash = "sha256:fdff938789e8a0c4c496e1ee8a08ee3c7c3351239f235b53e60d4f5964d07e19", size = 565737, upload-time = "2025-12-11T09:16:59.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/81/c525760353dff91ae2e4c42c3f3d9bf0bfeecbb6165cc393e86915f1717d/stamina-25.2.0-py3-none-any.whl", hash = "sha256:7f0de7dba735464c256a31e6372c01b8bb51fb6efd649e6773f4ce804462feea", size = 18791, upload-time = "2025-12-11T09:16:57.235Z" },
-]
-
-[[package]]
 name = "stevedore"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
-]
-
-[[package]]
-name = "typeguard"
-version = "4.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.17.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", hash = "sha256:0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba", size = 103517, upload-time = "2025-08-30T12:35:24.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e8404659a6335e7af868e90657efb73916ef31ddf3d8b9cb237/typer-0.17.3-py3-none-any.whl", hash = "sha256:643919a79182ab7ac7581056d93c6a2b865b026adf2872c4d02c72758e6f095b", size = 46494, upload-time = "2025-08-30T12:35:22.391Z" },
 ]
 
 [[package]]
@@ -580,83 +235,12 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-inspection"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
-]
-
-[[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uv-secure"
-version = "0.14.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "asyncer" },
-    { name = "hishel", extra = ["async"] },
-    { name = "httpx" },
-    { name = "humanize" },
-    { name = "inflect" },
-    { name = "packaging" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "rich" },
-    { name = "stamina" },
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/c6/277e7827ad6715353366e8d26af605e17c387b7af8093859dcd69e005cc2/uv_secure-0.14.4.tar.gz", hash = "sha256:008ce8b2714caad0da8ae4a2e972de6afeb06151e22ee712877aac022cd20a5f", size = 25696, upload-time = "2025-11-03T21:28:56.292Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/e5/3cd0ccb74e955faa7787fa0b20c31c22a002d53a7272f47c6d37e45feeea/uv_secure-0.14.4-py3-none-any.whl", hash = "sha256:86c5b43de2aa98231c630fb6e19c17730e2040855e8c3aa422d68c1040304893", size = 33370, upload-time = "2025-11-03T21:28:54.884Z" },
-]
-
-[package.optional-dependencies]
-faster-async = [
-    { name = "uvloop", marker = "sys_platform != 'win32'" },
-    { name = "winloop", marker = "sys_platform == 'win32'" },
-]
-
-[[package]]
-name = "uvloop"
-version = "0.21.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/c0/854216d09d33c543f12a44b393c402e89a920b1a0a7dc634c42de91b9cf6/uvloop-0.21.0.tar.gz", hash = "sha256:3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3", size = 2492741, upload-time = "2024-10-14T23:38:35.489Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/8d/2cbef610ca21539f0f36e2b34da49302029e7c9f09acef0b1c3b5839412b/uvloop-0.21.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bfd55dfcc2a512316e65f16e503e9e450cab148ef11df4e4e679b5e8253a5281", size = 1468123, upload-time = "2024-10-14T23:38:00.688Z" },
-    { url = "https://files.pythonhosted.org/packages/93/0d/b0038d5a469f94ed8f2b2fce2434a18396d8fbfb5da85a0a9781ebbdec14/uvloop-0.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787ae31ad8a2856fc4e7c095341cccc7209bd657d0e71ad0dc2ea83c4a6fa8af", size = 819325, upload-time = "2024-10-14T23:38:02.309Z" },
-    { url = "https://files.pythonhosted.org/packages/50/94/0a687f39e78c4c1e02e3272c6b2ccdb4e0085fda3b8352fecd0410ccf915/uvloop-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ee4d4ef48036ff6e5cfffb09dd192c7a5027153948d85b8da7ff705065bacc6", size = 4582806, upload-time = "2024-10-14T23:38:04.711Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload-time = "2024-10-14T23:38:06.385Z" },
-    { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload-time = "2024-10-14T23:38:08.416Z" },
-    { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload-time = "2024-10-14T23:38:10.888Z" },
-]
-
-[[package]]
-name = "winloop"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/79/4532e3f8957bff7b0fe9bc92d9ee6ff8aa40be85a7fab7961f9bdbd21852/winloop-0.2.2.tar.gz", hash = "sha256:b967a8bcc45cb9a6845e5d4fc77a493b8b9928b44b9230ff336b9b10ae399132", size = 2545548, upload-time = "2025-08-12T19:50:42.372Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/5c/f0c900368f57f17ac258b30fde3530ef0bf9e2cd2fd83f5ec446b46d90e0/winloop-0.2.2-cp313-cp313-win32.whl", hash = "sha256:b99be023a14d35a726ba3b66128cb988e7906d68b96fc7cacbe11bbfafbf5bbc", size = 544266, upload-time = "2025-08-12T19:50:27.055Z" },
-    { url = "https://files.pythonhosted.org/packages/94/e4/a5dc019b1b60e324873cff8c5dca7a1d1d81d5f4f8182856a9e3c01a94ff/winloop-0.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:7af51dab0bd04243521553e56d8673b59908b518d5ceb0dbdd628ea3bf81ce87", size = 653270, upload-time = "2025-08-12T19:50:28.088Z" },
-    { url = "https://files.pythonhosted.org/packages/34/0f/4a82859cf24677a3d05a783eed7aaf302d1c959bab0b9a674efaababfcde/winloop-0.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:5298b250ccda8927e4ceb8fd2650910bcbce9aa3b1c10006ee09a57f1bc669cf", size = 539399, upload-time = "2025-08-12T19:50:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/964ac072f12168cd1edfc02dc8dba676791cfadd4eb91a849778d854dc4e/winloop-0.2.2-cp314-cp314-win32.whl", hash = "sha256:70752a2182f70c1289874a43d446749101a91326dad2348edb772e9a1ab3ee25", size = 549604, upload-time = "2025-08-12T19:50:31.24Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a8/ce4f056042d19ef27f067c3a42427b1c777a85575a87447de0e9f99ed068/winloop-0.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:882cb79ee83d2a294630eed2fddf34d4dcd21e6f77f6b1cdf85e9a4917f75e84", size = 664377, upload-time = "2025-08-12T19:50:32.278Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/2b/e50e1a7907c547f4f1a0af3f0c081674ec9cee62c05b62f27e8402941c13/winloop-0.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:e77a56efa9564b7d57595ae93051354a6b551bf745d021a3d1d548453a34130f", size = 558828, upload-time = "2025-08-12T19:50:33.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/0b/c7e694d5835eb70f8d97c02bde234d5098afc5aab68b9444bd902f6cf762/winloop-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:8c600f5dc4a55ffc408f9d6cba798f349aab1a59d5c0d1172f70cd51cd27fad4", size = 656552, upload-time = "2025-08-12T19:50:34.5Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/01/c362fb46ad79139a680275fbd0abeb4aa02e0a0d119600de267c8db9317f/winloop-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0fa82a0e287be49ce8bacb1ee709540ace20e3823f0958f98c88a84f45e472ea", size = 817100, upload-time = "2025-08-12T19:50:36.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/84/8a6e51858d08282f5412711c3e6f10d0fc431c07566b15441886e5172499/winloop-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:4f16d83d0860f0897a995c692424bcd424a938d2f9ee11cfbc2464568b4822a0", size = 586396, upload-time = "2025-08-12T19:50:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/message_bus_lib/uv.lock
+++ b/shared_libs/message_bus_lib/uv.lock
@@ -902,11 +902,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/metric_sender_lib/uv.lock
+++ b/shared_libs/metric_sender_lib/uv.lock
@@ -866,11 +866,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/otel_lib/uv.lock
+++ b/shared_libs/otel_lib/uv.lock
@@ -893,11 +893,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/processor_manager_lib/uv.lock
+++ b/shared_libs/processor_manager_lib/uv.lock
@@ -730,11 +730,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/shared_libs/transformer_base_lib/uv.lock
+++ b/shared_libs/transformer_base_lib/uv.lock
@@ -1013,11 +1013,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 fix: upgrade urllib3 2.6.3 -> 2.7.0 and regenerate stale lockfiles

    Resolves PR validation pipeline failures caused by:
    - urllib3 2.6.3 CVEs (GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc)
    - Stale uv.lock in hl7_subscription_sender, hl7_mock_receiver,
      message_store_service, hl7_validation, message_replay_job