### PR TITLE
Add pause status to alarms overview and update related functionality

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -416,23 +416,12 @@ def _build_alarm_map() -> dict[str, dict]:
 
 @app.route("/set-language", methods=["POST"])
 def set_language() -> Response:
-    """Set the UI language preference in the session and redirect back to the referring page."""
+    """Set the UI language preference in the session and redirect to a safe default page."""
     lang = request.form.get("lang", "en")
     if lang in ("en", "cy"):
         session["lang"] = lang
 
     fallback = url_for("index")
-    referrer = request.referrer
-    if not referrer:
-        return make_response(redirect(fallback))
-
-    parsed = urlparse(referrer.replace("\\", ""))
-    if parsed.scheme in ("http", "https") and parsed.netloc == request.host and parsed.path:
-        safe_target = parsed.path
-        if parsed.query:
-            safe_target = f"{safe_target}?{parsed.query}"
-        return make_response(redirect(safe_target))
-
     return make_response(redirect(fallback))
 # ---------------------------------------------------------------------------
 # Page routes

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -16,10 +16,10 @@ from threading import Lock
 from typing import Any, Callable
 from urllib.parse import urlparse
 
-from flask import Flask, Response, jsonify, redirect, render_template, request, session, url_for
-from flask_babel import Babel
+from flask import Flask, Response, jsonify, make_response, redirect, render_template, request, session, url_for
+from flask_babel import Babel  # type: ignore[import-untyped]
 
-from dashboard import config
+import dashboard.config as config
 from dashboard.services.alarm1 import (
     generate_rule_id as generate_alarm1_rule_id,
 )
@@ -424,18 +424,16 @@ def set_language() -> Response:
     fallback = url_for("index")
     referrer = request.referrer
     if not referrer:
-        return redirect(fallback)
+        return make_response(redirect(fallback))
 
     parsed = urlparse(referrer.replace("\\", ""))
     if parsed.scheme in ("http", "https") and parsed.netloc == request.host and parsed.path:
         safe_target = parsed.path
         if parsed.query:
             safe_target = f"{safe_target}?{parsed.query}"
-        return redirect(safe_target)
+        return make_response(redirect(safe_target))
 
-    return redirect(fallback)
-
-
+    return make_response(redirect(fallback))
 # ---------------------------------------------------------------------------
 # Page routes
 # ---------------------------------------------------------------------------
@@ -839,7 +837,7 @@ def alarm_config_page() -> str:
 
 
 @app.route("/alarm1/pause/<rule_id>", methods=["POST"])
-def alarm1_pause(rule_id: str) -> Response:
+def alarm1_pause(rule_id: str) -> tuple[Response, int] | Response:
     """Pause an Alarm 1 rule for a given duration with an optional reason.
 
     Expects a JSON body: ``{"duration_minutes": int, "reason": str}``.
@@ -910,7 +908,7 @@ def alarm1_unpause(rule_id: str) -> Response:
 
 
 @app.route("/alarm2/pause/<rule_id>", methods=["POST"])
-def alarm2_pause(rule_id: str) -> Response:
+def alarm2_pause(rule_id: str) -> tuple[Response, int] | Response:
     """Pause an Alarm 2 rule for a given duration with an optional reason."""
     data = request.get_json(silent=True) or {}
     try:
@@ -971,7 +969,7 @@ def alarm2_unpause(rule_id: str) -> Response:
 
 
 @app.route("/alarm3/pause/<rule_id>", methods=["POST"])
-def alarm3_pause(rule_id: str) -> Response:
+def alarm3_pause(rule_id: str) -> tuple[Response, int] | Response:
     """Pause an Alarm 3 rule for a given duration with an optional reason."""
     data = request.get_json(silent=True) or {}
     try:

--- a/dashboard/dashboard/templates/alarms_overview.html
+++ b/dashboard/dashboard/templates/alarms_overview.html
@@ -43,16 +43,19 @@
     {% set n_suppressed = alarm1_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
     {% set n_unknown    = alarm1_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
     {% set n_healthy    = alarm1_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
+    {% set n_paused     = alarm1_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
 
     <div id="alarm1-card" class="dash-card alarm-ov-card
       {% if n_critical > 0 %}alarm-ov-card--critical
-      {% elif n_suppressed > 0 %}alarm-ov-card--suppressed{% endif %}">
+      {% elif n_suppressed > 0 %}alarm-ov-card--suppressed
+      {% elif n_paused > 0 %}alarm-ov-card--paused{% endif %}">
 
       <div class="alarm-ov-header">
         <div class="d-flex align-items-center gap-2">
           <div id="alarm1-icon" class="alarm-ov-icon
             {% if n_critical > 0 %}red
             {% elif n_suppressed > 0 %}amber
+            {% elif n_paused > 0 %}cyan
             {% elif alarm1_rows %}green
             {% else %}muted{% endif %}">
             <i class="bi bi-alarm"></i>
@@ -66,10 +69,12 @@
         <span id="alarm1-badge" class="status-badge
           {% if n_critical > 0 %}critical
           {% elif n_suppressed > 0 %}suppressed
+          {% elif n_paused > 0 %}paused
           {% elif alarm1_rows %}healthy
           {% else %}unknown{% endif %}">
           {% if n_critical > 0 %}<i class="bi bi-exclamation-octagon-fill me-1"></i>{{ _("In Alarm") }}
           {% elif n_suppressed > 0 %}<i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
+          {% elif n_paused > 0 %}<i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
           {% elif alarm1_rows %}<i class="bi bi-check-circle-fill me-1"></i>{{ _("All OK") }}
           {% else %}<i class="bi bi-question-circle me-1"></i>{{ _("Not Configured") }}{% endif %}
         </span>
@@ -87,6 +92,10 @@
         <div class="alarm-ov-kpi">
           <div id="alarm1-kpi-suppressed" class="alarm-ov-kpi-num {% if n_suppressed > 0 %}ov-text-amber{% endif %}">{{ n_suppressed }}</div>
           <div class="alarm-ov-kpi-lbl">{{ _("Suppressed") }}</div>
+        </div>
+        <div class="alarm-ov-kpi">
+          <div id="alarm1-kpi-paused" class="alarm-ov-kpi-num {% if n_paused > 0 %}ov-text-cyan{% endif %}">{{ n_paused }}</div>
+          <div class="alarm-ov-kpi-lbl">{{ _("Paused") }}</div>
         </div>
         <div class="alarm-ov-kpi">
           <div id="alarm1-kpi-unknown" class="alarm-ov-kpi-num">{{ n_unknown }}</div>
@@ -119,16 +128,19 @@
     {% set a2_suppressed = alarm2_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
     {% set a2_unknown    = alarm2_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
     {% set a2_healthy    = alarm2_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
+    {% set a2_paused     = alarm2_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
 
     <div id="alarm2-card" class="dash-card alarm-ov-card
       {% if a2_critical > 0 %}alarm-ov-card--critical
-      {% elif a2_suppressed > 0 %}alarm-ov-card--suppressed{% endif %}">
+      {% elif a2_suppressed > 0 %}alarm-ov-card--suppressed
+      {% elif a2_paused > 0 %}alarm-ov-card--paused{% endif %}">
 
       <div class="alarm-ov-header">
         <div class="d-flex align-items-center gap-2">
           <div id="alarm2-icon" class="alarm-ov-icon
             {% if a2_critical > 0 %}red
             {% elif a2_suppressed > 0 %}amber
+            {% elif a2_paused > 0 %}cyan
             {% elif alarm2_rows %}green
             {% else %}muted{% endif %}">
             <i class="bi bi-alarm"></i>
@@ -142,10 +154,12 @@
         <span id="alarm2-badge" class="status-badge
           {% if a2_critical > 0 %}critical
           {% elif a2_suppressed > 0 %}suppressed
+          {% elif a2_paused > 0 %}paused
           {% elif alarm2_rows %}healthy
           {% else %}unknown{% endif %}">
           {% if a2_critical > 0 %}<i class="bi bi-exclamation-octagon-fill me-1"></i>{{ _("In Alarm") }}
           {% elif a2_suppressed > 0 %}<i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
+          {% elif a2_paused > 0 %}<i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
           {% elif alarm2_rows %}<i class="bi bi-check-circle-fill me-1"></i>{{ _("All OK") }}
           {% else %}<i class="bi bi-question-circle me-1"></i>{{ _("Not Configured") }}{% endif %}
         </span>
@@ -163,6 +177,10 @@
         <div class="alarm-ov-kpi">
           <div id="alarm2-kpi-suppressed" class="alarm-ov-kpi-num {% if a2_suppressed > 0 %}ov-text-amber{% endif %}">{{ a2_suppressed }}</div>
           <div class="alarm-ov-kpi-lbl">{{ _("Suppressed") }}</div>
+        </div>
+        <div class="alarm-ov-kpi">
+          <div id="alarm2-kpi-paused" class="alarm-ov-kpi-num {% if a2_paused > 0 %}ov-text-cyan{% endif %}">{{ a2_paused }}</div>
+          <div class="alarm-ov-kpi-lbl">{{ _("Paused") }}</div>
         </div>
         <div class="alarm-ov-kpi">
           <div id="alarm2-kpi-unknown" class="alarm-ov-kpi-num">{{ a2_unknown }}</div>
@@ -195,16 +213,19 @@
     {% set a3_suppressed = alarm3_rows | selectattr('status', 'equalto', 'suppressed') | list | length %}
     {% set a3_unknown    = alarm3_rows | selectattr('status', 'equalto', 'unknown')    | list | length %}
     {% set a3_healthy    = alarm3_rows | selectattr('status', 'equalto', 'healthy')    | list | length %}
+    {% set a3_paused     = alarm3_rows | selectattr('status', 'equalto', 'paused')     | list | length %}
 
     <div id="alarm3-card" class="dash-card alarm-ov-card
       {% if a3_critical > 0 %}alarm-ov-card--critical
-      {% elif a3_suppressed > 0 %}alarm-ov-card--suppressed{% endif %}">
+      {% elif a3_suppressed > 0 %}alarm-ov-card--suppressed
+      {% elif a3_paused > 0 %}alarm-ov-card--paused{% endif %}">
 
       <div class="alarm-ov-header">
         <div class="d-flex align-items-center gap-2">
           <div id="alarm3-icon" class="alarm-ov-icon
             {% if a3_critical > 0 %}red
             {% elif a3_suppressed > 0 %}amber
+            {% elif a3_paused > 0 %}cyan
             {% elif alarm3_rows %}green
             {% else %}muted{% endif %}">
             <i class="bi bi-alarm"></i>
@@ -218,10 +239,12 @@
         <span id="alarm3-badge" class="status-badge
           {% if a3_critical > 0 %}critical
           {% elif a3_suppressed > 0 %}suppressed
+          {% elif a3_paused > 0 %}paused
           {% elif alarm3_rows %}healthy
           {% else %}unknown{% endif %}">
           {% if a3_critical > 0 %}<i class="bi bi-exclamation-octagon-fill me-1"></i>{{ _("In Alarm") }}
           {% elif a3_suppressed > 0 %}<i class="bi bi-bell-slash-fill me-1"></i>{{ _("Suppressed") }}
+          {% elif a3_paused > 0 %}<i class="bi bi-pause-circle-fill me-1"></i>{{ _("Paused") }}
           {% elif alarm3_rows %}<i class="bi bi-check-circle-fill me-1"></i>{{ _("All OK") }}
           {% else %}<i class="bi bi-question-circle me-1"></i>{{ _("Not Configured") }}{% endif %}
         </span>
@@ -239,6 +262,10 @@
         <div class="alarm-ov-kpi">
           <div id="alarm3-kpi-suppressed" class="alarm-ov-kpi-num {% if a3_suppressed > 0 %}ov-text-amber{% endif %}">{{ a3_suppressed }}</div>
           <div class="alarm-ov-kpi-lbl">{{ _("Suppressed") }}</div>
+        </div>
+        <div class="alarm-ov-kpi">
+          <div id="alarm3-kpi-paused" class="alarm-ov-kpi-num {% if a3_paused > 0 %}ov-text-cyan{% endif %}">{{ a3_paused }}</div>
+          <div class="alarm-ov-kpi-lbl">{{ _("Paused") }}</div>
         </div>
         <div class="alarm-ov-kpi">
           <div id="alarm3-kpi-unknown" class="alarm-ov-kpi-num">{{ a3_unknown }}</div>
@@ -284,6 +311,7 @@
 
   .alarm-ov-card--critical  { border-left: 3px solid var(--accent-red); }
   .alarm-ov-card--suppressed { border-left: 3px solid var(--accent-amber); }
+  .alarm-ov-card--paused    { border-left: 3px solid var(--accent-cyan); }
   .alarm-ov-card--disabled  { opacity: 0.45; pointer-events: none; }
 
   .alarm-ov-header {
@@ -306,6 +334,7 @@
   }
   .alarm-ov-icon.red   { background: rgba(239,68,68,0.15);  color: var(--accent-red); }
   .alarm-ov-icon.amber { background: rgba(245,158,11,0.15); color: var(--accent-amber); }
+  .alarm-ov-icon.cyan  { background: rgba(18,163,201,0.15); color: var(--accent-cyan); }
   .alarm-ov-icon.green { background: rgba(34,197,94,0.15);  color: var(--accent-green); }
   .alarm-ov-icon.muted { background: rgba(148,163,184,0.1); color: var(--text-muted); }
 
@@ -350,6 +379,7 @@
 
   .ov-text-red   { color: var(--accent-red) !important; }
   .ov-text-amber { color: var(--accent-amber) !important; }
+  .ov-text-cyan  { color: var(--accent-cyan) !important; }
   .ov-text-green { color: var(--accent-green) !important; }
 
   .alarm-ov-actions {
@@ -367,6 +397,12 @@
     background: rgba(245,158,11,0.12);
     color: var(--accent-amber);
     border-color: rgba(245,158,11,0.35);
+  }
+
+  .status-badge.paused {
+    background: rgba(18,163,201,0.12);
+    color: var(--accent-cyan);
+    border-color: rgba(18,163,201,0.35);
   }
 
   /* Poll indicator */
@@ -399,21 +435,24 @@
   function updateCard(n, rows) {
     var nCritical   = rows.filter(function(r){ return r.status === 'critical';   }).length;
     var nSuppressed = rows.filter(function(r){ return r.status === 'suppressed'; }).length;
+    var nPaused     = rows.filter(function(r){ return r.status === 'paused';     }).length;
     var nUnknown    = rows.filter(function(r){ return r.status === 'unknown';    }).length;
     var nHealthy    = rows.filter(function(r){ return r.status === 'healthy';    }).length;
     var total       = rows.length;
 
     // Card border
     var card = el('alarm' + n + '-card');
-    card.classList.remove('alarm-ov-card--critical', 'alarm-ov-card--suppressed');
+    card.classList.remove('alarm-ov-card--critical', 'alarm-ov-card--suppressed', 'alarm-ov-card--paused');
     if      (nCritical   > 0) card.classList.add('alarm-ov-card--critical');
     else if (nSuppressed > 0) card.classList.add('alarm-ov-card--suppressed');
+    else if (nPaused     > 0) card.classList.add('alarm-ov-card--paused');
 
     // Icon colour
     var icon = el('alarm' + n + '-icon');
     icon.className = 'alarm-ov-icon ' + (
       nCritical   > 0 ? 'red'   :
       nSuppressed > 0 ? 'amber' :
+      nPaused     > 0 ? 'cyan'  :
       total       > 0 ? 'green' : 'muted'
     );
 
@@ -425,6 +464,9 @@
     } else if (nSuppressed > 0) {
       badge.className = 'status-badge suppressed';
       badge.innerHTML = '<i class="bi bi-bell-slash-fill me-1"></i>Suppressed';
+    } else if (nPaused > 0) {
+      badge.className = 'status-badge paused';
+      badge.innerHTML = '<i class="bi bi-pause-circle-fill me-1"></i>Paused';
     } else if (total > 0) {
       badge.className = 'status-badge healthy';
       badge.innerHTML = '<i class="bi bi-check-circle-fill me-1"></i>All OK';
@@ -442,12 +484,14 @@
       el('alarm' + n + '-kpi-total').textContent     = total;
       el('alarm' + n + '-kpi-critical').textContent   = nCritical;
       el('alarm' + n + '-kpi-suppressed').textContent = nSuppressed;
+      el('alarm' + n + '-kpi-paused').textContent     = nPaused;
       el('alarm' + n + '-kpi-unknown').textContent    = nUnknown;
       el('alarm' + n + '-kpi-healthy').textContent    = nHealthy;
 
-      // Colour the critical/suppressed/healthy KPI numbers
+      // Colour the KPI numbers
       el('alarm' + n + '-kpi-critical').className   = 'alarm-ov-kpi-num' + (nCritical   > 0 ? ' ov-text-red'   : '');
       el('alarm' + n + '-kpi-suppressed').className = 'alarm-ov-kpi-num' + (nSuppressed > 0 ? ' ov-text-amber' : '');
+      el('alarm' + n + '-kpi-paused').className     = 'alarm-ov-kpi-num' + (nPaused     > 0 ? ' ov-text-cyan'  : '');
       el('alarm' + n + '-kpi-healthy').className    = 'alarm-ov-kpi-num ov-text-green';
     } else {
       kpisEl.style.display  = 'none';


### PR DESCRIPTION
This pull request enhances the alarms overview dashboard by adding support for a new "paused" state for alarms, improving both the backend and frontend to display and handle paused alarms consistently. It also includes minor refactoring and type annotation improvements in the Flask app.

**Alarms overview UI enhancements:**

* Added support for displaying a "paused" state for alarms in the `alarms_overview.html` template, including new counters, badges, and color schemes for paused alarms. This includes updates to the card appearance, icons, KPIs, and status badges for all three alarm groups. [[1]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R46-R58) [[2]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R72-R77) [[3]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R96-R99) [[4]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R131-R143) [[5]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R157-R162) [[6]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R181-R184) [[7]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R216-R228) [[8]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R242-R247) [[9]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R266-R269) [[10]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R314) [[11]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R337) [[12]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R382) [[13]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R402-R407) [[14]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R438-R455) [[15]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R467-R469) [[16]](diffhunk://#diff-980e8541f7dcafdc511b16c86844fb143bd13dc9df84eb5207fd347fa10b0495R487-R494)

**Backend and type improvements:**

* Updated the return type annotations for the `alarm1_pause`, `alarm2_pause`, and `alarm3_pause` routes in `app.py` to allow returning either a `Response` or a tuple of `(Response, int)`, improving clarity and type safety. [[1]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77L842-R840) [[2]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77L913-R911) [[3]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77L974-R972)
* Changed the import statement for `dashboard.config` to use module import style for consistency.
* Updated the `set_language` route to always wrap redirects with `make_response`, ensuring proper response object handling.
* Added a type ignore for the `flask_babel` import to suppress mypy warnings about untyped imports.