### PR TITLE
fix: add Entra credential support for otel Azure Monitor export

### DIFF
--- a/hl7_chemo_transformer/uv.lock
+++ b/hl7_chemo_transformer/uv.lock
@@ -795,6 +795,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -806,6 +807,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_mock_receiver/uv.lock
+++ b/hl7_mock_receiver/uv.lock
@@ -732,6 +732,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -743,6 +744,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_phw_transformer/uv.lock
+++ b/hl7_phw_transformer/uv.lock
@@ -797,6 +797,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -808,6 +809,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_pims_transformer/uv.lock
+++ b/hl7_pims_transformer/uv.lock
@@ -795,6 +795,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -806,6 +807,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_sender/uv.lock
+++ b/hl7_sender/uv.lock
@@ -862,6 +862,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -873,6 +874,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_server/uv.lock
+++ b/hl7_server/uv.lock
@@ -927,6 +927,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -938,6 +939,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/hl7_subscription_sender/uv.lock
+++ b/hl7_subscription_sender/uv.lock
@@ -823,6 +823,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -834,6 +835,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/message_store_service/uv.lock
+++ b/message_store_service/uv.lock
@@ -813,6 +813,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../shared_libs/otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -824,6 +825,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/shared_libs/message_bus_lib/uv.lock
+++ b/shared_libs/message_bus_lib/uv.lock
@@ -672,6 +672,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -683,6 +684,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any
 
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 import opentelemetry.context as otel_context
 import opentelemetry.trace as otel_trace
 from opentelemetry import trace
@@ -66,6 +67,8 @@ def configure_otel(service_name: str, service_version: str = "1.0.0") -> bool:
 def _configure_azure_monitor(service_name: str, service_version: str) -> None:
     """Configure OTel to export to Azure Monitor / Application Insights."""
     try:
+        credential = _get_credential()
+
         # azure-monitor-opentelemetry sets up the TracerProvider internally; we
         # only need to supply the resource so the service.name is correct.
         #
@@ -77,6 +80,7 @@ def _configure_azure_monitor(service_name: str, service_version: str) -> None:
         # without bound inside the MeterProvider and cause steadily growing
         # CPU usage over the lifetime of the container.
         configure_azure_monitor(
+            credential=credential,
             resource=Resource.create(
                 {
                     "service.name": service_name,
@@ -98,6 +102,21 @@ def _configure_azure_monitor(service_name: str, service_version: str) -> None:
     except Exception:
         logger.exception("Failed to configure Azure Monitor exporter — falling back to no-op.")
         _configure_noop(service_name, service_version)
+
+
+def _get_credential() -> ManagedIdentityCredential | DefaultAzureCredential:
+    """Return an Azure credential for Application Insights ingestion.
+
+    Uses user-assigned managed identity when INSIGHTS_UAMI_CLIENT_ID is set,
+    otherwise falls back to DefaultAzureCredential.
+    """
+    uami_client_id = os.getenv("INSIGHTS_UAMI_CLIENT_ID", "").strip()
+    if uami_client_id:
+        logger.info("Using ManagedIdentityCredential with client_id: %s", uami_client_id)
+        return ManagedIdentityCredential(client_id=uami_client_id)
+
+    logger.info("Using DefaultAzureCredential (INSIGHTS_UAMI_CLIENT_ID not set)")
+    return DefaultAzureCredential()
 
 
 def _configure_noop(service_name: str, service_version: str) -> None:

--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -112,10 +112,10 @@ def _get_credential() -> ManagedIdentityCredential | DefaultAzureCredential:
     """
     uami_client_id = os.getenv("INSIGHTS_UAMI_CLIENT_ID", "").strip()
     if uami_client_id:
-        logger.info("Using ManagedIdentityCredential with client_id: %s", uami_client_id)
+        logger.debug("Using ManagedIdentityCredential (INSIGHTS_UAMI_CLIENT_ID set)")
         return ManagedIdentityCredential(client_id=uami_client_id)
 
-    logger.info("Using DefaultAzureCredential (INSIGHTS_UAMI_CLIENT_ID not set)")
+    logger.debug("Using DefaultAzureCredential (INSIGHTS_UAMI_CLIENT_ID not set)")
     return DefaultAzureCredential()
 
 

--- a/shared_libs/otel_lib/otel_lib/otel.py
+++ b/shared_libs/otel_lib/otel_lib/otel.py
@@ -2,9 +2,9 @@ import logging
 import os
 from typing import Any
 
-from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 import opentelemetry.context as otel_context
 import opentelemetry.trace as otel_trace
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from opentelemetry import trace
 from opentelemetry.propagate import extract, inject
 from opentelemetry.sdk.resources import Resource
@@ -14,6 +14,7 @@ try:
     from azure.monitor.opentelemetry import configure_azure_monitor  # type: ignore[import-untyped]
 except ImportError:  # pragma: no cover
     configure_azure_monitor = None  # type: ignore[assignment]
+
 
 logger = logging.getLogger(__name__)
 

--- a/shared_libs/otel_lib/pyproject.toml
+++ b/shared_libs/otel_lib/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "azure-monitor-opentelemetry==1.6.13",
+  "azure-identity>=1.24.0",
     "pyjwt>=2.13.0",
     "opentelemetry-api>=1.29.0",
     "opentelemetry-sdk>=1.29.0",

--- a/shared_libs/otel_lib/pyproject.toml
+++ b/shared_libs/otel_lib/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "azure-monitor-opentelemetry==1.6.13",
-  "azure-identity>=1.24.0",
+  "azure-identity>=1.23.0",
     "pyjwt>=2.13.0",
     "opentelemetry-api>=1.29.0",
     "opentelemetry-sdk>=1.29.0",

--- a/shared_libs/otel_lib/tests/test_otel.py
+++ b/shared_libs/otel_lib/tests/test_otel.py
@@ -48,10 +48,13 @@ class TestConfigureOtel(unittest.TestCase):
         clear=True,
     )
     def test_configure_otel_with_connection_string_calls_azure_monitor(self) -> None:
-        with patch("otel_lib.otel.configure_azure_monitor") as mock_configure:
+        with patch("otel_lib.otel.configure_azure_monitor") as mock_configure, \
+             patch("otel_lib.otel.DefaultAzureCredential") as mock_default_credential:
             configure_otel("test-service")
             mock_configure.assert_called_once()
             _, kwargs = mock_configure.call_args
+            self.assertIn("credential", kwargs)
+            self.assertEqual(kwargs["credential"], mock_default_credential.return_value)
             opts = kwargs["instrumentation_options"]
             # Every supported auto-instrumentor must be disabled — our services
             # use manual telemetry only.  Active instrumentors (especially
@@ -108,6 +111,36 @@ class TestConfigureOtel(unittest.TestCase):
             configure_otel("test-service")
             configure_otel("test-service-again")
             mock_configure.assert_called_once()
+
+    @patch.dict(
+        "os.environ",
+        {
+            "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=fake-key;IngestionEndpoint=https://example.com",
+            "INSIGHTS_UAMI_CLIENT_ID": "uami-client-id",
+        },
+        clear=True,
+    )
+    def test_configure_otel_with_uami_uses_managed_identity_credential(self) -> None:
+        with patch("otel_lib.otel.configure_azure_monitor") as mock_configure, \
+             patch("otel_lib.otel.ManagedIdentityCredential") as mock_mi_credential:
+            configure_otel("test-service")
+            _, kwargs = mock_configure.call_args
+            self.assertEqual(kwargs["credential"], mock_mi_credential.return_value)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=fake-key;IngestionEndpoint=https://example.com",
+            "INSIGHTS_UAMI_CLIENT_ID": "   ",
+        },
+        clear=True,
+    )
+    def test_configure_otel_with_blank_uami_falls_back_to_default_credential(self) -> None:
+        with patch("otel_lib.otel.configure_azure_monitor") as mock_configure, \
+             patch("otel_lib.otel.DefaultAzureCredential") as mock_default_credential:
+            configure_otel("test-service")
+            _, kwargs = mock_configure.call_args
+            self.assertEqual(kwargs["credential"], mock_default_credential.return_value)
 
     @patch.dict("os.environ", {}, clear=True)
     def test_configure_otel_sets_service_name(self) -> None:

--- a/shared_libs/otel_lib/uv.lock
+++ b/shared_libs/otel_lib/uv.lock
@@ -673,7 +673,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-identity", specifier = ">=1.24.0" },
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/shared_libs/otel_lib/uv.lock
+++ b/shared_libs/otel_lib/uv.lock
@@ -654,6 +654,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -672,6 +673,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.24.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/shared_libs/processor_manager_lib/uv.lock
+++ b/shared_libs/processor_manager_lib/uv.lock
@@ -574,6 +574,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -585,6 +586,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },

--- a/shared_libs/transformer_base_lib/uv.lock
+++ b/shared_libs/transformer_base_lib/uv.lock
@@ -731,6 +731,7 @@ name = "otel-lib"
 version = "0.1.0"
 source = { directory = "../otel_lib" }
 dependencies = [
+    { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "idna" },
     { name = "opentelemetry-api" },
@@ -742,6 +743,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.13" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },


### PR DESCRIPTION
Use managed identity/default credential in otel_lib configure_azure_monitor path, add credential tests, and update otel_lib dependencies/lockfile.