### PR TITLE
fix: drop non-string application_properties values before OTel trace …

### DIFF
--- a/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
@@ -90,8 +90,17 @@ class MessageReceiverClient:
 
         try:
             props = dict(msg.application_properties or {})
-            # Service Bus stores string keys as bytes in some SDK versions; normalise them.
-            normalised = {k.decode() if isinstance(k, bytes) else k: v for k, v in props.items()}
+            # Normalise keys (bytes → str) and values (bytes → str); drop non-string values
+            # such as integers that are valid Service Bus properties but cannot be OTel headers
+            # and would cause re.search to raise TypeError inside the W3C propagator.
+            normalised: dict[str, str] = {}
+            for k, v in props.items():
+                str_key = k.decode("utf-8") if isinstance(k, bytes) else str(k)
+                if isinstance(v, bytes):
+                    normalised[str_key] = v.decode("utf-8")
+                elif isinstance(v, str):
+                    normalised[str_key] = v
+                # Skip int/float/bool/None — not valid propagation header values
             ctx = extract_trace_context(normalised)
             token = otel_context.attach(ctx)
             try:

--- a/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
+++ b/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
@@ -378,5 +378,55 @@ class TestAutoLockRenewerLifecycle(unittest.TestCase):
         mock_renewer_cls.assert_not_called()
 
 
+class TestInvokeWithTraceContext(unittest.TestCase):
+    """Tests for _invoke_with_trace_context value-normalisation logic."""
+
+    def _make_client(self) -> MessageReceiverClient:
+        sb_client = MagicMock()
+        return MessageReceiverClient(sb_client, "test-queue", propagate_trace_context=True)
+
+    def _make_message(self, props: dict | None) -> MagicMock:
+        msg = MagicMock()
+        msg.application_properties = props
+        return msg
+
+    def test_integer_value_in_application_properties_does_not_raise(self) -> None:
+        """Integer values in application_properties must be silently dropped so the
+        W3C propagator never receives a non-string carrier value (regression for
+        TypeError: expected string or bytes-like object, got 'int')."""
+        client = self._make_client()
+        msg = self._make_message({"SomeIntProp": 42, "OtherProp": "hello"})
+
+        called_with = []
+
+        def processor(m: Any) -> bool:
+            called_with.append(m)
+            return True
+
+        # Must not raise TypeError
+        result = client._invoke_with_trace_context(processor, msg)
+
+        self.assertTrue(result)
+        self.assertEqual(called_with, [msg])
+
+    def test_bytes_key_and_value_are_decoded(self) -> None:
+        """Bytes keys and values should be decoded to str before being passed to extract."""
+        client = self._make_client()
+        msg = self._make_message({b"SomeProp": b"some-value"})
+
+        result = client._invoke_with_trace_context(lambda m: True, msg)
+
+        self.assertTrue(result)
+
+    def test_none_application_properties_does_not_raise(self) -> None:
+        """None application_properties should be handled gracefully."""
+        client = self._make_client()
+        msg = self._make_message(None)
+
+        result = client._invoke_with_trace_context(lambda m: True, msg)
+
+        self.assertTrue(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…context extraction

Integer (and other non-string) values in Service Bus application_properties caused a TypeError inside the W3C propagator (re.search received an int instead of a string).

Normalise the carrier dict in _invoke_with_trace_context so that only str/bytes values are passed to extract_trace_context; bytes values are decoded to str and int/float/bool/None values are silently dropped as they cannot be valid propagation headers.

Adds TestInvokeWithTraceContext unit tests covering the integer-value, bytes, and None application_properties cases.