### PR TITLE
Fix duplicate configure_azure_monitor calls causing CPU spikes

### DIFF
--- a/shared_libs/event_logger_lib/event_logger_lib/event_logger.py
+++ b/shared_libs/event_logger_lib/event_logger_lib/event_logger.py
@@ -39,6 +39,21 @@ class EventLogger:
             )
             return
 
+        # If otel_lib.configure_otel() has already initialised Azure Monitor,
+        # skip to avoid duplicate exporters and background threads.
+        try:
+            from otel_lib import is_configured as otel_is_configured
+
+            if otel_is_configured():
+                logger.info(
+                    "Azure Monitor already initialised by otel_lib — "
+                    "EventLogger skipping duplicate configure_azure_monitor call."
+                )
+                EventLogger._azure_monitor_initialized = True
+                return
+        except ImportError:
+            pass  # otel_lib not installed — fall through to legacy init
+
         # Check if this library should initialize Azure Monitor
         azure_monitor_owner = (
             os.getenv("AZURE_MONITOR_OWNER", "event_logger").strip().lower()

--- a/shared_libs/metric_sender_lib/metric_sender_lib/metric_sender.py
+++ b/shared_libs/metric_sender_lib/metric_sender_lib/metric_sender.py
@@ -38,6 +38,21 @@ class MetricSender:
             )
 
     def _initialize_azure_monitor(self) -> None:
+        # If otel_lib.configure_otel() has already initialised Azure Monitor,
+        # skip to avoid duplicate exporters and background threads.
+        try:
+            from otel_lib import is_configured as otel_is_configured
+
+            if otel_is_configured():
+                logger.info(
+                    "Azure Monitor already initialised by otel_lib — "
+                    "MetricSender skipping duplicate configure_azure_monitor call."
+                )
+                self._meter = metrics.get_meter(__name__)
+                return
+        except ImportError:
+            pass  # otel_lib not installed — fall through to legacy init
+
         # Check if this library should initialize Azure Monitor
         # AZURE_MONITOR_OWNER needs set to 'metric_sender' on components where only metric_sender_lib is used
         azure_monitor_owner = (

--- a/shared_libs/otel_lib/otel_lib/__init__.py
+++ b/shared_libs/otel_lib/otel_lib/__init__.py
@@ -4,10 +4,12 @@ from .otel import (
     extract_trace_context,
     get_tracer,
     inject_trace_context,
+    is_configured,
 )
 
 __all__ = [
     "configure_otel",
+    "is_configured",
     "get_tracer",
     "inject_trace_context",
     "extract_trace_context",

--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 _otel_configured: bool = False
 
 
+def is_configured() -> bool:
+    """Return True if ``configure_otel`` has already been called successfully."""
+    return _otel_configured
+
+
 def configure_otel(service_name: str, service_version: str = "1.0.0") -> bool:
     """Configure OpenTelemetry for the service.
 
@@ -31,6 +36,8 @@ def configure_otel(service_name: str, service_version: str = "1.0.0") -> bool:
     Also installs an OtelCorrelationFilter on the root logger so every log
     record carries the current trace_id and span_id.
 
+    This function is safe to call multiple times — subsequent calls are no-ops.
+
     Args:
         service_name: The OTel service.name resource attribute (e.g. "phw-hl7-transformer").
         service_version: The OTel service.version resource attribute.
@@ -38,6 +45,11 @@ def configure_otel(service_name: str, service_version: str = "1.0.0") -> bool:
     Returns:
         True to indicate OTel has been configured.
     """
+    global _otel_configured
+    if _otel_configured:
+        logger.debug("OpenTelemetry already configured — skipping re-initialisation.")
+        return True
+
     connection_string = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
 
     if connection_string:
@@ -49,6 +61,7 @@ def configure_otel(service_name: str, service_version: str = "1.0.0") -> bool:
         _configure_noop(service_name, service_version)
 
     _install_log_filter()
+    _otel_configured = True
     return True
 
 

--- a/shared_libs/otel_lib/tests/test_otel.py
+++ b/shared_libs/otel_lib/tests/test_otel.py
@@ -6,7 +6,14 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
 import otel_lib.otel as otel_module
-from otel_lib import OtelCorrelationFilter, configure_otel, extract_trace_context, get_tracer, inject_trace_context
+from otel_lib import (
+    OtelCorrelationFilter,
+    configure_otel,
+    extract_trace_context,
+    get_tracer,
+    inject_trace_context,
+    is_configured,
+)
 from otel_lib.otel import _configure_noop
 
 
@@ -70,6 +77,25 @@ class TestConfigureOtel(unittest.TestCase):
         root_logger = logging.getLogger()
         otel_filters = [f for f in root_logger.filters if isinstance(f, OtelCorrelationFilter)]
         self.assertEqual(len(otel_filters), 1)
+
+    def test_is_configured_false_before_configure(self) -> None:
+        self.assertFalse(is_configured())
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_is_configured_true_after_configure(self) -> None:
+        configure_otel("test-service")
+        self.assertTrue(is_configured())
+
+    @patch.dict(
+        "os.environ",
+        {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=fake-key;IngestionEndpoint=https://example.com"},
+        clear=True,
+    )
+    def test_configure_otel_guard_prevents_double_azure_monitor_call(self) -> None:
+        with patch("otel_lib.otel.configure_azure_monitor") as mock_configure:
+            configure_otel("test-service")
+            configure_otel("test-service-again")
+            mock_configure.assert_called_once()
 
     @patch.dict("os.environ", {}, clear=True)
     def test_configure_otel_sets_service_name(self) -> None:


### PR DESCRIPTION
Restore the _otel_configured guard in configure_otel() so it is safe to call multiple times (only the first call takes effect).  Expose a public is_configured() helper so EventLogger and MetricSender can detect that otel_lib has already initialised Azure Monitor and skip their own configure_azure_monitor() call.

Before this fix, hl7_sender (and any service using both otel_lib and EventLogger) called configure_azure_monitor twice at startup, creating duplicate PeriodicExportingMetricReader and BatchSpanProcessor instances with their own background thread pools — doubling periodic export work and causing ~100% CPU spikes on the 5-minute lock-renewal cycle.