### PR TITLE
feat: enhance queue display to show critical and warning ordered by crit first, basically ordered by active messages in queue

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -450,6 +450,8 @@ def index() -> str:
         no_alarm1_configured=not any(r.get("alarm_enabled", False) for r in cfg1.get("rules", {}).values()),
         no_alarm2_configured=not any(r.get("alarm_enabled", False) for r in cfg2.get("rules", {}).values()),
         no_alarm3_configured=not any(r.get("alarm_enabled", False) for r in cfg3.get("rules", {}).values()),
+        queue_warn_threshold=config.QUEUE_WARNING_THRESHOLD,
+        queue_crit_threshold=config.QUEUE_CRITICAL_THRESHOLD,
     )
 
 

--- a/dashboard/dashboard/static/js/dashboard.js
+++ b/dashboard/dashboard/static/js/dashboard.js
@@ -5,7 +5,9 @@
 (function () {
   "use strict";
 
-  const REFRESH_INTERVAL = window.REFRESH_INTERVAL || 30; // seconds
+  const REFRESH_INTERVAL   = window.REFRESH_INTERVAL   || 30; // seconds
+  const WARN_THRESHOLD     = window.QUEUE_WARN_THRESHOLD || 10;
+  const CRIT_THRESHOLD     = window.QUEUE_CRIT_THRESHOLD || 50;
 
   /* ------------------------------------------------------------------ */
   /* Countdown timer                                                      */
@@ -38,6 +40,14 @@
     el.classList.add("counter-pop");
     el.textContent = newVal;
     el.addEventListener("animationend", () => el.classList.remove("counter-pop"), { once: true });
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
   }
 
   /* ------------------------------------------------------------------ */
@@ -162,27 +172,65 @@
 
   /* ------------------------------------------------------------------ */
   /* Update queue table                                                    */
+  /* Full rebuild on every poll so rows are added/removed as queues       */
+  /* transition between healthy and non-healthy states.                   */
   /* ------------------------------------------------------------------ */
+  function queueStatus(q) {
+    if (q.active_message_count >= CRIT_THRESHOLD) return "critical";
+    if (q.active_message_count >= WARN_THRESHOLD || q.dead_letter_message_count > 0) return "warning";
+    return "healthy";
+  }
+
   function updateQueueTable(queues) {
-    for (const q of queues) {
-      const row = document.querySelector(`tr[data-queue-name="${q.name}"]`);
-      if (!row) continue;
+    const table = document.getElementById("queue-table");
+    if (!table) return;
+    const tbody = table.querySelector("tbody");
+    if (!tbody) return;
 
-      const activeEl = row.querySelector("[data-col='active']");
-      const dlqEl    = row.querySelector("[data-col='dlq']");
+    // Filter to only non-healthy queues
+    const nonHealthy = queues.filter(q => queueStatus(q) !== "healthy");
 
-      if (activeEl) {
-        animateCounter(activeEl, q.active_message_count);
-        activeEl.className = "count-cell " +
-          (q.active_message_count >= 50 ? "critical" :
-           q.active_message_count >= 10 ? "warning"  : "zero");
-      }
-      if (dlqEl) {
-        animateCounter(dlqEl, q.dead_letter_message_count);
-        dlqEl.className = "count-cell " +
-          (q.dead_letter_message_count > 0 ? "dlq-warn" : "zero");
-      }
+    // Sort: critical first, then warning; within each group by active desc
+    const statusOrder = { critical: 0, warning: 1 };
+    nonHealthy.sort((a, b) => {
+      const diff = statusOrder[queueStatus(a)] - statusOrder[queueStatus(b)];
+      if (diff !== 0) return diff;
+      return b.active_message_count - a.active_message_count;
+    });
+
+    const rows = [];
+    for (const q of nonHealthy) {
+      const status = queueStatus(q);
+      const active = q.active_message_count;
+      const dlq    = q.dead_letter_message_count;
+      const sched  = q.scheduled_message_count || 0;
+
+      const activeClass = status === "critical" ? "critical"
+                        : active >= WARN_THRESHOLD ? "warning" : "zero";
+      const dlqClass = dlq > 0 ? "dlq-warn" : "zero";
+
+      const tr = document.createElement("tr");
+      tr.dataset.queueName = q.name;
+      tr.innerHTML =
+        `<td class="queue-name-cell" data-col="name">${escapeHtml(q.name)}</td>` +
+        `<td class="count-cell text-end ${activeClass}" data-col="active">${active}</td>` +
+        `<td class="count-cell text-end ${dlqClass}" data-col="dlq">${dlq}</td>` +
+        `<td class="count-cell text-end zero" data-col="sched">${sched}</td>` +
+        `<td><span class="status-badge ${status}">${status}</span></td>`;
+      rows.push(tr);
     }
+
+    // All-clear row when every queue is healthy
+    if (rows.length === 0) {
+      const tr = document.createElement("tr");
+      const label = window.I18N_ALL_QUEUES_HEALTHY || "All queues healthy";
+      tr.innerHTML =
+        `<td colspan="5" class="text-center" style="padding:1rem;color:var(--accent-green);">` +
+        `<i class="bi bi-check-circle me-1"></i> ${escapeHtml(label)}</td>`;
+      rows.push(tr);
+    }
+
+    tbody.replaceChildren(...rows);
   }
 
   /* ------------------------------------------------------------------ */

--- a/dashboard/dashboard/templates/index.html
+++ b/dashboard/dashboard/templates/index.html
@@ -3,7 +3,12 @@
 {% block title %}{{ _("Overview") }}{% endblock %}
 
 {% block head %}
-<script>window.REFRESH_INTERVAL = {{ refresh_interval }};</script>
+<script>
+  window.REFRESH_INTERVAL      = {{ refresh_interval }};
+  window.QUEUE_WARN_THRESHOLD  = {{ queue_warn_threshold }};
+  window.QUEUE_CRIT_THRESHOLD  = {{ queue_crit_threshold }};
+  window.I18N_ALL_QUEUES_HEALTHY = {{ _("All queues healthy") | tojson }};
+</script>
 {% endblock %}
 
 {% block content %}
@@ -479,11 +484,11 @@
             </thead>
             <tbody>
               {% set critical_qs = status.queues
-                 | selectattr('active_message_count', 'ge', 50)
+                 | selectattr('active_message_count', 'ge', queue_crit_threshold)
                  | sort(attribute='active_message_count', reverse=True)
                  | list %}
               {% set noncritical_qs = status.queues
-                 | rejectattr('active_message_count', 'ge', 50)
+                 | rejectattr('active_message_count', 'ge', queue_crit_threshold)
                  | sort(attribute='active_message_count', reverse=True)
                  | list %}
               {# Critical queues first, sorted by active message count descending #}
@@ -499,14 +504,14 @@
                 <td><span class="status-badge critical">critical</span></td>
               </tr>
               {% endfor %}
-              {# Warning queues next: non-critical but active >= 10 or has DLQ messages, sorted by active desc #}
+              {# Warning queues next: non-critical but active >= warn threshold or has DLQ messages, sorted by active desc #}
               {% for q in noncritical_qs %}
               {% set active = q.active_message_count %}
               {% set dlq = q.dead_letter_message_count %}
-              {% if active >= 10 or dlq > 0 %}
+              {% if active >= queue_warn_threshold or dlq > 0 %}
               <tr data-queue-name="{{ q.name }}">
                 <td class="queue-name-cell" data-col="name">{{ q.name }}</td>
-                <td class="count-cell text-end {{ 'warning' if active >= 10 else 'zero' }}"
+                <td class="count-cell text-end {{ 'warning' if active >= queue_warn_threshold else 'zero' }}"
                     data-col="active">{{ active }}</td>
                 <td class="count-cell text-end {{ 'dlq-warn' if dlq > 0 else 'zero' }}"
                     data-col="dlq">{{ dlq }}</td>
@@ -517,7 +522,7 @@
               {% endfor %}
               {# All-clear row shown when every queue is healthy #}
               {% if critical_qs | length == 0
-                 and noncritical_qs | selectattr('active_message_count', 'ge', 10) | list | length == 0
+                 and noncritical_qs | selectattr('active_message_count', 'ge', queue_warn_threshold) | list | length == 0
                  and noncritical_qs | selectattr('dead_letter_message_count', 'gt', 0) | list | length == 0 %}
               <tr>
                 <td colspan="5" class="text-center" style="padding: 1rem; color: var(--accent-green);">

--- a/dashboard/dashboard/templates/index.html
+++ b/dashboard/dashboard/templates/index.html
@@ -478,20 +478,53 @@
               </tr>
             </thead>
             <tbody>
-              {% for q in status.queues | sort(attribute='active_message_count', reverse=True) %}
+              {% set critical_qs = status.queues
+                 | selectattr('active_message_count', 'ge', 50)
+                 | sort(attribute='active_message_count', reverse=True)
+                 | list %}
+              {% set noncritical_qs = status.queues
+                 | rejectattr('active_message_count', 'ge', 50)
+                 | sort(attribute='active_message_count', reverse=True)
+                 | list %}
+              {# Critical queues first, sorted by active message count descending #}
+              {% for q in critical_qs %}
               {% set active = q.active_message_count %}
               {% set dlq = q.dead_letter_message_count %}
-              {% set q_health = 'critical' if active >= 50 else ('warning' if active >= 10 or dlq > 0 else 'healthy') %}
               <tr data-queue-name="{{ q.name }}">
                 <td class="queue-name-cell" data-col="name">{{ q.name }}</td>
-                <td class="count-cell text-end {{ 'critical' if active >= 50 else ('warning' if active >= 10 else 'zero') }}"
+                <td class="count-cell text-end critical" data-col="active">{{ active }}</td>
+                <td class="count-cell text-end {{ 'dlq-warn' if dlq > 0 else 'zero' }}"
+                    data-col="dlq">{{ dlq }}</td>
+                <td class="count-cell text-end zero" data-col="sched">{{ q.scheduled_message_count }}</td>
+                <td><span class="status-badge critical">critical</span></td>
+              </tr>
+              {% endfor %}
+              {# Warning queues next: non-critical but active >= 10 or has DLQ messages, sorted by active desc #}
+              {% for q in noncritical_qs %}
+              {% set active = q.active_message_count %}
+              {% set dlq = q.dead_letter_message_count %}
+              {% if active >= 10 or dlq > 0 %}
+              <tr data-queue-name="{{ q.name }}">
+                <td class="queue-name-cell" data-col="name">{{ q.name }}</td>
+                <td class="count-cell text-end {{ 'warning' if active >= 10 else 'zero' }}"
                     data-col="active">{{ active }}</td>
                 <td class="count-cell text-end {{ 'dlq-warn' if dlq > 0 else 'zero' }}"
                     data-col="dlq">{{ dlq }}</td>
                 <td class="count-cell text-end zero" data-col="sched">{{ q.scheduled_message_count }}</td>
-                <td><span class="status-badge {{ q_health }}">{{ q_health }}</span></td>
+                <td><span class="status-badge warning">warning</span></td>
               </tr>
+              {% endif %}
               {% endfor %}
+              {# All-clear row shown when every queue is healthy #}
+              {% if critical_qs | length == 0
+                 and noncritical_qs | selectattr('active_message_count', 'ge', 10) | list | length == 0
+                 and noncritical_qs | selectattr('dead_letter_message_count', 'gt', 0) | list | length == 0 %}
+              <tr>
+                <td colspan="5" class="text-center" style="padding: 1rem; color: var(--accent-green);">
+                  <i class="bi bi-check-circle me-1"></i> {{ _("All queues healthy") }}
+                </td>
+              </tr>
+              {% endif %}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION

This pull request refactors the queue health section in the dashboard to improve clarity and user experience. Queues are now explicitly categorized and displayed by health status: critical queues are shown first, followed by warning queues, with a clear "All queues healthy" message when appropriate.

**Queue health display improvements:**

* Queues with `active_message_count` ≥ 50 are grouped and displayed as "critical" with a dedicated status badge and styling.
* Non-critical queues (active < 50) are further filtered: those with `active_message_count` ≥ 10 or any dead-letter messages are shown as "warning" with appropriate styling.
* The table now shows a single "All queues healthy" row when no queues are in a warning or critical state, making the dashboard easier to interpret at a glance.

**Code structure and maintainability:**

* The logic for determining and displaying queue health is now split into separate loops for critical and warning queues, simplifying future maintenance and reducing complexity.