### PR TITLE
Add pause functionality for alarms in dashboard templates

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -917,8 +917,13 @@ def alarm2_pause(rule_id: str) -> Response:
         duration = int(data.get("duration_minutes", 60))
         if duration < 1:
             raise ValueError("duration_minutes must be >= 1")
-    except (TypeError, ValueError) as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+    except (TypeError, ValueError):
+        logging.getLogger(__name__).warning(
+            "Invalid pause request payload for alarm2 rule_id=%s",
+            rule_id,
+            exc_info=True,
+        )
+        return jsonify({"ok": False, "error": "Invalid duration_minutes value."}), 400
 
     reason = str(data.get("reason", "")).strip()
     pause_alarm2_rule(rule_id, duration, reason)

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -979,7 +979,8 @@ def alarm3_pause(rule_id: str) -> Response:
         if duration < 1:
             raise ValueError("duration_minutes must be >= 1")
     except (TypeError, ValueError) as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        logging.warning("Invalid alarm3 pause payload", exc_info=True)
+        return jsonify({"ok": False, "error": "Invalid request payload."}), 400
 
     reason = str(data.get("reason", "")).strip()
     pause_alarm3_rule(rule_id, duration, reason)

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
 from typing import Any, Callable
@@ -20,12 +20,25 @@ from flask import Flask, Response, jsonify, redirect, render_template, request, 
 from flask_babel import Babel
 
 from dashboard import config
+from dashboard.services.alarm1 import (
+    generate_rule_id as generate_alarm1_rule_id,
+)
+from dashboard.services.alarm1 import (
+    get_alarm_status,
+    get_config_page_data,
+    load_alarm_config,
+    pause_alarm_rule,
+    save_alarm_config,
+    unpause_alarm_rule,
+)
 from dashboard.services.alarm2 import (
     generate_rule_id,
     get_alarm2_config_page_data,
     get_alarm2_status,
     load_alarm2_config,
+    pause_alarm2_rule,
     save_alarm2_config,
+    unpause_alarm2_rule,
 )
 from dashboard.services.alarm3 import (
     generate_rule_id as generate_alarm3_rule_id,
@@ -34,16 +47,9 @@ from dashboard.services.alarm3 import (
     get_alarm3_config_page_data,
     get_alarm3_status,
     load_alarm3_config,
+    pause_alarm3_rule,
     save_alarm3_config,
-)
-from dashboard.services.alarms import (
-    generate_rule_id as generate_alarm1_rule_id,
-)
-from dashboard.services.alarms import (
-    get_alarm_status,
-    get_config_page_data,
-    load_alarm_config,
-    save_alarm_config,
+    unpause_alarm3_rule,
 )
 from dashboard.services.arm import discover_flows, queue_to_microservice_ids
 from dashboard.services.azure_monitor import (
@@ -830,6 +836,188 @@ def alarm_config_page() -> str:
         config_ok=bool(config.AZURE_LOG_ANALYTICS_WORKSPACE_ID),
         smtp_configured=bool(config.ALERT_EMAIL_ENABLED and config.ACS_CONNECTION_STRING and config.ALERT_EMAIL_TO),
     )
+
+
+@app.route("/alarm1/pause/<rule_id>", methods=["POST"])
+def alarm1_pause(rule_id: str) -> Response:
+    """Pause an Alarm 1 rule for a given duration with an optional reason.
+
+    Expects a JSON body: ``{"duration_minutes": int, "reason": str}``.
+    Optimistically updates the in-memory cache so the page reload is instant
+    rather than waiting for a fresh Azure Log Analytics query.
+    """
+    data = request.get_json(silent=True) or {}
+    try:
+        duration = int(data.get("duration_minutes", 60))
+        if duration < 1:
+            raise ValueError("duration_minutes must be >= 1")
+    except (TypeError, ValueError) as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    reason = str(data.get("reason", "")).strip()
+    pause_alarm_rule(rule_id, duration, reason)
+
+    # Optimistically patch the cached row so the page reload is instant.
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    now = datetime.now(timezone.utc)
+    paused_until_dt = now + timedelta(minutes=duration)
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarms", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "paused"
+                    row["pause_remaining"] = float(duration)
+                    row["pause_reason"] = reason
+                    row["paused_until"] = paused_until_dt.strftime("%d %b %Y  %H:%M UTC")
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarms"]["data"] = cached_rows
+            _cache_data["alarms"]["ts"] = time.monotonic()  # mark as fresh
+    return jsonify({"ok": True})
+
+
+@app.route("/alarm1/unpause/<rule_id>", methods=["POST"])
+def alarm1_unpause(rule_id: str) -> Response:
+    """Remove a manual pause from an Alarm 1 rule, restoring normal evaluation.
+
+    Optimistically sets the row to 'unknown' in the cache so the reload is
+    instant, then marks the cache as stale so a background refresh re-evaluates
+    the true alarm status shortly afterwards.
+    """
+    unpause_alarm_rule(rule_id)
+
+    # Optimistically patch the cached row: show 'unknown' instantly,
+    # then let the stale cache trigger a background re-evaluation.
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarms", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "unknown"
+                    row.pop("pause_remaining", None)
+                    row.pop("pause_reason", None)
+                    row.pop("paused_until", None)
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarms"]["data"] = cached_rows
+        # Mark stale — background refresh will resolve the true status shortly.
+        if "alarms" in _cache_data:
+            _cache_data["alarms"]["ts"] = 0.0
+    return jsonify({"ok": True})
+
+
+@app.route("/alarm2/pause/<rule_id>", methods=["POST"])
+def alarm2_pause(rule_id: str) -> Response:
+    """Pause an Alarm 2 rule for a given duration with an optional reason."""
+    data = request.get_json(silent=True) or {}
+    try:
+        duration = int(data.get("duration_minutes", 60))
+        if duration < 1:
+            raise ValueError("duration_minutes must be >= 1")
+    except (TypeError, ValueError) as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    reason = str(data.get("reason", "")).strip()
+    pause_alarm2_rule(rule_id, duration, reason)
+
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    now = datetime.now(timezone.utc)
+    paused_until_dt = now + timedelta(minutes=duration)
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarm2", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "paused"
+                    row["pause_remaining"] = float(duration)
+                    row["pause_reason"] = reason
+                    row["paused_until"] = paused_until_dt.strftime("%d %b %Y  %H:%M UTC")
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarm2"]["data"] = cached_rows
+            _cache_data["alarm2"]["ts"] = time.monotonic()
+    return jsonify({"ok": True})
+
+
+@app.route("/alarm2/unpause/<rule_id>", methods=["POST"])
+def alarm2_unpause(rule_id: str) -> Response:
+    """Remove a manual pause from an Alarm 2 rule, restoring normal evaluation."""
+    unpause_alarm2_rule(rule_id)
+
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarm2", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "unknown"
+                    row.pop("pause_remaining", None)
+                    row.pop("pause_reason", None)
+                    row.pop("paused_until", None)
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarm2"]["data"] = cached_rows
+        if "alarm2" in _cache_data:
+            _cache_data["alarm2"]["ts"] = 0.0
+    return jsonify({"ok": True})
+
+
+@app.route("/alarm3/pause/<rule_id>", methods=["POST"])
+def alarm3_pause(rule_id: str) -> Response:
+    """Pause an Alarm 3 rule for a given duration with an optional reason."""
+    data = request.get_json(silent=True) or {}
+    try:
+        duration = int(data.get("duration_minutes", 60))
+        if duration < 1:
+            raise ValueError("duration_minutes must be >= 1")
+    except (TypeError, ValueError) as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    reason = str(data.get("reason", "")).strip()
+    pause_alarm3_rule(rule_id, duration, reason)
+
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    now = datetime.now(timezone.utc)
+    paused_until_dt = now + timedelta(minutes=duration)
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarm3", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "paused"
+                    row["pause_remaining"] = float(duration)
+                    row["pause_reason"] = reason
+                    row["paused_until"] = paused_until_dt.strftime("%d %b %Y  %H:%M UTC")
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarm3"]["data"] = cached_rows
+            _cache_data["alarm3"]["ts"] = time.monotonic()
+    return jsonify({"ok": True})
+
+
+@app.route("/alarm3/unpause/<rule_id>", methods=["POST"])
+def alarm3_unpause(rule_id: str) -> Response:
+    """Remove a manual pause from an Alarm 3 rule, restoring normal evaluation."""
+    unpause_alarm3_rule(rule_id)
+
+    _PAUSE_ORDER = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
+    with _cache_lock:
+        cached_rows = _cache_data.get("alarm3", {}).get("data")
+        if isinstance(cached_rows, list):
+            for row in cached_rows:
+                if row.get("id") == rule_id:
+                    row["status"] = "unknown"
+                    row.pop("pause_remaining", None)
+                    row.pop("pause_reason", None)
+                    row.pop("paused_until", None)
+                    break
+            cached_rows.sort(key=lambda r: _PAUSE_ORDER.get(r.get("status", ""), 9))
+            _cache_data["alarm3"]["data"] = cached_rows
+        if "alarm3" in _cache_data:
+            _cache_data["alarm3"]["ts"] = 0.0
+    return jsonify({"ok": True})
 
 
 @app.route("/alarms/outgoing-messages")

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -852,7 +852,8 @@ def alarm1_pause(rule_id: str) -> Response:
         if duration < 1:
             raise ValueError("duration_minutes must be >= 1")
     except (TypeError, ValueError) as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        app.logger.warning("Invalid pause request payload: %s", exc)
+        return jsonify({"ok": False, "error": "Invalid duration_minutes value."}), 400
 
     reason = str(data.get("reason", "")).strip()
     pause_alarm_rule(rule_id, duration, reason)

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -321,6 +321,45 @@ def _send_alarm_email(
 
 
 # ---------------------------------------------------------------------------
+# Pause / unpause helpers
+# ---------------------------------------------------------------------------
+
+def pause_alarm_rule(rule_id: str, duration_minutes: int, reason: str = "") -> None:
+    """Pause a specific Alarm 1 rule for ``duration_minutes``.
+
+    Writes ``paused_until`` (ISO timestamp) and ``pause_reason`` into the rule's
+    state entry.  The alarm evaluator will skip the rule and return ``status='paused'``
+    until that time has elapsed.
+    """
+    state = _load_alarm_state()
+    state_rules = state.setdefault("rules", {})
+    now = datetime.now(timezone.utc)
+    paused_until = now + timedelta(minutes=duration_minutes)
+    state_rules.setdefault(rule_id, {}).update({
+        "paused_until": paused_until.isoformat(),
+        "pause_reason": reason.strip(),
+    })
+    _save_alarm_state(state)
+    log.info("Alarm 1 rule %s paused for %d minutes (until %s). Reason: %s",
+             rule_id, duration_minutes, paused_until.isoformat(), reason or "(none)")
+
+
+def unpause_alarm_rule(rule_id: str) -> None:
+    """Remove a manual pause from a specific Alarm 1 rule, restoring normal evaluation."""
+    state = _load_alarm_state()
+    state_rules = state.get("rules", {})
+    rule_state = state_rules.get(rule_id, {})
+    rule_state.pop("paused_until", None)
+    rule_state.pop("pause_reason", None)
+    if rule_state:
+        state_rules[rule_id] = rule_state
+    elif rule_id in state_rules:
+        del state_rules[rule_id]
+    _save_alarm_state(state)
+    log.info("Alarm 1 rule %s unpaused", rule_id)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -365,6 +404,33 @@ def get_alarm_status() -> list[dict]:
         workflow_id = rule_cfg.get("workflow_id", "").strip()
         period_threshold = _applicable_threshold(rule_cfg, now)
         last_msg = last_times.get(workflow_id) if workflow_id else None
+
+        # Check for manual pause before any alarm evaluation.
+        rule_state = state_rules.get(rid, {})
+        paused_until = _parse_dt(rule_state.get("paused_until"))
+        if paused_until and paused_until > now:
+            pause_remaining = (paused_until - now).total_seconds() / 60
+            results.append(_build_row(
+                rid, rule_cfg,
+                last_msg=last_msg,
+                status="paused",
+                minutes_since=(now - last_msg).total_seconds() / 60 if last_msg else None,
+                cooldown_remaining=None,
+                now=now,
+                pause_remaining=pause_remaining,
+                pause_reason=rule_state.get("pause_reason", ""),
+                paused_until=paused_until,
+            ))
+            continue
+        # Clear stale pause state if the pause window has elapsed.
+        if paused_until and paused_until <= now:
+            rule_state.pop("paused_until", None)
+            rule_state.pop("pause_reason", None)
+            if rule_state:
+                state_rules[rid] = rule_state
+            elif rid in state_rules:
+                del state_rules[rid]
+            state_dirty = True
 
         if last_msg is None:
             results.append(_build_row(
@@ -432,7 +498,7 @@ def get_alarm_status() -> list[dict]:
     if state_dirty:
         _save_alarm_state({"rules": state_rules})
 
-    _order = {"critical": 0, "suppressed": 1, "unknown": 2, "healthy": 3}
+    _order = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
     results.sort(key=lambda r: _order.get(r["status"], 9))
     return results
 
@@ -445,6 +511,9 @@ def _build_row(
     minutes_since: float | None,
     cooldown_remaining: float | None,
     now: datetime,
+    pause_remaining: float | None = None,
+    pause_reason: str = "",
+    paused_until: datetime | None = None,
 ) -> dict:
     """Build the status-row dict for a single Alarm 1 rule."""
     period = get_current_period(now)
@@ -468,6 +537,9 @@ def _build_row(
         "minutes_since": round(minutes_since, 1) if minutes_since is not None else None,
         "duration_label": _format_duration(minutes_since) if minutes_since is not None else "No data",
         "cooldown_remaining": round(cooldown_remaining, 0) if cooldown_remaining is not None else None,
+        "pause_remaining": round(pause_remaining, 0) if pause_remaining is not None else None,
+        "pause_reason": pause_reason,
+        "paused_until": paused_until.strftime("%d %b %Y  %H:%M UTC") if paused_until else None,
     }
 
 

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -91,6 +91,45 @@ def _save_alarm2_state(state: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pause / unpause helpers
+# ---------------------------------------------------------------------------
+
+def pause_alarm2_rule(rule_id: str, duration_minutes: int, reason: str = "") -> None:
+    """Pause a specific Alarm 2 rule for ``duration_minutes``.
+
+    Writes ``paused_until`` (ISO timestamp) and ``pause_reason`` into the rule's
+    state entry.  The alarm evaluator will skip the rule and return ``status='paused'``
+    until that time has elapsed.
+    """
+    state = _load_alarm2_state()
+    state_rules = state.setdefault("rules", {})
+    now = datetime.now(timezone.utc)
+    paused_until = now + timedelta(minutes=duration_minutes)
+    state_rules.setdefault(rule_id, {}).update({
+        "paused_until": paused_until.isoformat(),
+        "pause_reason": reason.strip(),
+    })
+    _save_alarm2_state(state)
+    log.info("Alarm 2 rule %s paused for %d minutes (until %s). Reason: %s",
+             rule_id, duration_minutes, paused_until.isoformat(), reason or "(none)")
+
+
+def unpause_alarm2_rule(rule_id: str) -> None:
+    """Remove a manual pause from a specific Alarm 2 rule, restoring normal evaluation."""
+    state = _load_alarm2_state()
+    state_rules = state.get("rules", {})
+    rule_state = state_rules.get(rule_id, {})
+    rule_state.pop("paused_until", None)
+    rule_state.pop("pause_reason", None)
+    if rule_state:
+        state_rules[rule_id] = rule_state
+    elif rule_id in state_rules:
+        del state_rules[rule_id]
+    _save_alarm2_state(state)
+    log.info("Alarm 2 rule %s unpaused", rule_id)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -302,6 +341,27 @@ def get_alarm2_status() -> list[dict]:
         gap        = int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP))
         total      = totals.get(rid)
 
+        # Check for manual pause before any alarm evaluation.
+        rule_state = state_rules.get(rid, {})
+        paused_until = _parse_dt(rule_state.get("paused_until"))
+        if paused_until and paused_until > now:
+            pause_remaining = (paused_until - now).total_seconds() / 60
+            results.append(_build_row(rid, rule, rule_cfg, total=total, status="paused",
+                                      cooldown_remaining=None, now=now,
+                                      pause_remaining=pause_remaining,
+                                      pause_reason=rule_state.get("pause_reason", ""),
+                                      paused_until=paused_until))
+            continue
+        # Clear stale pause state if the pause window has elapsed.
+        if paused_until and paused_until <= now:
+            rule_state.pop("paused_until", None)
+            rule_state.pop("pause_reason", None)
+            if rule_state:
+                state_rules[rid] = rule_state
+            elif rid in state_rules:
+                del state_rules[rid]
+            state_dirty = True
+
         if total is None:
             results.append(_build_row(rid, rule, rule_cfg, total=None, status="unknown",
                                       cooldown_remaining=None, now=now))
@@ -360,7 +420,7 @@ def get_alarm2_status() -> list[dict]:
     if state_dirty:
         _save_alarm2_state({"rules": state_rules})
 
-    _order = {"critical": 0, "suppressed": 1, "unknown": 2, "healthy": 3}
+    _order = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
     results.sort(key=lambda r: _order.get(r["status"], 9))
     return results
 
@@ -373,6 +433,9 @@ def _build_row(
     status: str,
     cooldown_remaining: float | None,
     now: datetime,
+    pause_remaining: float | None = None,
+    pause_reason: str = "",
+    paused_until: datetime | None = None,
 ) -> dict:
     """Build the status-row dict for a single Alarm 2 rule."""
     window = int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES))
@@ -388,6 +451,9 @@ def _build_row(
         "messages_display":        _format_count(total),
         "status":                  status,
         "cooldown_remaining":      round(cooldown_remaining, 0) if cooldown_remaining is not None else None,
+        "pause_remaining":         round(pause_remaining, 0) if pause_remaining is not None else None,
+        "pause_reason":            pause_reason,
+        "paused_until":            paused_until.strftime("%d %b %Y  %H:%M UTC") if paused_until else None,
     }
 
 

--- a/dashboard/dashboard/services/alarm3.py
+++ b/dashboard/dashboard/services/alarm3.py
@@ -90,6 +90,45 @@ def _save_alarm3_state(state: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pause / unpause helpers
+# ---------------------------------------------------------------------------
+
+def pause_alarm3_rule(rule_id: str, duration_minutes: int, reason: str = "") -> None:
+    """Pause a specific Alarm 3 rule for ``duration_minutes``.
+
+    Writes ``paused_until`` (ISO timestamp) and ``pause_reason`` into the rule's
+    state entry.  The alarm evaluator will skip the rule and return ``status='paused'``
+    until that time has elapsed.
+    """
+    state = _load_alarm3_state()
+    state_rules = state.setdefault("rules", {})
+    now = datetime.now(timezone.utc)
+    paused_until = now + timedelta(minutes=duration_minutes)
+    state_rules.setdefault(rule_id, {}).update({
+        "paused_until": paused_until.isoformat(),
+        "pause_reason": reason.strip(),
+    })
+    _save_alarm3_state(state)
+    log.info("Alarm 3 rule %s paused for %d minutes (until %s). Reason: %s",
+             rule_id, duration_minutes, paused_until.isoformat(), reason or "(none)")
+
+
+def unpause_alarm3_rule(rule_id: str) -> None:
+    """Remove a manual pause from a specific Alarm 3 rule, restoring normal evaluation."""
+    state = _load_alarm3_state()
+    state_rules = state.get("rules", {})
+    rule_state = state_rules.get(rule_id, {})
+    rule_state.pop("paused_until", None)
+    rule_state.pop("pause_reason", None)
+    if rule_state:
+        state_rules[rule_id] = rule_state
+    elif rule_id in state_rules:
+        del state_rules[rule_id]
+    _save_alarm3_state(state)
+    log.info("Alarm 3 rule %s unpaused", rule_id)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -306,6 +345,27 @@ def get_alarm3_status() -> list[dict]:
         gap       = int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP))
         count     = counts.get(rid)
 
+        # Check for manual pause before any alarm evaluation.
+        rule_state = state_rules.get(rid, {})
+        paused_until = _parse_dt(rule_state.get("paused_until"))
+        if paused_until and paused_until > now:
+            pause_remaining = (paused_until - now).total_seconds() / 60
+            results.append(_build_row(rid, rule, rule_cfg, count=count, status="paused",
+                                      cooldown_remaining=None, now=now,
+                                      pause_remaining=pause_remaining,
+                                      pause_reason=rule_state.get("pause_reason", ""),
+                                      paused_until=paused_until))
+            continue
+        # Clear stale pause state if the pause window has elapsed.
+        if paused_until and paused_until <= now:
+            rule_state.pop("paused_until", None)
+            rule_state.pop("pause_reason", None)
+            if rule_state:
+                state_rules[rid] = rule_state
+            elif rid in state_rules:
+                del state_rules[rid]
+            state_dirty = True
+
         if count is None:
             results.append(_build_row(rid, rule, rule_cfg, count=None, status="unknown",
                                       cooldown_remaining=None, now=now))
@@ -364,7 +424,7 @@ def get_alarm3_status() -> list[dict]:
     if state_dirty:
         _save_alarm3_state({"rules": state_rules})
 
-    _order = {"critical": 0, "suppressed": 1, "unknown": 2, "healthy": 3}
+    _order = {"paused": 0, "critical": 1, "suppressed": 2, "unknown": 3, "healthy": 4}
     results.sort(key=lambda r: _order.get(r["status"], 9))
     return results
 
@@ -377,6 +437,9 @@ def _build_row(
     status: str,
     cooldown_remaining: float | None,
     now: datetime,
+    pause_remaining: float | None = None,
+    pause_reason: str = "",
+    paused_until: datetime | None = None,
 ) -> dict:
     """Build the status-row dict for a single Alarm 3 rule."""
     window = int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES))
@@ -392,6 +455,9 @@ def _build_row(
         "failure_display":         f"{count:,}" if count is not None else "—",
         "status":                  status,
         "cooldown_remaining":      round(cooldown_remaining, 0) if cooldown_remaining is not None else None,
+        "pause_remaining":         round(pause_remaining, 0) if pause_remaining is not None else None,
+        "pause_reason":            pause_reason,
+        "paused_until":            paused_until.strftime("%d %b %Y  %H:%M UTC") if paused_until else None,
     }
 
 

--- a/dashboard/dashboard/templates/alarm.html
+++ b/dashboard/dashboard/templates/alarm.html
@@ -65,6 +65,7 @@
   <!-- KPI strip -->
   {% set n_critical   = alarm_rows | selectattr('status', 'equalto', 'critical')   | list | length %}
   {% set n_suppressed = alarm_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
+  {% set n_paused     = alarm_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
   {% set n_unknown    = alarm_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
   {% set n_healthy    = alarm_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
   {% set current_period = alarm_rows[0].current_period if alarm_rows else 'day' %}
@@ -91,6 +92,13 @@
       <div class="kpi-body">
         <div class="kpi-number">{{ n_suppressed }}</div>
         <div class="kpi-label">{{ _("Suppressed") }}</div>
+      </div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-icon blue"><i class="bi bi-pause-circle-fill"></i></div>
+      <div class="kpi-body">
+        <div class="kpi-number">{{ n_paused }}</div>
+        <div class="kpi-label">{{ _("Paused") }}</div>
       </div>
     </div>
     <div class="kpi-card">
@@ -177,6 +185,10 @@
                 <span class="status-badge suppressed">
                   <i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
                 </span>
+              {% elif row.status == 'paused' %}
+                <span class="status-badge paused" {% if row.pause_reason %}title="{{ row.pause_reason }}"{% endif %}>
+                  <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
+                </span>
               {% elif row.status == 'unknown' %}
                 <span class="status-badge unknown">
                   <i class="bi bi-question-circle me-1"></i>{{ _("Unknown") }}
@@ -248,15 +260,42 @@
                   <i class="bi bi-hourglass-split me-1"></i>{{ row.cooldown_remaining | int }} {{ _("min left") }}
                 </div>
               {% endif %}
+              {% if row.status == 'paused' and row.pause_remaining %}
+                <div style="color:var(--accent-cyan); font-size:0.75rem; margin-top:2px;">
+                  <i class="bi bi-pause-circle me-1"></i>{{ row.pause_remaining | int }} {{ _("min left") }}
+                </div>
+              {% endif %}
             </td>
 
-            <td style="text-align:center;">
+            <td style="text-align:center; white-space:nowrap;">
+              <!-- Gear icon → config -->
               <a href="{{ url_for('alarm_config_page') }}#rule-{{ row.id }}"
                  title="Go to config for {{ row.display_name }}"
                  class="btn-dash"
                  style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
                 <i class="bi bi-gear-fill"></i>
               </a>
+              {% if row.status == 'paused' %}
+              <!-- Resume button -->
+              <button type="button"
+                      class="btn-dash btn-resume ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Resume alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem; color:var(--accent-green); border-color:rgba(74,222,128,0.35);">
+                <i class="bi bi-play-fill"></i>
+              </button>
+              {% else %}
+              <!-- Pause button -->
+              <button type="button"
+                      class="btn-dash btn-pause ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Pause alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
+                <i class="bi bi-pause-fill"></i>
+              </button>
+              {% endif %}
             </td>
 
           </tr>
@@ -306,12 +345,207 @@
     border-left: 3px solid var(--border-color);
   }
 
-  /* Suppressed badge — amber, reusing status-badge base styles */
-  .status-badge.suppressed {
-    background: rgba(245,158,11,0.12);
-    color: var(--accent-amber);
-    border-color: rgba(245,158,11,0.35);
+  /* Paused badge — cyan teal */
+  .status-badge.paused {
+    background: rgba(18,163,201,0.12);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.35);
   }
+
+  /* Duration pill selected state */
+  .duration-opt--selected {
+    background: rgba(18,163,201,0.15);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.5);
+  }
+
+  /* Darker modal backdrop */
+  .modal-backdrop { opacity: 0.75 !important; }
 </style>
+
+<!-- ── Pause Modal ─────────────────────────────────────────────────────── -->
+<div class="modal fade" id="pauseModal" tabindex="-1" aria-labelledby="pauseModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="background:var(--card-bg-solid, #1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); box-shadow:0 16px 60px rgba(0,0,0,0.75);">
+      <div class="modal-header" style="border-bottom:1px solid var(--border-color);">
+        <h5 class="modal-title" id="pauseModalLabel">
+          <i class="bi bi-pause-circle-fill me-2" style="color:var(--accent-cyan)"></i>
+          {{ _("Pause Alarm") }}
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+      </div>
+      <div class="modal-body">
+        <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:1rem;">
+          {{ _("Temporarily silence") }} <strong id="pauseRuleName"></strong>.
+          {{ _("The alarm will automatically resume when the pause window expires.") }}
+        </p>
+
+        <label class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Pause Duration") }}
+        </label>
+        <div class="d-flex flex-wrap gap-2 mb-3" id="durationPicker">
+          {% for label, mins in [("30 min", 30), ("1 hour", 60), ("2 hours", 120), ("4 hours", 240), ("8 hours", 480), ("24 hours", 1440)] %}
+          <button type="button"
+                  class="btn-dash duration-opt {% if mins == 60 %}duration-opt--selected{% endif %}"
+                  data-minutes="{{ mins }}"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _(label) }}
+          </button>
+          {% endfor %}
+          <button type="button"
+                  class="btn-dash duration-opt"
+                  data-minutes="custom"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _("Custom…") }}
+          </button>
+        </div>
+
+        <!-- Custom duration row (hidden by default) -->
+        <div id="customDurationRow" class="d-flex align-items-center gap-2 mb-3" style="display:none !important;">
+          <input type="number" id="customDurationValue" min="1" max="9999" value="90"
+                 class="form-control"
+                 style="width:90px; background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+          <select id="customDurationUnit"
+                  class="form-select"
+                  style="width:110px; background:var(--card-bg-solid,#1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+            <option value="1">{{ _("minutes") }}</option>
+            <option value="60" selected>{{ _("hours") }}</option>
+          </select>
+          <span style="font-size:0.78rem; color:var(--text-muted);">= <span id="customDurationPreview">90 hours</span></span>
+        </div>
+
+        <label for="pauseReasonInput" class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Reason") }} <span style="font-weight:400; text-transform:none;">({{ _("optional") }})</span>
+        </label>
+        <textarea id="pauseReasonInput"
+                  class="form-control"
+                  rows="2"
+                  maxlength="200"
+                  placeholder="{{ _('e.g. Planned maintenance, known issue…') }}"
+                  style="background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem; resize:none;"></textarea>
+        <div id="pauseError" class="mt-2" style="color:var(--accent-red); font-size:0.8rem; display:none;"></div>
+      </div>
+      <div class="modal-footer" style="border-top:1px solid var(--border-color);">
+        <button type="button" class="btn-dash" data-bs-dismiss="modal">{{ _("Cancel") }}</button>
+        <button type="button" class="btn-dash" id="pauseConfirmBtn"
+                style="color:var(--accent-cyan); border-color:rgba(18,163,201,0.45);">
+          <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Confirm Pause") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  let activeRuleId = null;
+  let selectedMinutes = 60;
+  let isCustom = false;
+
+  const customRow    = document.getElementById('customDurationRow');
+  const customVal    = document.getElementById('customDurationValue');
+  const customUnit   = document.getElementById('customDurationUnit');
+  const customPreview = document.getElementById('customDurationPreview');
+
+  function updateCustomPreview() {
+    const v = parseInt(customVal.value, 10) || 1;
+    const u = parseInt(customUnit.value, 10);
+    const totalMins = v * u;
+    customPreview.textContent = totalMins === 1 ? '1 minute' :
+      totalMins < 60 ? totalMins + ' minutes' :
+      totalMins % 60 === 0 ? (totalMins / 60) + (totalMins / 60 === 1 ? ' hour' : ' hours') :
+      (totalMins / 60).toFixed(1) + ' hours';
+    selectedMinutes = totalMins;
+  }
+
+  customVal.addEventListener('input', updateCustomPreview);
+  customUnit.addEventListener('change', updateCustomPreview);
+  updateCustomPreview();
+
+  /* ── Duration pill selection ── */
+  document.getElementById('durationPicker').addEventListener('click', function (e) {
+    const btn = e.target.closest('.duration-opt');
+    if (!btn) return;
+    document.querySelectorAll('.duration-opt').forEach(b => b.classList.remove('duration-opt--selected'));
+    btn.classList.add('duration-opt--selected');
+
+    if (btn.dataset.minutes === 'custom') {
+      isCustom = true;
+      customRow.style.setProperty('display', 'flex', 'important');
+      updateCustomPreview();
+    } else {
+      isCustom = false;
+      customRow.style.setProperty('display', 'none', 'important');
+      selectedMinutes = parseInt(btn.dataset.minutes, 10);
+    }
+  });
+
+  /* ── Open modal for Pause ── */
+  document.querySelectorAll('.btn-pause').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      activeRuleId = btn.dataset.ruleId;
+      document.getElementById('pauseRuleName').textContent = btn.dataset.ruleName;
+      document.getElementById('pauseReasonInput').value = '';
+      document.getElementById('pauseError').style.display = 'none';
+      // Reset to 1-hour default
+      document.querySelectorAll('.duration-opt').forEach(b => {
+        b.classList.toggle('duration-opt--selected', b.dataset.minutes === '60');
+      });
+      isCustom = false;
+      selectedMinutes = 60;
+      customRow.style.setProperty('display', 'none', 'important');
+      new bootstrap.Modal(document.getElementById('pauseModal')).show();
+    });
+  });
+
+  /* ── Confirm pause ── */
+  document.getElementById('pauseConfirmBtn').addEventListener('click', function () {
+    if (!activeRuleId) return;
+    if (isCustom) { updateCustomPreview(); }
+    const reason = document.getElementById('pauseReasonInput').value.trim();
+    const errEl  = document.getElementById('pauseError');
+    errEl.style.display = 'none';
+
+    if (!selectedMinutes || selectedMinutes < 1) {
+      errEl.textContent = '{{ _("Please select a valid duration.") }}';
+      errEl.style.display = 'block';
+      return;
+    }
+
+    fetch('/alarm1/pause/' + encodeURIComponent(activeRuleId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ duration_minutes: selectedMinutes, reason: reason }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        bootstrap.Modal.getInstance(document.getElementById('pauseModal')).hide();
+        window.location.reload();
+      } else {
+        errEl.textContent = data.error || '{{ _("An error occurred. Please try again.") }}';
+        errEl.style.display = 'block';
+      }
+    })
+    .catch(function () {
+      errEl.textContent = '{{ _("Network error. Please try again.") }}';
+      errEl.style.display = 'block';
+    });
+  });
+
+  /* ── Resume (unpause) ── */
+  document.querySelectorAll('.btn-resume').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      fetch('/alarm1/unpause/' + encodeURIComponent(btn.dataset.ruleId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .then(function () { window.location.reload(); });
+    });
+  });
+}());
+</script>
 
 {% endblock %}

--- a/dashboard/dashboard/templates/alarm.html
+++ b/dashboard/dashboard/templates/alarm.html
@@ -525,7 +525,7 @@
         bootstrap.Modal.getInstance(document.getElementById('pauseModal')).hide();
         window.location.reload();
       } else {
-        errEl.textContent = data.error || '{{ _("An error occurred. Please try again.") }}';
+        errEl.textContent = data.error || {{ _("An error occurred. Please try again.") | tojson }};
         errEl.style.display = 'block';
       }
     })

--- a/dashboard/dashboard/templates/alarm.html
+++ b/dashboard/dashboard/templates/alarm.html
@@ -530,7 +530,7 @@
       }
     })
     .catch(function () {
-      errEl.textContent = '{{ _("Network error. Please try again.") }}';
+      errEl.textContent = {{ _("Network error. Please try again.") | tojson }};
       errEl.style.display = 'block';
     });
   });

--- a/dashboard/dashboard/templates/alarm.html
+++ b/dashboard/dashboard/templates/alarm.html
@@ -509,7 +509,7 @@
     errEl.style.display = 'none';
 
     if (!selectedMinutes || selectedMinutes < 1) {
-      errEl.textContent = '{{ _("Please select a valid duration.") }}';
+      errEl.textContent = {{ _("Please select a valid duration.") | tojson }};
       errEl.style.display = 'block';
       return;
     }

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -470,7 +470,7 @@
         bootstrap.Modal.getInstance(document.getElementById('pauseModal')).hide();
         window.location.reload();
       } else {
-        errEl.textContent = data.error || '{{ _("An error occurred. Please try again.") }}';
+        errEl.textContent = data.error || {{ _("An error occurred. Please try again.") | tojson }};
         errEl.style.display = 'block';
       }
     })

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -65,6 +65,7 @@
   <!-- KPI strip -->
   {% set n_critical   = alarm2_rows | selectattr('status', 'equalto', 'critical')   | list | length %}
   {% set n_suppressed = alarm2_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
+  {% set n_paused     = alarm2_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
   {% set n_unknown    = alarm2_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
   {% set n_healthy    = alarm2_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
 
@@ -90,6 +91,13 @@
       <div class="kpi-body">
         <div class="kpi-number">{{ n_suppressed }}</div>
         <div class="kpi-label">{{ _("Suppressed") }}</div>
+      </div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-icon blue"><i class="bi bi-pause-circle-fill"></i></div>
+      <div class="kpi-body">
+        <div class="kpi-number">{{ n_paused }}</div>
+        <div class="kpi-label">{{ _("Paused") }}</div>
       </div>
     </div>
     <div class="kpi-card">
@@ -142,7 +150,7 @@
         </thead>
         <tbody>
           {% for row in alarm2_rows %}
-          <tr class="{% if row.status == 'critical' %}alarm-row--critical{% elif row.status == 'suppressed' %}alarm-row--suppressed{% elif row.status == 'unknown' %}alarm-row--unknown{% endif %}">
+          <tr class="{% if row.status == 'critical' %}alarm-row--critical{% elif row.status == 'suppressed' %}alarm-row--suppressed{% elif row.status == 'paused' %}alarm-row--paused{% elif row.status == 'unknown' %}alarm-row--unknown{% endif %}">
 
             <td>
               {% if row.status == 'critical' %}
@@ -152,6 +160,10 @@
               {% elif row.status == 'suppressed' %}
                 <span class="status-badge suppressed">
                   <i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
+                </span>
+              {% elif row.status == 'paused' %}
+                <span class="status-badge paused" {% if row.pause_reason %}title="{{ row.pause_reason }}"{% endif %}>
+                  <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
                 </span>
               {% elif row.status == 'unknown' %}
                 <span class="status-badge unknown">
@@ -196,15 +208,39 @@
                   <i class="bi bi-hourglass-split me-1"></i>{{ row.cooldown_remaining | int }} {{ _("min left") }}
                 </div>
               {% endif %}
+              {% if row.status == 'paused' and row.pause_remaining %}
+                <div style="color:var(--accent-cyan); font-size:0.75rem; margin-top:2px;">
+                  <i class="bi bi-pause-circle me-1"></i>{{ row.pause_remaining | int }} {{ _("min left") }}
+                </div>
+              {% endif %}
             </td>
 
-            <td style="text-align:center;">
+            <td style="text-align:center; white-space:nowrap;">
               <a href="{{ url_for('alarm2_config_page') }}#rule-{{ row.id }}"
                  title="Go to config for {{ row.display_name }}"
                  class="btn-dash"
                  style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
                 <i class="bi bi-gear-fill"></i>
               </a>
+              {% if row.status == 'paused' %}
+              <button type="button"
+                      class="btn-dash btn-resume ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Resume alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem; color:var(--accent-green); border-color:rgba(74,222,128,0.35);">
+                <i class="bi bi-play-fill"></i>
+              </button>
+              {% else %}
+              <button type="button"
+                      class="btn-dash btn-pause ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Pause alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
+                <i class="bi bi-pause-fill"></i>
+              </button>
+              {% endif %}
             </td>
 
           </tr>
@@ -259,6 +295,201 @@
     color: var(--accent-amber);
     border-color: rgba(245,158,11,0.35);
   }
+
+  .status-badge.paused {
+    background: rgba(18,163,201,0.12);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.35);
+  }
+
+  .alarm-row--paused {
+    background: rgba(18,163,201,0.04);
+    border-left: 3px solid var(--accent-cyan);
+  }
+
+  .duration-opt--selected {
+    background: rgba(18,163,201,0.15);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.5);
+  }
+
+  .modal-backdrop { opacity: 0.75 !important; }
 </style>
+
+<!-- ── Pause Modal ─────────────────────────────────────────────────────── -->
+<div class="modal fade" id="pauseModal" tabindex="-1" aria-labelledby="pauseModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="background:var(--card-bg-solid, #1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); box-shadow:0 16px 60px rgba(0,0,0,0.75);">
+      <div class="modal-header" style="border-bottom:1px solid var(--border-color);">
+        <h5 class="modal-title" id="pauseModalLabel">
+          <i class="bi bi-pause-circle-fill me-2" style="color:var(--accent-cyan)"></i>
+          {{ _("Pause Alarm") }}
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+      </div>
+      <div class="modal-body">
+        <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:1rem;">
+          {{ _("Temporarily silence") }} <strong id="pauseRuleName"></strong>.
+          {{ _("The alarm will automatically resume when the pause window expires.") }}
+        </p>
+
+        <label class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Pause Duration") }}
+        </label>
+        <div class="d-flex flex-wrap gap-2 mb-3" id="durationPicker">
+          {% for label, mins in [("30 min", 30), ("1 hour", 60), ("2 hours", 120), ("4 hours", 240), ("8 hours", 480), ("24 hours", 1440)] %}
+          <button type="button"
+                  class="btn-dash duration-opt {% if mins == 60 %}duration-opt--selected{% endif %}"
+                  data-minutes="{{ mins }}"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _(label) }}
+          </button>
+          {% endfor %}
+          <button type="button"
+                  class="btn-dash duration-opt"
+                  data-minutes="custom"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _("Custom…") }}
+          </button>
+        </div>
+
+        <div id="customDurationRow" class="d-flex align-items-center gap-2 mb-3" style="display:none !important;">
+          <input type="number" id="customDurationValue" min="1" max="9999" value="90"
+                 class="form-control"
+                 style="width:90px; background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+          <select id="customDurationUnit"
+                  class="form-select"
+                  style="width:110px; background:var(--card-bg-solid,#1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+            <option value="1">{{ _("minutes") }}</option>
+            <option value="60" selected>{{ _("hours") }}</option>
+          </select>
+          <span style="font-size:0.78rem; color:var(--text-muted);">= <span id="customDurationPreview">90 hours</span></span>
+        </div>
+
+        <label for="pauseReasonInput" class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Reason") }} <span style="font-weight:400; text-transform:none;">({{ _("optional") }})</span>
+        </label>
+        <textarea id="pauseReasonInput"
+                  class="form-control"
+                  rows="2"
+                  maxlength="200"
+                  placeholder="{{ _('e.g. Planned maintenance, known issue…') }}"
+                  style="background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem; resize:none;"></textarea>
+        <div id="pauseError" class="mt-2" style="color:var(--accent-red); font-size:0.8rem; display:none;"></div>
+      </div>
+      <div class="modal-footer" style="border-top:1px solid var(--border-color);">
+        <button type="button" class="btn-dash" data-bs-dismiss="modal">{{ _("Cancel") }}</button>
+        <button type="button" class="btn-dash" id="pauseConfirmBtn"
+                style="color:var(--accent-cyan); border-color:rgba(18,163,201,0.45);">
+          <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Confirm Pause") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  let activeRuleId = null;
+  let selectedMinutes = 60;
+  let isCustom = false;
+
+  const customRow     = document.getElementById('customDurationRow');
+  const customVal     = document.getElementById('customDurationValue');
+  const customUnit    = document.getElementById('customDurationUnit');
+  const customPreview = document.getElementById('customDurationPreview');
+
+  function updateCustomPreview() {
+    const v = parseInt(customVal.value, 10) || 1;
+    const u = parseInt(customUnit.value, 10);
+    const totalMins = v * u;
+    customPreview.textContent = totalMins === 1 ? '1 minute' :
+      totalMins < 60 ? totalMins + ' minutes' :
+      totalMins % 60 === 0 ? (totalMins / 60) + (totalMins / 60 === 1 ? ' hour' : ' hours') :
+      (totalMins / 60).toFixed(1) + ' hours';
+    selectedMinutes = totalMins;
+  }
+
+  customVal.addEventListener('input', updateCustomPreview);
+  customUnit.addEventListener('change', updateCustomPreview);
+  updateCustomPreview();
+
+  document.getElementById('durationPicker').addEventListener('click', function (e) {
+    const btn = e.target.closest('.duration-opt');
+    if (!btn) return;
+    document.querySelectorAll('.duration-opt').forEach(b => b.classList.remove('duration-opt--selected'));
+    btn.classList.add('duration-opt--selected');
+    if (btn.dataset.minutes === 'custom') {
+      isCustom = true;
+      customRow.style.setProperty('display', 'flex', 'important');
+      updateCustomPreview();
+    } else {
+      isCustom = false;
+      customRow.style.setProperty('display', 'none', 'important');
+      selectedMinutes = parseInt(btn.dataset.minutes, 10);
+    }
+  });
+
+  document.querySelectorAll('.btn-pause').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      activeRuleId = btn.dataset.ruleId;
+      document.getElementById('pauseRuleName').textContent = btn.dataset.ruleName;
+      document.getElementById('pauseReasonInput').value = '';
+      document.getElementById('pauseError').style.display = 'none';
+      document.querySelectorAll('.duration-opt').forEach(b => {
+        b.classList.toggle('duration-opt--selected', b.dataset.minutes === '60');
+      });
+      isCustom = false;
+      selectedMinutes = 60;
+      customRow.style.setProperty('display', 'none', 'important');
+      new bootstrap.Modal(document.getElementById('pauseModal')).show();
+    });
+  });
+
+  document.getElementById('pauseConfirmBtn').addEventListener('click', function () {
+    if (!activeRuleId) return;
+    if (isCustom) { updateCustomPreview(); }
+    const reason = document.getElementById('pauseReasonInput').value.trim();
+    const errEl  = document.getElementById('pauseError');
+    errEl.style.display = 'none';
+    if (!selectedMinutes || selectedMinutes < 1) {
+      errEl.textContent = '{{ _("Please select a valid duration.") }}';
+      errEl.style.display = 'block';
+      return;
+    }
+    fetch('/alarm2/pause/' + encodeURIComponent(activeRuleId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ duration_minutes: selectedMinutes, reason: reason }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        bootstrap.Modal.getInstance(document.getElementById('pauseModal')).hide();
+        window.location.reload();
+      } else {
+        errEl.textContent = data.error || '{{ _("An error occurred. Please try again.") }}';
+        errEl.style.display = 'block';
+      }
+    })
+    .catch(function () {
+      errEl.textContent = '{{ _("Network error. Please try again.") }}';
+      errEl.style.display = 'block';
+    });
+  });
+
+  document.querySelectorAll('.btn-resume').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      fetch('/alarm2/unpause/' + encodeURIComponent(btn.dataset.ruleId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .then(function () { window.location.reload(); });
+    });
+  });
+}());
+</script>
 
 {% endblock %}

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -455,7 +455,7 @@
     const errEl  = document.getElementById('pauseError');
     errEl.style.display = 'none';
     if (!selectedMinutes || selectedMinutes < 1) {
-      errEl.textContent = '{{ _("Please select a valid duration.") }}';
+      errEl.textContent = {{ _("Please select a valid duration.") | tojson }};
       errEl.style.display = 'block';
       return;
     }

--- a/dashboard/dashboard/templates/alarm3.html
+++ b/dashboard/dashboard/templates/alarm3.html
@@ -65,6 +65,7 @@
   <!-- KPI strip -->
   {% set n_critical   = alarm3_rows | selectattr('status', 'equalto', 'critical')   | list | length %}
   {% set n_suppressed = alarm3_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
+  {% set n_paused     = alarm3_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
   {% set n_unknown    = alarm3_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
   {% set n_healthy    = alarm3_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
 
@@ -90,6 +91,13 @@
       <div class="kpi-body">
         <div class="kpi-number">{{ n_suppressed }}</div>
         <div class="kpi-label">{{ _("Suppressed") }}</div>
+      </div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-icon blue"><i class="bi bi-pause-circle-fill"></i></div>
+      <div class="kpi-body">
+        <div class="kpi-number">{{ n_paused }}</div>
+        <div class="kpi-label">{{ _("Paused") }}</div>
       </div>
     </div>
     <div class="kpi-card">
@@ -142,7 +150,7 @@
         </thead>
         <tbody>
           {% for row in alarm3_rows %}
-          <tr class="{% if row.status == 'critical' %}alarm-row--critical{% elif row.status == 'suppressed' %}alarm-row--suppressed{% elif row.status == 'unknown' %}alarm-row--unknown{% endif %}">
+          <tr class="{% if row.status == 'critical' %}alarm-row--critical{% elif row.status == 'suppressed' %}alarm-row--suppressed{% elif row.status == 'paused' %}alarm-row--paused{% elif row.status == 'unknown' %}alarm-row--unknown{% endif %}">
 
             <td>
               {% if row.status == 'critical' %}
@@ -152,6 +160,10 @@
               {% elif row.status == 'suppressed' %}
                 <span class="status-badge suppressed">
                   <i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
+                </span>
+              {% elif row.status == 'paused' %}
+                <span class="status-badge paused" {% if row.pause_reason %}title="{{ row.pause_reason }}"{% endif %}>
+                  <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
                 </span>
               {% elif row.status == 'unknown' %}
                 <span class="status-badge unknown">
@@ -196,15 +208,39 @@
                   <i class="bi bi-hourglass-split me-1"></i>{{ row.cooldown_remaining | int }} {{ _("min left") }}
                 </div>
               {% endif %}
+              {% if row.status == 'paused' and row.pause_remaining %}
+                <div style="color:var(--accent-cyan); font-size:0.75rem; margin-top:2px;">
+                  <i class="bi bi-pause-circle me-1"></i>{{ row.pause_remaining | int }} {{ _("min left") }}
+                </div>
+              {% endif %}
             </td>
 
-            <td style="text-align:center;">
+            <td style="text-align:center; white-space:nowrap;">
               <a href="{{ url_for('alarm3_config_page') }}#rule-{{ row.id }}"
                  title="Go to config for {{ row.display_name }}"
                  class="btn-dash"
                  style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
                 <i class="bi bi-gear-fill"></i>
               </a>
+              {% if row.status == 'paused' %}
+              <button type="button"
+                      class="btn-dash btn-resume ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Resume alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem; color:var(--accent-green); border-color:rgba(74,222,128,0.35);">
+                <i class="bi bi-play-fill"></i>
+              </button>
+              {% else %}
+              <button type="button"
+                      class="btn-dash btn-pause ms-1"
+                      data-rule-id="{{ row.id }}"
+                      data-rule-name="{{ row.display_name }}"
+                      title="Pause alarm for {{ row.display_name }}"
+                      style="padding:0.2rem 0.5rem; font-size:0.75rem; display:inline-flex; align-items:center; gap:0.25rem;">
+                <i class="bi bi-pause-fill"></i>
+              </button>
+              {% endif %}
             </td>
 
           </tr>
@@ -259,6 +295,201 @@
     color: var(--accent-amber);
     border-color: rgba(245,158,11,0.35);
   }
+
+  .status-badge.paused {
+    background: rgba(18,163,201,0.12);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.35);
+  }
+
+  .alarm-row--paused {
+    background: rgba(18,163,201,0.04);
+    border-left: 3px solid var(--accent-cyan);
+  }
+
+  .duration-opt--selected {
+    background: rgba(18,163,201,0.15);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.5);
+  }
+
+  .modal-backdrop { opacity: 0.75 !important; }
 </style>
+
+<!-- ── Pause Modal ─────────────────────────────────────────────────────── -->
+<div class="modal fade" id="pauseModal" tabindex="-1" aria-labelledby="pauseModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="background:var(--card-bg-solid, #1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); box-shadow:0 16px 60px rgba(0,0,0,0.75);">
+      <div class="modal-header" style="border-bottom:1px solid var(--border-color);">
+        <h5 class="modal-title" id="pauseModalLabel">
+          <i class="bi bi-pause-circle-fill me-2" style="color:var(--accent-cyan)"></i>
+          {{ _("Pause Alarm") }}
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+      </div>
+      <div class="modal-body">
+        <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:1rem;">
+          {{ _("Temporarily silence") }} <strong id="pauseRuleName"></strong>.
+          {{ _("The alarm will automatically resume when the pause window expires.") }}
+        </p>
+
+        <label class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Pause Duration") }}
+        </label>
+        <div class="d-flex flex-wrap gap-2 mb-3" id="durationPicker">
+          {% for label, mins in [("30 min", 30), ("1 hour", 60), ("2 hours", 120), ("4 hours", 240), ("8 hours", 480), ("24 hours", 1440)] %}
+          <button type="button"
+                  class="btn-dash duration-opt {% if mins == 60 %}duration-opt--selected{% endif %}"
+                  data-minutes="{{ mins }}"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _(label) }}
+          </button>
+          {% endfor %}
+          <button type="button"
+                  class="btn-dash duration-opt"
+                  data-minutes="custom"
+                  style="font-size:0.78rem; padding:0.3rem 0.7rem;">
+            {{ _("Custom…") }}
+          </button>
+        </div>
+
+        <div id="customDurationRow" class="d-flex align-items-center gap-2 mb-3" style="display:none !important;">
+          <input type="number" id="customDurationValue" min="1" max="9999" value="90"
+                 class="form-control"
+                 style="width:90px; background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+          <select id="customDurationUnit"
+                  class="form-select"
+                  style="width:110px; background:var(--card-bg-solid,#1b2a3b); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem;">
+            <option value="1">{{ _("minutes") }}</option>
+            <option value="60" selected>{{ _("hours") }}</option>
+          </select>
+          <span style="font-size:0.78rem; color:var(--text-muted);">= <span id="customDurationPreview">90 hours</span></span>
+        </div>
+
+        <label for="pauseReasonInput" class="form-label" style="font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted);">
+          {{ _("Reason") }} <span style="font-weight:400; text-transform:none;">({{ _("optional") }})</span>
+        </label>
+        <textarea id="pauseReasonInput"
+                  class="form-control"
+                  rows="2"
+                  maxlength="200"
+                  placeholder="{{ _('e.g. Planned maintenance, known issue…') }}"
+                  style="background:var(--input-bg,rgba(255,255,255,0.05)); border:1px solid var(--border-color); color:var(--text-primary); font-size:0.85rem; resize:none;"></textarea>
+        <div id="pauseError" class="mt-2" style="color:var(--accent-red); font-size:0.8rem; display:none;"></div>
+      </div>
+      <div class="modal-footer" style="border-top:1px solid var(--border-color);">
+        <button type="button" class="btn-dash" data-bs-dismiss="modal">{{ _("Cancel") }}</button>
+        <button type="button" class="btn-dash" id="pauseConfirmBtn"
+                style="color:var(--accent-cyan); border-color:rgba(18,163,201,0.45);">
+          <i class="bi bi-pause-circle-fill me-1"></i>{{ _("Confirm Pause") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  let activeRuleId = null;
+  let selectedMinutes = 60;
+  let isCustom = false;
+
+  const customRow     = document.getElementById('customDurationRow');
+  const customVal     = document.getElementById('customDurationValue');
+  const customUnit    = document.getElementById('customDurationUnit');
+  const customPreview = document.getElementById('customDurationPreview');
+
+  function updateCustomPreview() {
+    const v = parseInt(customVal.value, 10) || 1;
+    const u = parseInt(customUnit.value, 10);
+    const totalMins = v * u;
+    customPreview.textContent = totalMins === 1 ? '1 minute' :
+      totalMins < 60 ? totalMins + ' minutes' :
+      totalMins % 60 === 0 ? (totalMins / 60) + (totalMins / 60 === 1 ? ' hour' : ' hours') :
+      (totalMins / 60).toFixed(1) + ' hours';
+    selectedMinutes = totalMins;
+  }
+
+  customVal.addEventListener('input', updateCustomPreview);
+  customUnit.addEventListener('change', updateCustomPreview);
+  updateCustomPreview();
+
+  document.getElementById('durationPicker').addEventListener('click', function (e) {
+    const btn = e.target.closest('.duration-opt');
+    if (!btn) return;
+    document.querySelectorAll('.duration-opt').forEach(b => b.classList.remove('duration-opt--selected'));
+    btn.classList.add('duration-opt--selected');
+    if (btn.dataset.minutes === 'custom') {
+      isCustom = true;
+      customRow.style.setProperty('display', 'flex', 'important');
+      updateCustomPreview();
+    } else {
+      isCustom = false;
+      customRow.style.setProperty('display', 'none', 'important');
+      selectedMinutes = parseInt(btn.dataset.minutes, 10);
+    }
+  });
+
+  document.querySelectorAll('.btn-pause').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      activeRuleId = btn.dataset.ruleId;
+      document.getElementById('pauseRuleName').textContent = btn.dataset.ruleName;
+      document.getElementById('pauseReasonInput').value = '';
+      document.getElementById('pauseError').style.display = 'none';
+      document.querySelectorAll('.duration-opt').forEach(b => {
+        b.classList.toggle('duration-opt--selected', b.dataset.minutes === '60');
+      });
+      isCustom = false;
+      selectedMinutes = 60;
+      customRow.style.setProperty('display', 'none', 'important');
+      new bootstrap.Modal(document.getElementById('pauseModal')).show();
+    });
+  });
+
+  document.getElementById('pauseConfirmBtn').addEventListener('click', function () {
+    if (!activeRuleId) return;
+    if (isCustom) { updateCustomPreview(); }
+    const reason = document.getElementById('pauseReasonInput').value.trim();
+    const errEl  = document.getElementById('pauseError');
+    errEl.style.display = 'none';
+    if (!selectedMinutes || selectedMinutes < 1) {
+      errEl.textContent = '{{ _("Please select a valid duration.") }}';
+      errEl.style.display = 'block';
+      return;
+    }
+    fetch('/alarm3/pause/' + encodeURIComponent(activeRuleId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ duration_minutes: selectedMinutes, reason: reason }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        bootstrap.Modal.getInstance(document.getElementById('pauseModal')).hide();
+        window.location.reload();
+      } else {
+        errEl.textContent = data.error || '{{ _("An error occurred. Please try again.") }}';
+        errEl.style.display = 'block';
+      }
+    })
+    .catch(function () {
+      errEl.textContent = '{{ _("Network error. Please try again.") }}';
+      errEl.style.display = 'block';
+    });
+  });
+
+  document.querySelectorAll('.btn-resume').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      fetch('/alarm3/unpause/' + encodeURIComponent(btn.dataset.ruleId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .then(function () { window.location.reload(); });
+    });
+  });
+}());
+</script>
 
 {% endblock %}


### PR DESCRIPTION
- Introduced a new KPI for paused alarms in alarm.html, alarm2.html, and alarm3.html.
- Updated the alarm status display to include a paused state with appropriate badges.
- Implemented pause and resume buttons for each alarm, allowing users to temporarily silence alarms.
- Added a modal for confirming pause duration and reason, with options for predefined and custom durations.
- Enhanced the JavaScript logic to handle pause and resume actions, including error handling and UI updates.