### PR TITLE
Inthub 586056 dashboard idna

### DIFF
--- a/dashboard/uv.lock
+++ b/dashboard/uv.lock
@@ -456,11 +456,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
INTHUB-586056: Bump idna to 3.16 in dashboard to fix https://github.com/advisories/GHSA-65pc-fj4g-8rjx
Upgrades the transitive idna dependency from 3.12 to 3.16 in dashboard/uv.lock to address https://github.com/advisories/GHSA-65pc-fj4g-8rjx, where specially crafted inputs to idna.encode() could bypass the https://github.com/advisories/GHSA-jjg7-2v4v-x38h fix. Fixed in idna 3.15.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>