### PR TITLE
Fix memory leak: replace InMemorySpanExporter with no-op TracerProvider

### DIFF
--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -8,8 +8,6 @@ from opentelemetry import trace
 from opentelemetry.propagate import extract, inject
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 try:
     from azure.monitor.opentelemetry import configure_azure_monitor  # type: ignore[import-untyped]
@@ -93,7 +91,13 @@ def _configure_azure_monitor(service_name: str, service_version: str) -> None:
 
 
 def _configure_noop(service_name: str, service_version: str) -> None:
-    """Install a minimal TracerProvider with an in-memory (effectively no-op) exporter."""
+    """Install a minimal TracerProvider with no exporter.
+
+    Without a SpanProcessor, finished spans are silently discarded and
+    garbage-collected.  Previous versions used ``InMemorySpanExporter``
+    which stored every span in an ever-growing list, causing a memory leak
+    in long-running services.
+    """
     resource = Resource.create(
         {
             "service.name": service_name,
@@ -101,8 +105,6 @@ def _configure_noop(service_name: str, service_version: str) -> None:
         }
     )
     provider = TracerProvider(resource=resource)
-    # InMemorySpanExporter discards spans; this keeps OTel APIs functional without output.
-    provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
     trace.set_tracer_provider(provider)
 
 


### PR DESCRIPTION
InMemorySpanExporter stores every finished span in an ever-growing list (self._finished_spans) that is never cleared.  With wrap_handler creating a span per message, this list grows without bound in long-running sender containers, causing the gradual CPU/memory climb visible in monitoring.

Replace with a bare TracerProvider (no SpanProcessor).  Finished spans are silently discarded and garbage-collected while all OTel APIs remain functional.