### PR TITLE
INTHUB-586056 Add CPU and memory history graphs to Container App cards

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -46,7 +46,11 @@ from dashboard.services.alarms import (
     save_alarm_config,
 )
 from dashboard.services.arm import discover_flows, queue_to_microservice_ids
-from dashboard.services.azure_monitor import get_exceptions, get_messages_today
+from dashboard.services.azure_monitor import (
+    get_container_app_metric_history,
+    get_exceptions,
+    get_messages_today,
+)
 from dashboard.services.container_apps import get_container_apps_metrics
 from dashboard.services.flows import build_flow_data, get_active_flows, get_flows, overall_health, queue_to_workflow_id
 from dashboard.services.service_bus import get_message_metrics, get_queues
@@ -619,6 +623,20 @@ def api_flows() -> Response:
             "container_metrics": container_metrics,
         }
     )
+
+
+@app.route("/api/container-app/<name>/history")
+def api_container_app_history(name: str) -> Response:
+    """JSON endpoint returning CPU% and memory (MiB) history for a Container App.
+
+    Query params:
+        hours: window size — one of 1, 6, 24, 168 (defaults to 1).
+    """
+    hours_raw = request.args.get("hours", "1", type=str)
+    allowed = {"1": 1, "6": 6, "24": 24, "168": 168}
+    hours = allowed.get(hours_raw, 1)
+    history = get_container_app_metric_history(name, hours=hours)
+    return jsonify(history)
 
 
 @app.route("/api/messages")

--- a/dashboard/dashboard/services/azure_monitor.py
+++ b/dashboard/dashboard/services/azure_monitor.py
@@ -253,3 +253,103 @@ def get_container_app_metrics() -> list[dict]:
     except Exception as exc:
         log.error("Failed to fetch Container App metrics: %s", exc)
         return []
+
+
+def get_container_app_metric_history(app_name: str, hours: int = 1) -> dict:
+    """
+    Query Azure Monitor for CPU and memory time-series for a single Container App.
+
+    Returns a dict::
+
+        {
+            "name": "<app_name>",
+            "timestamps": ["2024-01-01T00:00:00Z", ...],
+            "cpu":        [12.3, 14.1, ...],     # CpuPercentage (%)
+            "memory_mb":  [128.4, 130.2, ...],   # WorkingSetBytes converted to MiB
+        }
+
+    Falls back to a dict with empty lists on any error.
+    """
+    empty = {"name": app_name, "timestamps": [], "cpu": [], "memory_mb": []}
+
+    if not all(
+        [
+            config.AZURE_SUBSCRIPTION_ID,
+            config.AZURE_CONTAINER_APPS_RESOURCE_GROUP,
+        ]
+    ):
+        log.warning("Container Apps resource configuration missing")
+        return empty
+
+    # Validate the app name to avoid URL injection — Container App names use the
+    # Azure naming rules (lowercase letters, digits, hyphens).
+    if not re.fullmatch(r"[a-zA-Z0-9\-]{1,64}", app_name):
+        log.warning("Invalid container app name: %r", app_name)
+        return empty
+
+    # Choose an appropriate aggregation interval based on the requested window.
+    if hours <= 1:
+        interval = "PT1M"
+    elif hours <= 6:
+        interval = "PT5M"
+    elif hours <= 24:
+        interval = "PT15M"
+    else:
+        interval = "PT1H"
+
+    try:
+        import requests  # noqa: PLC0415
+
+        cred = get_azure_credential()
+        token = cred.get_token("https://management.azure.com/.default").token
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        now = datetime.now(timezone.utc)
+        start = (now - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        resource_id = (
+            f"/subscriptions/{config.AZURE_SUBSCRIPTION_ID}"
+            f"/resourceGroups/{config.AZURE_CONTAINER_APPS_RESOURCE_GROUP}"
+            f"/providers/Microsoft.App/containerApps/{app_name}"
+        )
+        query = (
+            "api-version=2018-01-01"
+            "&metricnames=CpuPercentage,WorkingSetBytes"
+            f"&timespan={start}/{end}"
+            f"&interval={interval}"
+            "&aggregation=Average"
+            "&metricnamespace=microsoft.app/containerapps"
+        )
+        url = f"https://management.azure.com{resource_id}/providers/microsoft.insights/metrics?{query}"
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Build a unified timestamp axis from the CPU series (both series share
+        # the same interval so timestamps line up).
+        cpu_points: dict[str, float] = {}
+        mem_points: dict[str, float] = {}
+        for m in data.get("value", []):
+            metric_name = m.get("name", {}).get("value", "")
+            for ts in m.get("timeseries", []):
+                for dp in ts.get("data", []):
+                    t = dp.get("timeStamp")
+                    val = dp.get("average")
+                    if t is None or val is None:
+                        continue
+                    if metric_name == "CpuPercentage":
+                        cpu_points[t] = round(float(val), 2)
+                    elif metric_name == "WorkingSetBytes":
+                        mem_points[t] = round(float(val) / 1048576, 2)
+
+        timestamps = sorted(set(cpu_points) | set(mem_points))
+        return {
+            "name": app_name,
+            "timestamps": timestamps,
+            "cpu": [cpu_points.get(t, 0.0) for t in timestamps],
+            "memory_mb": [mem_points.get(t, 0.0) for t in timestamps],
+        }
+    except Exception as exc:
+        log.error("Failed to fetch metric history for %s: %s", app_name, exc)
+        return empty

--- a/dashboard/dashboard/services/azure_monitor.py
+++ b/dashboard/dashboard/services/azure_monitor.py
@@ -264,8 +264,8 @@ def get_container_app_metric_history(app_name: str, hours: int = 1) -> dict:
         {
             "name": "<app_name>",
             "timestamps": ["2024-01-01T00:00:00Z", ...],
-            "cpu":        [12.3, 14.1, ...],     # CpuPercentage (%)
-            "memory_mb":  [128.4, 130.2, ...],   # WorkingSetBytes converted to MiB
+            "cpu":        [12.3, None, 14.1, ...],   # CpuPercentage (%); None where data is absent
+            "memory_mb":  [128.4, 130.2, ...],       # WorkingSetBytes converted to MiB; None where absent
         }
 
     Falls back to a dict with empty lists on any error.
@@ -281,9 +281,10 @@ def get_container_app_metric_history(app_name: str, hours: int = 1) -> dict:
         log.warning("Container Apps resource configuration missing")
         return empty
 
-    # Validate the app name to avoid URL injection — Container App names use the
-    # Azure naming rules (lowercase letters, digits, hyphens).
-    if not re.fullmatch(r"[a-zA-Z0-9\-]{1,64}", app_name):
+    # Validate the app name to avoid URL injection — Container App names follow
+    # Azure naming rules (lowercase letters, digits, hyphens; 1–32 chars;
+    # must start and end with a letter or digit).
+    if not re.fullmatch(r"[a-z0-9]([a-z0-9\-]{0,30}[a-z0-9])?", app_name):
         log.warning("Invalid container app name: %r", app_name)
         return empty
 
@@ -347,8 +348,8 @@ def get_container_app_metric_history(app_name: str, hours: int = 1) -> dict:
         return {
             "name": app_name,
             "timestamps": timestamps,
-            "cpu": [cpu_points.get(t, 0.0) for t in timestamps],
-            "memory_mb": [mem_points.get(t, 0.0) for t in timestamps],
+            "cpu": [cpu_points.get(t) for t in timestamps],
+            "memory_mb": [mem_points.get(t) for t in timestamps],
         }
     except Exception as exc:
         log.error("Failed to fetch metric history for %s: %s", app_name, exc)

--- a/dashboard/dashboard/services/azure_monitor.py
+++ b/dashboard/dashboard/services/azure_monitor.py
@@ -16,6 +16,10 @@ from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
 
+# Azure Container App naming rules: lowercase letters, digits, hyphens;
+# 1–32 characters; must start and end with a letter or digit.
+_CONTAINER_APP_NAME_RE = re.compile(r"[a-z0-9]([a-z0-9\-]{0,30}[a-z0-9])?$")
+
 
 def _get_logs_client() -> Any:
     cred = get_azure_credential()
@@ -282,9 +286,8 @@ def get_container_app_metric_history(app_name: str, hours: int = 1) -> dict:
         return empty
 
     # Validate the app name to avoid URL injection — Container App names follow
-    # Azure naming rules (lowercase letters, digits, hyphens; 1–32 chars;
-    # must start and end with a letter or digit).
-    if not re.fullmatch(r"[a-z0-9]([a-z0-9\-]{0,30}[a-z0-9])?", app_name):
+    # Azure naming rules (see _CONTAINER_APP_NAME_RE).
+    if not _CONTAINER_APP_NAME_RE.fullmatch(app_name):
         log.warning("Invalid container app name: %r", app_name)
         return empty
 

--- a/dashboard/dashboard/static/css/style.css
+++ b/dashboard/dashboard/static/css/style.css
@@ -866,6 +866,89 @@ table.dash-table td {
 .metric-bar-fill.cpu  { background: linear-gradient(90deg, var(--accent-blue), var(--accent-cyan)); }
 .metric-bar-fill.mem  { background: linear-gradient(90deg, var(--accent-purple), var(--accent-cyan)); }
 
+/* Clickable Container App card — expands to show CPU & memory history */
+.app-metric-card--clickable {
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.app-metric-card--clickable:hover,
+.app-metric-card--clickable:focus-visible {
+  border-color: var(--accent-cyan);
+  box-shadow: 0 0 0 1px var(--accent-cyan);
+  outline: none;
+}
+.app-metric-card--open {
+  border-color: var(--accent-cyan);
+}
+.app-metric-chevron {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-right: 0.15rem;
+  transition: transform 0.15s ease;
+}
+.app-metric-history {
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px dashed var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  cursor: default;
+}
+.app-history-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.app-history-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.app-history-range-buttons {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+.app-history-range-buttons .btn-range {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.app-history-range-buttons .btn-range:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-cyan);
+}
+.app-history-range-buttons .btn-range.active {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: var(--accent-blue);
+}
+.app-history-status {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+}
+.app-history-chart-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.app-history-chart-title {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.app-history-chart {
+  width: 100%;
+  display: block;
+}
+
 /* ---------- Buttons ---------- */
 .btn-dash {
   background: var(--bg-secondary);

--- a/dashboard/dashboard/static/css/style.css
+++ b/dashboard/dashboard/static/css/style.css
@@ -868,14 +868,18 @@ table.dash-table td {
 
 /* Clickable Container App card — expands to show CPU & memory history */
 .app-metric-card--clickable {
-  cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
+.app-metric-card-header {
+  cursor: pointer;
+}
+.app-metric-card-header:focus-visible {
+  outline: none;
+}
 .app-metric-card--clickable:hover,
-.app-metric-card--clickable:focus-visible {
+.app-metric-card--clickable:focus-within {
   border-color: var(--accent-cyan);
   box-shadow: 0 0 0 1px var(--accent-cyan);
-  outline: none;
 }
 .app-metric-card--open {
   border-color: var(--accent-cyan);

--- a/dashboard/dashboard/static/css/style.css
+++ b/dashboard/dashboard/static/css/style.css
@@ -872,6 +872,14 @@ table.dash-table td {
 }
 .app-metric-card-header {
   cursor: pointer;
+  /* Reset <button> element defaults */
+  background: none;
+  border: none;
+  padding: 0;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  font: inherit;
 }
 .app-metric-card-header:focus-visible {
   outline: none;

--- a/dashboard/dashboard/static/js/app-history.js
+++ b/dashboard/dashboard/static/js/app-history.js
@@ -1,0 +1,230 @@
+/*
+ * Container-App CPU & memory history chart.
+ *
+ * Clicking an .app-metric-card--clickable expands a panel below the existing
+ * gauges containing two small canvas-based line charts (CPU%, Memory MiB).
+ *
+ * The fetch is lazy: history is only loaded when the card is first opened or
+ * when the user changes the time range.  Data is cached per-card per-range
+ * for the lifetime of the page to keep re-opens snappy.
+ */
+(function () {
+  'use strict';
+
+  // ----- chart drawing -----------------------------------------------------
+
+  function getCssVar(name, fallback) {
+    var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return v || fallback;
+  }
+
+  function drawLineChart(canvas, points, opts) {
+    opts = opts || {};
+    var dpr = window.devicePixelRatio || 1;
+    var cssW = canvas.clientWidth || canvas.parentElement.clientWidth || 300;
+    var cssH = parseInt(canvas.getAttribute('height'), 10) || 90;
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    canvas.style.height = cssH + 'px';
+
+    var ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    var padL = 32, padR = 6, padT = 6, padB = 14;
+    var plotW = cssW - padL - padR;
+    var plotH = cssH - padT - padB;
+
+    var muted = getCssVar('--text-muted', '#888');
+    var border = getCssVar('--border-color', '#333');
+    var stroke = opts.color || getCssVar('--accent-blue', '#12A3C9');
+    var fill = opts.fill || 'rgba(18,163,201,0.15)';
+
+    if (!points || points.length === 0) {
+      ctx.fillStyle = muted;
+      ctx.font = '11px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('No data', cssW / 2, cssH / 2);
+      return;
+    }
+
+    var vals = points.map(function (p) { return p.v; });
+    var minV = Math.min.apply(null, vals);
+    var maxV = Math.max.apply(null, vals);
+    if (opts.yMin !== undefined) minV = Math.min(minV, opts.yMin);
+    if (opts.yMax !== undefined) maxV = Math.max(maxV, opts.yMax);
+    if (minV === maxV) { maxV = minV + 1; }
+    // Snap min down to zero for nicer charts of small positive values.
+    if (minV > 0 && minV < (maxV - minV) * 0.5) { minV = 0; }
+
+    function x(i) { return padL + (points.length === 1 ? plotW / 2 : (i / (points.length - 1)) * plotW); }
+    function y(v) { return padT + plotH - ((v - minV) / (maxV - minV)) * plotH; }
+
+    // Axes / gridlines
+    ctx.strokeStyle = border;
+    ctx.lineWidth = 1;
+    ctx.font = '10px system-ui, sans-serif';
+    ctx.fillStyle = muted;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    var gridCount = 3;
+    for (var g = 0; g <= gridCount; g++) {
+      var gy = padT + (plotH * g) / gridCount;
+      var gv = maxV - ((maxV - minV) * g) / gridCount;
+      ctx.beginPath();
+      ctx.moveTo(padL, gy);
+      ctx.lineTo(padL + plotW, gy);
+      ctx.globalAlpha = 0.35;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+      ctx.fillText(gv.toFixed(gv >= 100 ? 0 : 1), padL - 4, gy);
+    }
+
+    // X-axis labels — first and last timestamps
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    var firstLabel = opts.formatX ? opts.formatX(points[0].t) : '';
+    var lastLabel = opts.formatX ? opts.formatX(points[points.length - 1].t) : '';
+    ctx.fillText(firstLabel, padL, padT + plotH + 2);
+    ctx.textAlign = 'right';
+    ctx.fillText(lastLabel, padL + plotW, padT + plotH + 2);
+
+    // Area fill
+    ctx.beginPath();
+    ctx.moveTo(x(0), y(points[0].v));
+    for (var i = 1; i < points.length; i++) { ctx.lineTo(x(i), y(points[i].v)); }
+    ctx.lineTo(x(points.length - 1), padT + plotH);
+    ctx.lineTo(x(0), padT + plotH);
+    ctx.closePath();
+    ctx.fillStyle = fill;
+    ctx.fill();
+
+    // Line
+    ctx.beginPath();
+    ctx.moveTo(x(0), y(points[0].v));
+    for (var j = 1; j < points.length; j++) { ctx.lineTo(x(j), y(points[j].v)); }
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+
+  function formatTimestamp(iso, hours) {
+    try {
+      var d = new Date(iso);
+      if (hours <= 24) {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      }
+      return d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+             ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (e) { return ''; }
+  }
+
+  // ----- card behaviour ----------------------------------------------------
+
+  function renderCharts(panel, hours, data) {
+    var ts = (data && data.timestamps) || [];
+    var canvases = panel.querySelectorAll('canvas.app-history-chart');
+    canvases.forEach(function (cv) {
+      var series = cv.getAttribute('data-series');
+      var vals = (data && data[series]) || [];
+      var points = ts.map(function (t, i) { return { t: t, v: Number(vals[i] || 0) }; });
+      var isCpu = series === 'cpu';
+      drawLineChart(cv, points, {
+        color: isCpu
+          ? getCssVar('--accent-cyan', '#12A3C9')
+          : getCssVar('--accent-purple', '#7e57c2'),
+        fill: isCpu ? 'rgba(18,163,201,0.18)' : 'rgba(126,87,194,0.18)',
+        yMin: 0,
+        yMax: isCpu ? 100 : undefined,
+        formatX: function (t) { return formatTimestamp(t, hours); },
+      });
+    });
+  }
+
+  function loadHistory(card, hours) {
+    var name = card.getAttribute('data-app-name');
+    var panel = card.querySelector('.app-metric-history');
+    var status = panel.querySelector('.app-history-status');
+    var cacheKey = name + '|' + hours;
+    card._historyCache = card._historyCache || {};
+
+    function show(data) {
+      renderCharts(panel, hours, data);
+      var n = (data && data.timestamps && data.timestamps.length) || 0;
+      status.textContent = n ? (n + ' points') : 'no data';
+    }
+
+    if (card._historyCache[cacheKey]) {
+      show(card._historyCache[cacheKey]);
+      return;
+    }
+
+    status.textContent = 'Loading…';
+    fetch('/api/container-app/' + encodeURIComponent(name) + '/history?hours=' + hours, {
+      headers: { 'Accept': 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (data) {
+        card._historyCache[cacheKey] = data;
+        show(data);
+      })
+      .catch(function (err) {
+        console.error('history fetch failed', err);
+        status.textContent = 'error';
+        renderCharts(panel, hours, { timestamps: [], cpu: [], memory_mb: [] });
+      });
+  }
+
+  window.toggleAppHistory = function (card) {
+    var panel = card.querySelector('.app-metric-history');
+    if (!panel) return;
+    var chev = card.querySelector('.app-metric-chevron');
+    var isOpen = !panel.hasAttribute('hidden');
+
+    if (isOpen) {
+      panel.setAttribute('hidden', '');
+      card.classList.remove('app-metric-card--open');
+      if (chev) { chev.classList.remove('bi-chevron-down'); chev.classList.add('bi-chevron-right'); }
+      return;
+    }
+
+    panel.removeAttribute('hidden');
+    card.classList.add('app-metric-card--open');
+    if (chev) { chev.classList.remove('bi-chevron-right'); chev.classList.add('bi-chevron-down'); }
+
+    // Wire up range buttons once.
+    if (!card._historyWired) {
+      card._historyWired = true;
+      panel.querySelectorAll('.btn-range').forEach(function (btn) {
+        btn.addEventListener('click', function (ev) {
+          ev.stopPropagation();
+          panel.querySelectorAll('.btn-range').forEach(function (b) { b.classList.remove('active'); });
+          btn.classList.add('active');
+          loadHistory(card, parseInt(btn.getAttribute('data-hours'), 10) || 1);
+        });
+      });
+    }
+
+    var activeBtn = panel.querySelector('.btn-range.active') || panel.querySelector('.btn-range');
+    var hours = activeBtn ? parseInt(activeBtn.getAttribute('data-hours'), 10) : 1;
+    loadHistory(card, hours || 1);
+  };
+
+  // Redraw open charts on resize so they stay crisp.
+  var resizeTimer = null;
+  window.addEventListener('resize', function () {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      document.querySelectorAll('.app-metric-card--open').forEach(function (card) {
+        var panel = card.querySelector('.app-metric-history');
+        if (!panel || panel.hasAttribute('hidden')) return;
+        var activeBtn = panel.querySelector('.btn-range.active');
+        var hours = activeBtn ? parseInt(activeBtn.getAttribute('data-hours'), 10) : 1;
+        var name = card.getAttribute('data-app-name');
+        var cached = card._historyCache && card._historyCache[name + '|' + hours];
+        if (cached) renderCharts(panel, hours, cached);
+      });
+    }, 150);
+  });
+})();

--- a/dashboard/dashboard/static/js/app-history.js
+++ b/dashboard/dashboard/static/js/app-history.js
@@ -127,7 +127,11 @@
     canvases.forEach(function (cv) {
       var series = cv.getAttribute('data-series');
       var vals = (data && data[series]) || [];
-      var points = ts.map(function (t, i) { return { t: t, v: Number(vals[i] || 0) }; });
+      var points = ts.reduce(function (acc, t, i) {
+        var v = vals[i];
+        if (v != null) { acc.push({ t: t, v: Number(v) }); }
+        return acc;
+      }, []);
       var isCpu = series === 'cpu';
       drawLineChart(cv, points, {
         color: isCpu

--- a/dashboard/dashboard/static/js/app-history.js
+++ b/dashboard/dashboard/static/js/app-history.js
@@ -183,18 +183,21 @@
   window.toggleAppHistory = function (card) {
     var panel = card.querySelector('.app-metric-history');
     if (!panel) return;
+    var header = card.querySelector('.app-metric-card-header');
     var chev = card.querySelector('.app-metric-chevron');
     var isOpen = !panel.hasAttribute('hidden');
 
     if (isOpen) {
       panel.setAttribute('hidden', '');
       card.classList.remove('app-metric-card--open');
+      if (header) { header.setAttribute('aria-expanded', 'false'); }
       if (chev) { chev.classList.remove('bi-chevron-down'); chev.classList.add('bi-chevron-right'); }
       return;
     }
 
     panel.removeAttribute('hidden');
     card.classList.add('app-metric-card--open');
+    if (header) { header.setAttribute('aria-expanded', 'true'); }
     if (chev) { chev.classList.remove('bi-chevron-right'); chev.classList.add('bi-chevron-down'); }
 
     // Wire up range buttons once.

--- a/dashboard/dashboard/templates/flows.html
+++ b/dashboard/dashboard/templates/flows.html
@@ -380,10 +380,8 @@
         <div class="col-12 col-sm-6 col-lg-4">
           <div class="app-metric-card app-metric-card--clickable"
                data-app-name="{{ app.name }}">
-            <div class="app-metric-card-header"
-                 role="button" tabindex="0"
-                 onclick="toggleAppHistory(this.closest('.app-metric-card--clickable'))"
-                 onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAppHistory(this.closest('.app-metric-card--clickable'));}">
+            <button type="button" class="app-metric-card-header" aria-expanded="false"
+                    onclick="toggleAppHistory(this.closest('.app-metric-card--clickable'))">
               <div class="app-metric-name">
                 <i class="bi bi-chevron-right app-metric-chevron"></i> {{ app.name }}
               </div>
@@ -401,7 +399,7 @@
               <div style="font-size:0.65rem; color:var(--text-muted); margin-top:0.2rem;">
                 <i class="bi bi-layers"></i> {{ app.replicas }} {{ _("replica(s)") }}
               </div>
-            </div>
+            </button>
             <div class="app-metric-history" hidden>
               <div class="app-history-controls">
                 <span class="app-history-label">{{ _("History") }}</span>

--- a/dashboard/dashboard/templates/flows.html
+++ b/dashboard/dashboard/templates/flows.html
@@ -379,28 +379,30 @@
         {% for app in apps %}
         <div class="col-12 col-sm-6 col-lg-4">
           <div class="app-metric-card app-metric-card--clickable"
-               role="button" tabindex="0"
-               data-app-name="{{ app.name }}"
-               onclick="toggleAppHistory(this)"
-               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAppHistory(this);}">
-            <div class="app-metric-name">
-              <i class="bi bi-chevron-right app-metric-chevron"></i> {{ app.name }}
-            </div>
-            <div>
-              <div class="metric-bar-label"><span>{{ _("CPU") }}</span><span>{{ app.cpu_usage }}%</span></div>
-              <div class="metric-bar"><div class="metric-bar-fill cpu" style="width:{{ [app.cpu_usage, 100] | min }}%"></div></div>
-            </div>
-            <div>
-              <div class="metric-bar-label">
-                <span>{{ _("Memory") }}</span>
-                <span>{{ (app.memory_bytes / 1048576) | round(1) }} MB</span>
+               data-app-name="{{ app.name }}">
+            <div class="app-metric-card-header"
+                 role="button" tabindex="0"
+                 onclick="toggleAppHistory(this.closest('.app-metric-card--clickable'))"
+                 onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAppHistory(this.closest('.app-metric-card--clickable'));}">
+              <div class="app-metric-name">
+                <i class="bi bi-chevron-right app-metric-chevron"></i> {{ app.name }}
               </div>
-              <div class="metric-bar"><div class="metric-bar-fill mem" style="width:{{ [(app.memory_bytes / 536870912 * 100), 100] | min | round(1) }}%"></div></div>
+              <div>
+                <div class="metric-bar-label"><span>{{ _("CPU") }}</span><span>{{ app.cpu_usage }}%</span></div>
+                <div class="metric-bar"><div class="metric-bar-fill cpu" style="width:{{ [app.cpu_usage, 100] | min }}%"></div></div>
+              </div>
+              <div>
+                <div class="metric-bar-label">
+                  <span>{{ _("Memory") }}</span>
+                  <span>{{ (app.memory_bytes / 1048576) | round(1) }} MB</span>
+                </div>
+                <div class="metric-bar"><div class="metric-bar-fill mem" style="width:{{ [(app.memory_bytes / 536870912 * 100), 100] | min | round(1) }}%"></div></div>
+              </div>
+              <div style="font-size:0.65rem; color:var(--text-muted); margin-top:0.2rem;">
+                <i class="bi bi-layers"></i> {{ app.replicas }} {{ _("replica(s)") }}
+              </div>
             </div>
-            <div style="font-size:0.65rem; color:var(--text-muted); margin-top:0.2rem;">
-              <i class="bi bi-layers"></i> {{ app.replicas }} {{ _("replica(s)") }}
-            </div>
-            <div class="app-metric-history" hidden onclick="event.stopPropagation();">
+            <div class="app-metric-history" hidden>
               <div class="app-history-controls">
                 <span class="app-history-label">{{ _("History") }}</span>
                 <div class="app-history-range-buttons" role="group">

--- a/dashboard/dashboard/templates/flows.html
+++ b/dashboard/dashboard/templates/flows.html
@@ -378,8 +378,14 @@
       <div class="row g-2">
         {% for app in apps %}
         <div class="col-12 col-sm-6 col-lg-4">
-          <div class="app-metric-card">
-            <div class="app-metric-name">{{ app.name }}</div>
+          <div class="app-metric-card app-metric-card--clickable"
+               role="button" tabindex="0"
+               data-app-name="{{ app.name }}"
+               onclick="toggleAppHistory(this)"
+               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAppHistory(this);}">
+            <div class="app-metric-name">
+              <i class="bi bi-chevron-right app-metric-chevron"></i> {{ app.name }}
+            </div>
             <div>
               <div class="metric-bar-label"><span>{{ _("CPU") }}</span><span>{{ app.cpu_usage }}%</span></div>
               <div class="metric-bar"><div class="metric-bar-fill cpu" style="width:{{ [app.cpu_usage, 100] | min }}%"></div></div>
@@ -393,6 +399,26 @@
             </div>
             <div style="font-size:0.65rem; color:var(--text-muted); margin-top:0.2rem;">
               <i class="bi bi-layers"></i> {{ app.replicas }} {{ _("replica(s)") }}
+            </div>
+            <div class="app-metric-history" hidden onclick="event.stopPropagation();">
+              <div class="app-history-controls">
+                <span class="app-history-label">{{ _("History") }}</span>
+                <div class="app-history-range-buttons" role="group">
+                  <button type="button" class="btn-range active" data-hours="1">1h</button>
+                  <button type="button" class="btn-range" data-hours="6">6h</button>
+                  <button type="button" class="btn-range" data-hours="24">24h</button>
+                  <button type="button" class="btn-range" data-hours="168">7d</button>
+                </div>
+                <span class="app-history-status"></span>
+              </div>
+              <div class="app-history-chart-block">
+                <div class="app-history-chart-title">{{ _("CPU") }} (%)</div>
+                <canvas class="app-history-chart" data-series="cpu" height="90"></canvas>
+              </div>
+              <div class="app-history-chart-block">
+                <div class="app-history-chart-title">{{ _("Memory") }} (MiB)</div>
+                <canvas class="app-history-chart" data-series="memory_mb" height="90"></canvas>
+              </div>
             </div>
           </div>
         </div>
@@ -557,6 +583,7 @@
 
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
+<script src="{{ url_for('static', filename='js/app-history.js') }}"></script>
 <script>
   // Pre-apply filter from URL param (e.g. ?filter=healthy)
   const _urlFilter = new URLSearchParams(window.location.search).get('filter');

--- a/dashboard/tests/test_app.py
+++ b/dashboard/tests/test_app.py
@@ -119,6 +119,35 @@ class TestApiRoutes:
         assert "messages" in data
         assert "count" in data
 
+    def test_api_container_app_history_returns_json(self, client: FlaskClient) -> None:
+        fake_history = {
+            "name": "my-app",
+            "timestamps": ["2024-01-01T00:00:00Z"],
+            "cpu": [12.5],
+            "memory_mb": [128.0],
+        }
+        with patch("dashboard.app.get_container_app_metric_history", return_value=fake_history) as mock_fn:
+            response = client.get("/api/container-app/my-app/history")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data == fake_history
+        mock_fn.assert_called_once_with("my-app", hours=1)
+
+    def test_api_container_app_history_accepts_valid_hours(self, client: FlaskClient) -> None:
+        fake_history = {"name": "my-app", "timestamps": [], "cpu": [], "memory_mb": []}
+        for hours_str, hours_int in [("1", 1), ("6", 6), ("24", 24), ("168", 168)]:
+            with patch("dashboard.app.get_container_app_metric_history", return_value=fake_history) as mock_fn:
+                response = client.get(f"/api/container-app/my-app/history?hours={hours_str}")
+            assert response.status_code == 200
+            mock_fn.assert_called_once_with("my-app", hours=hours_int)
+
+    def test_api_container_app_history_defaults_to_1h_for_invalid_hours(self, client: FlaskClient) -> None:
+        fake_history = {"name": "my-app", "timestamps": [], "cpu": [], "memory_mb": []}
+        with patch("dashboard.app.get_container_app_metric_history", return_value=fake_history) as mock_fn:
+            response = client.get("/api/container-app/my-app/history?hours=999")
+        assert response.status_code == 200
+        mock_fn.assert_called_once_with("my-app", hours=1)
+
 
 class TestEnvLoading:
     def test_load_dotenv_sets_missing_values_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/dashboard/tests/test_azure_monitor.py
+++ b/dashboard/tests/test_azure_monitor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from azure.monitor.query import LogsQueryStatus
 
@@ -48,3 +48,181 @@ def test_get_messages_today_maps_trace_properties() -> None:
     assert messages[0]["event"] == "MESSAGE_RECEIVED"
     assert messages[0]["app"] == "uks-dev-mpi-hl7server-ca"
     assert messages[0]["dimensions"]["workflow_id"] == "mpi-to-topic"
+
+
+# ---------------------------------------------------------------------------
+# get_container_app_metric_history tests
+# ---------------------------------------------------------------------------
+
+def _make_metric_response(cpu_points: list[dict], mem_points: list[dict]) -> dict:
+    """Build a minimal Azure Monitor metrics REST response."""
+    return {
+        "value": [
+            {
+                "name": {"value": "CpuPercentage"},
+                "timeseries": [{"data": cpu_points}],
+            },
+            {
+                "name": {"value": "WorkingSetBytes"},
+                "timeseries": [{"data": mem_points}],
+            },
+        ]
+    }
+
+
+class TestGetContainerAppMetricHistoryInvalidName:
+    def test_empty_name_returns_empty(self) -> None:
+        result = azure_monitor.get_container_app_metric_history("", hours=1)
+        assert result == {"name": "", "timestamps": [], "cpu": [], "memory_mb": []}
+
+    def test_uppercase_name_returns_empty(self) -> None:
+        result = azure_monitor.get_container_app_metric_history("MyApp", hours=1)
+        assert result == {"name": "MyApp", "timestamps": [], "cpu": [], "memory_mb": []}
+
+    def test_name_with_slash_returns_empty(self) -> None:
+        result = azure_monitor.get_container_app_metric_history("app/name", hours=1)
+        assert result == {"name": "app/name", "timestamps": [], "cpu": [], "memory_mb": []}
+
+    def test_name_ending_with_hyphen_returns_empty(self) -> None:
+        result = azure_monitor.get_container_app_metric_history("my-app-", hours=1)
+        assert result == {"name": "my-app-", "timestamps": [], "cpu": [], "memory_mb": []}
+
+    def test_name_too_long_returns_empty(self) -> None:
+        long_name = "a" * 33
+        result = azure_monitor.get_container_app_metric_history(long_name, hours=1)
+        assert result == {"name": long_name, "timestamps": [], "cpu": [], "memory_mb": []}
+
+    def test_valid_name_passes_validation(self) -> None:
+        """A valid name should not return early due to validation (requires Azure config)."""
+        with patch.object(azure_monitor.config, "AZURE_SUBSCRIPTION_ID", ""), \
+                patch.object(azure_monitor.config, "AZURE_CONTAINER_APPS_RESOURCE_GROUP", ""):
+            result = azure_monitor.get_container_app_metric_history("my-app", hours=1)
+        # Returns empty because Azure config is missing, not because validation failed.
+        assert result["name"] == "my-app"
+        assert result["timestamps"] == []
+
+
+class TestGetContainerAppMetricHistoryIntervalSelection:
+    """Verify that the correct aggregation interval is chosen for each window size."""
+
+    def _call_and_capture_url(self, hours: int) -> str:
+        """Call the function and return the URL that was requested."""
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = _make_metric_response([], [])
+        fake_resp.raise_for_status.return_value = None
+
+        fake_cred = MagicMock()
+        fake_cred.get_token.return_value = MagicMock(token="tok")
+
+        with patch.object(azure_monitor.config, "AZURE_SUBSCRIPTION_ID", "sub-1"), \
+                patch.object(azure_monitor.config, "AZURE_CONTAINER_APPS_RESOURCE_GROUP", "rg-1"), \
+                patch("dashboard.services.azure_monitor.get_azure_credential", return_value=fake_cred), \
+                patch("requests.get", return_value=fake_resp) as mock_get:
+            azure_monitor.get_container_app_metric_history("my-app", hours=hours)
+            return mock_get.call_args[0][0]
+
+    def test_1h_uses_pt1m(self) -> None:
+        assert "interval=PT1M" in self._call_and_capture_url(1)
+
+    def test_6h_uses_pt5m(self) -> None:
+        assert "interval=PT5M" in self._call_and_capture_url(6)
+
+    def test_24h_uses_pt15m(self) -> None:
+        assert "interval=PT15M" in self._call_and_capture_url(24)
+
+    def test_168h_uses_pt1h(self) -> None:
+        assert "interval=PT1H" in self._call_and_capture_url(168)
+
+
+class TestGetContainerAppMetricHistoryParsing:
+    """Verify Azure Monitor response parsing and timestamp alignment."""
+
+    def _call_with_response(self, api_response: dict, hours: int = 1) -> dict:
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = api_response
+        fake_resp.raise_for_status.return_value = None
+
+        fake_cred = MagicMock()
+        fake_cred.get_token.return_value = MagicMock(token="tok")
+
+        with patch.object(azure_monitor.config, "AZURE_SUBSCRIPTION_ID", "sub-1"), \
+                patch.object(azure_monitor.config, "AZURE_CONTAINER_APPS_RESOURCE_GROUP", "rg-1"), \
+                patch("dashboard.services.azure_monitor.get_azure_credential", return_value=fake_cred), \
+                patch("requests.get", return_value=fake_resp):
+            return azure_monitor.get_container_app_metric_history("my-app", hours=hours)
+
+    def test_parses_cpu_and_memory(self) -> None:
+        response = _make_metric_response(
+            cpu_points=[{"timeStamp": "2024-01-01T00:00:00Z", "average": 25.0}],
+            mem_points=[{"timeStamp": "2024-01-01T00:00:00Z", "average": 134217728.0}],
+        )
+        result = self._call_with_response(response)
+
+        assert result["name"] == "my-app"
+        assert result["timestamps"] == ["2024-01-01T00:00:00Z"]
+        assert result["cpu"] == [25.0]
+        assert result["memory_mb"] == [round(134217728.0 / 1048576, 2)]
+
+    def test_missing_cpu_point_is_none(self) -> None:
+        """When a timestamp has memory data but no CPU data, cpu entry should be None."""
+        response = _make_metric_response(
+            cpu_points=[],
+            mem_points=[{"timeStamp": "2024-01-01T00:00:00Z", "average": 104857600.0}],
+        )
+        result = self._call_with_response(response)
+
+        assert result["timestamps"] == ["2024-01-01T00:00:00Z"]
+        assert result["cpu"] == [None]
+        assert result["memory_mb"] == [100.0]
+
+    def test_missing_memory_point_is_none(self) -> None:
+        """When a timestamp has CPU data but no memory data, memory_mb entry should be None."""
+        response = _make_metric_response(
+            cpu_points=[{"timeStamp": "2024-01-01T00:00:00Z", "average": 10.0}],
+            mem_points=[],
+        )
+        result = self._call_with_response(response)
+
+        assert result["timestamps"] == ["2024-01-01T00:00:00Z"]
+        assert result["cpu"] == [10.0]
+        assert result["memory_mb"] == [None]
+
+    def test_datapoints_without_average_are_skipped(self) -> None:
+        """Data points with a missing 'average' field should be silently skipped."""
+        response = _make_metric_response(
+            cpu_points=[{"timeStamp": "2024-01-01T00:00:00Z"}],
+            mem_points=[],
+        )
+        result = self._call_with_response(response)
+
+        assert result["timestamps"] == []
+        assert result["cpu"] == []
+
+    def test_timestamps_are_sorted(self) -> None:
+        response = _make_metric_response(
+            cpu_points=[
+                {"timeStamp": "2024-01-01T00:02:00Z", "average": 5.0},
+                {"timeStamp": "2024-01-01T00:01:00Z", "average": 3.0},
+                {"timeStamp": "2024-01-01T00:00:00Z", "average": 1.0},
+            ],
+            mem_points=[],
+        )
+        result = self._call_with_response(response)
+
+        assert result["timestamps"] == [
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T00:01:00Z",
+            "2024-01-01T00:02:00Z",
+        ]
+
+    def test_request_error_returns_empty(self) -> None:
+        fake_cred = MagicMock()
+        fake_cred.get_token.return_value = MagicMock(token="tok")
+
+        with patch.object(azure_monitor.config, "AZURE_SUBSCRIPTION_ID", "sub-1"), \
+                patch.object(azure_monitor.config, "AZURE_CONTAINER_APPS_RESOURCE_GROUP", "rg-1"), \
+                patch("dashboard.services.azure_monitor.get_azure_credential", return_value=fake_cred), \
+                patch("requests.get", side_effect=RuntimeError("network error")):
+            result = azure_monitor.get_container_app_metric_history("my-app", hours=1)
+
+        assert result == {"name": "my-app", "timestamps": [], "cpu": [], "memory_mb": []}

--- a/dashboard/tests/test_azure_monitor.py
+++ b/dashboard/tests/test_azure_monitor.py
@@ -70,7 +70,7 @@ def _make_metric_response(cpu_points: list[dict], mem_points: list[dict]) -> dic
     }
 
 
-class TestGetContainerAppMetricHistoryInvalidName:
+class TestGetContainerAppMetricHistoryValidation:
     def test_empty_name_returns_empty(self) -> None:
         result = azure_monitor.get_container_app_metric_history("", hours=1)
         assert result == {"name": "", "timestamps": [], "cpu": [], "memory_mb": []}


### PR DESCRIPTION
Clicking a Container App card on the Flows page now expands the card to

show recent CPU% and memory (MiB) history as inline canvas line charts.

A range selector lets the user switch between 1h, 6h, 24h and 7d windows.

Backend:

- azure_monitor.py: new get_container_app_metric_history() that queries

  Azure Monitor for CpuPercentage and WorkingSetBytes time-series with an

  aggregation interval chosen automatically from the window size.

  App name is validated to prevent URL injection.

- app.py: new GET /api/container-app/<name>/history?hours=1|6|24|168

  endpoint returning {name, timestamps, cpu, memory_mb}.

Frontend:

- flows.html: Container App cards become clickable (role=button, keyboard

  accessible) with a hidden expansion panel containing range buttons and

  two canvases.

- app-history.js (new): lazy fetch with per-range in-page cache, raw

  canvas line charts (Retina-aware, gridlines, axis labels) consistent

  with the existing sb-chart.js pattern, debounced resize redraw.

- style.css: hover/open/chevron styling and history panel layout using

  existing DHCW palette variables.