### PR TITLE
fix: update language setting to redirect back to the referring page

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -415,13 +415,12 @@ def _build_alarm_map() -> dict[str, dict]:
 
 @app.route("/set-language", methods=["POST"])
 def set_language() -> Response:
-    """Set the UI language preference in the session and redirect to a safe default page."""
+    """Set the UI language preference in the session and redirect back to the referring page."""
     lang = request.form.get("lang", "en")
     if lang in ("en", "cy"):
         session["lang"] = lang
 
-    fallback = url_for("index")
-    return make_response(redirect(fallback))
+    return make_response(redirect(request.referrer or url_for("index")))
 # ---------------------------------------------------------------------------
 # Page routes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request updates the language preference handling in the application. Now, when a user changes the UI language, they are redirected back to the page they were on, rather than always being sent to the index page.

User experience improvement:

* The `set_language` route in `dashboard/dashboard/app.py` now redirects users back to the referring page after changing the language, instead of always redirecting to the index page.