### PR TITLE
fix: disable all OTel auto-instrumentors to stop CPU leak

### DIFF
--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -68,8 +68,14 @@ def _configure_azure_monitor(service_name: str, service_version: str) -> None:
     try:
         # azure-monitor-opentelemetry sets up the TracerProvider internally; we
         # only need to supply the resource so the service.name is correct.
-        # Disable instrumentors for libraries not used by our HL7 services to
-        # prevent ModuleNotFoundError when e.g. psycopg2 is not installed.
+        #
+        # Disable ALL auto-instrumentors — our HL7 services use manual
+        # telemetry only (EventLogger, wrap_handler spans).  Active
+        # auto-instrumentors create spans and HTTP-client metrics for every
+        # Azure SDK / urllib3 call, and azure_sdk tracing wraps every Service
+        # Bus send/receive.  The resulting metric time-series accumulate
+        # without bound inside the MeterProvider and cause steadily growing
+        # CPU usage over the lifetime of the container.
         configure_azure_monitor(
             resource=Resource.create(
                 {
@@ -78,10 +84,14 @@ def _configure_azure_monitor(service_name: str, service_version: str) -> None:
                 }
             ),
             instrumentation_options={
-                "django":   {"enabled": False},
-                "fastapi":  {"enabled": False},
-                "flask":    {"enabled": False},
-                "psycopg2": {"enabled": False},
+                "azure_sdk": {"enabled": False},
+                "django":    {"enabled": False},
+                "fastapi":   {"enabled": False},
+                "flask":     {"enabled": False},
+                "psycopg2":  {"enabled": False},
+                "requests":  {"enabled": False},
+                "urllib":    {"enabled": False},
+                "urllib3":   {"enabled": False},
             },
         ) # type: ignore
         logger.info("OpenTelemetry configured with Azure Monitor exporter for service '%s'.", service_name)

--- a/shared_libs/otel_lib/tests/test_otel.py
+++ b/shared_libs/otel_lib/tests/test_otel.py
@@ -51,6 +51,18 @@ class TestConfigureOtel(unittest.TestCase):
         with patch("otel_lib.otel.configure_azure_monitor") as mock_configure:
             configure_otel("test-service")
             mock_configure.assert_called_once()
+            _, kwargs = mock_configure.call_args
+            opts = kwargs["instrumentation_options"]
+            # Every supported auto-instrumentor must be disabled — our services
+            # use manual telemetry only.  Active instrumentors (especially
+            # azure_sdk and urllib3) create metric time-series that accumulate
+            # without bound and cause growing CPU usage.
+            for lib in ("azure_sdk", "django", "fastapi", "flask",
+                        "psycopg2", "requests", "urllib", "urllib3"):
+                self.assertFalse(
+                    opts[lib]["enabled"],
+                    f"Auto-instrumentor '{lib}' should be disabled",
+                )
 
     @patch.dict(
         "os.environ",


### PR DESCRIPTION
The azure-monitor-opentelemetry distro auto-instruments requests, urllib, urllib3 and azure_sdk by default.  These create HTTP-client metric time-series (histograms for duration, request/response size) and Azure SDK tracing spans for every Service Bus send/receive.

Metric time-series in the OTel MeterProvider are never garbage- collected, so unique attribute combinations accumulate without bound. Combined with urllib3 recording metrics for the Azure Monitor exporter's own HTTP calls (outside suppression context during token refresh) and azure_sdk tracing wrapping every AMQP operation, this produced steadily growing CPU usage across all containers.

Disable all auto-instrumentors — our HL7 services use manual telemetry only (EventLogger for logs, wrap_handler for spans). The TracerProvider, LoggerProvider, and MeterProvider pipelines remain fully functional for our explicit instrumentation.