### PR TITLE
Implement multi-threshold support for Alarm 2 and layout consistency

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -1092,7 +1092,9 @@ def alarm2_config_page() -> str:
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
             entry["window_duration_minutes"] = _int(f"window_duration_{rid}", 2880, minimum=1)
-            entry["threshold"] = _int(f"threshold_{rid}", 0, minimum=0)
+            entry["day_threshold"] = _int(f"day_threshold_{rid}", 0, minimum=0)
+            entry["evening_threshold"] = _int(f"evening_threshold_{rid}", 0, minimum=0)
+            entry["weekend_threshold"] = _int(f"weekend_threshold_{rid}", 0, minimum=0)
             entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60, minimum=1)
 
         # --- Add new rule if submitted ---
@@ -1105,7 +1107,9 @@ def alarm2_config_page() -> str:
                 "alarm_enabled": "new_enabled" in request.form,
                 "workflow_id": new_wid,
                 "window_duration_minutes": _int("new_window_duration", 2880, minimum=1),
-                "threshold": _int("new_threshold", 0, minimum=0),
+                "day_threshold": _int("new_day_threshold", 0, minimum=0),
+                "evening_threshold": _int("new_evening_threshold", 0, minimum=0),
+                "weekend_threshold": _int("new_weekend_threshold", 0, minimum=0),
                 "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
             }

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
+from dashboard.services.alarm_time_utils import get_current_period
 from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
@@ -85,34 +86,6 @@ def _save_alarm_state(state: dict) -> None:
 # ---------------------------------------------------------------------------
 # Time-period helpers
 # ---------------------------------------------------------------------------
-
-
-def get_current_period(now: datetime) -> str:
-    """Return the current time period: 'day', 'evening', or 'weekend'.
-
-    Weekend : Friday 17:00 → Monday 08:00 (UTC)
-    Day     : Monday–Friday 08:00–17:00 (UTC)
-    Evening : Monday–Friday 17:00–08:00, excluding weekend window (UTC)
-    """
-    weekday = now.weekday()  # 0 = Monday … 4 = Friday, 5 = Sat, 6 = Sun
-    time_mins = now.hour * 60 + now.minute
-    DAY_START = 8 * 60  # 08:00
-    DAY_END = 17 * 60  # 17:00
-
-    # Weekend window: Fri 17:00 → Mon 08:00
-    if weekday == 4 and time_mins >= DAY_END:  # Friday after 17:00
-        return "weekend"
-    if weekday in (5, 6):  # Saturday, Sunday
-        return "weekend"
-    if weekday == 0 and time_mins < DAY_START:  # Monday before 08:00
-        return "weekend"
-
-    # Day window: Mon–Fri 08:00–17:00
-    if 0 <= weekday <= 4 and DAY_START <= time_mins < DAY_END:
-        return "day"
-
-    # Everything else is evening
-    return "evening"
 
 
 def _applicable_threshold(server_cfg: dict, now: datetime) -> int:

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
+from dashboard.services.alarm_time_utils import PERIOD_SHORT_LABELS, get_current_period
 from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
@@ -39,7 +40,9 @@ CONFIG_PATH = Path(__file__).parent.parent.parent / "alarm2_config.json"
 STATE_PATH = Path(__file__).parent.parent.parent / "alarm2_state.json"
 
 DEFAULT_WINDOW_MINUTES = 2880  # 2 days
-DEFAULT_THRESHOLD = 0
+DEFAULT_DAY_THRESHOLD = 0
+DEFAULT_EVENING_THRESHOLD = 0
+DEFAULT_WEEKEND_THRESHOLD = 0
 DEFAULT_ALERTING_GAP = 60
 
 # Seed list of known rules — always present even if not yet enabled.
@@ -164,6 +167,16 @@ def _format_count(total: int | None) -> str:
     return f"{total:,}"
 
 
+def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
+    """Return the message-count alarm threshold for the current time period."""
+    period = get_current_period(now)
+    if period == "weekend":
+        return int(rule_cfg.get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD))
+    if period == "day":
+        return int(rule_cfg.get("day_threshold", DEFAULT_DAY_THRESHOLD))
+    return int(rule_cfg.get("evening_threshold", DEFAULT_EVENING_THRESHOLD))
+
+
 # ---------------------------------------------------------------------------
 # Log Analytics query
 # ---------------------------------------------------------------------------
@@ -244,6 +257,7 @@ def _send_alarm2_email(
     window_minutes: int,
     workflow_id: str,
     now: datetime,
+    period: str = "day",
     email_alerts_enabled: bool = False,
 ) -> None:
     """Send an HTML email via Azure Communication Services when Alarm 2 fires."""
@@ -255,7 +269,10 @@ def _send_alarm2_email(
         log.warning("Alarm 2 email enabled but ACS/ALERT_EMAIL_TO not set — skipping")
         return
 
+    from dashboard.services.alarm_time_utils import PERIOD_LABELS  # noqa: PLC0415
+
     window_label = f"{window_minutes // 60} hours" if window_minutes >= 60 else f"{window_minutes} minutes"
+    period_label = PERIOD_LABELS.get(period, period.title())
     subject = f"[Integration Hub] Alarm 2 — {display_name} low message volume ({messages_total} messages)"
     body = f"""<html><body style="font-family:Arial,sans-serif;color:#333;max-width:600px;">
 <h2 style="color:#c0392b;border-bottom:2px solid #c0392b;padding-bottom:8px;">
@@ -280,8 +297,8 @@ def _send_alarm2_email(
     <td style="border-bottom:1px solid #eee;color:#c0392b;font-weight:bold;">{messages_total:,}</td>
   </tr>
   <tr>
-    <td style="font-weight:bold;border-bottom:1px solid #eee;">Threshold</td>
-    <td style="border-bottom:1px solid #eee;">&lt;= {threshold:,}</td>
+    <td style="font-weight:bold;border-bottom:1px solid #eee;">Period / Threshold</td>
+    <td style="border-bottom:1px solid #eee;">{period_label} — &lt;= {threshold:,}</td>
   </tr>
   <tr style="background:#fff;">
     <td style="font-weight:bold;border-bottom:1px solid #eee;">Lookback Window</td>
@@ -348,7 +365,8 @@ def get_alarm2_status() -> list[dict]:
     for rule in enabled_rules:
         rid = rule["id"]
         rule_cfg = rules_cfg.get(rid, {})
-        threshold = int(rule_cfg.get("threshold", DEFAULT_THRESHOLD))
+        threshold = _applicable_threshold(rule_cfg, now)
+        period = get_current_period(now)
         gap = int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP))
         total = totals.get(rid)
 
@@ -415,6 +433,7 @@ def get_alarm2_status() -> list[dict]:
                 int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
                 rule_cfg.get("workflow_id", rule.get("workflow_id", "")),
                 now,
+                period=period,
                 email_alerts_enabled=rule_cfg.get("email_alerts_enabled", False),
             )
         else:
@@ -432,6 +451,7 @@ def get_alarm2_status() -> list[dict]:
                     int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
                     rule_cfg.get("workflow_id", rule.get("workflow_id", "")),
                     now,
+                    period=period,
                     email_alerts_enabled=rule_cfg.get("email_alerts_enabled", False),
                 )
             else:
@@ -464,13 +484,20 @@ def _build_row(
 ) -> dict:
     """Build the status-row dict for a single Alarm 2 rule."""
     window = int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES))
+    period = get_current_period(now)
+    period_threshold = _applicable_threshold(rule_cfg, now)
     return {
         "id": rid,
         "display_name": rule_cfg.get("display_name") or rule_seed.get("display_name", rid),
         "workflow_id": rule_cfg.get("workflow_id", rule_seed.get("workflow_id", "")),
         "window_duration_minutes": window,
         "window_label": _window_label(window),
-        "threshold": int(rule_cfg.get("threshold", DEFAULT_THRESHOLD)),
+        "day_threshold": int(rule_cfg.get("day_threshold", DEFAULT_DAY_THRESHOLD)),
+        "evening_threshold": int(rule_cfg.get("evening_threshold", DEFAULT_EVENING_THRESHOLD)),
+        "weekend_threshold": int(rule_cfg.get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD)),
+        "current_period": period,
+        "period_threshold": period_threshold,
+        "period_short_label": PERIOD_SHORT_LABELS.get(period, period.title()),
         "alerting_gap_minutes": int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
         "messages_total": total,
         "messages_display": _format_count(total),
@@ -533,7 +560,9 @@ def get_alarm2_config_page_data() -> list[dict]:
             "window_duration_minutes": int(
                 rules_cfg.get(r["id"], {}).get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)
             ),
-            "threshold": int(rules_cfg.get(r["id"], {}).get("threshold", DEFAULT_THRESHOLD)),
+            "day_threshold": int(rules_cfg.get(r["id"], {}).get("day_threshold", DEFAULT_DAY_THRESHOLD)),
+            "evening_threshold": int(rules_cfg.get(r["id"], {}).get("evening_threshold", DEFAULT_EVENING_THRESHOLD)),
+            "weekend_threshold": int(rules_cfg.get(r["id"], {}).get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD)),
             "alerting_gap_minutes": int(rules_cfg.get(r["id"], {}).get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
             "email_alerts_enabled": rules_cfg.get(r["id"], {}).get("email_alerts_enabled", False),
         }

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -168,13 +168,18 @@ def _format_count(total: int | None) -> str:
 
 
 def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
-    """Return the message-count alarm threshold for the current time period."""
+    """Return the message-count alarm threshold for the current time period.
+
+    Falls back to the legacy single ``threshold`` field for configs created
+    before per-period thresholds were introduced.
+    """
+    legacy = rule_cfg.get("threshold", None)
     period = get_current_period(now)
     if period == "weekend":
-        return int(rule_cfg.get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD))
+        return int(rule_cfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD))
     if period == "day":
-        return int(rule_cfg.get("day_threshold", DEFAULT_DAY_THRESHOLD))
-    return int(rule_cfg.get("evening_threshold", DEFAULT_EVENING_THRESHOLD))
+        return int(rule_cfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD))
+    return int(rule_cfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD))
 
 
 # ---------------------------------------------------------------------------
@@ -492,9 +497,9 @@ def _build_row(
         "workflow_id": rule_cfg.get("workflow_id", rule_seed.get("workflow_id", "")),
         "window_duration_minutes": window,
         "window_label": _window_label(window),
-        "day_threshold": int(rule_cfg.get("day_threshold", DEFAULT_DAY_THRESHOLD)),
-        "evening_threshold": int(rule_cfg.get("evening_threshold", DEFAULT_EVENING_THRESHOLD)),
-        "weekend_threshold": int(rule_cfg.get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD)),
+        "day_threshold": int(rule_cfg.get("day_threshold", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
+        "evening_threshold": int(rule_cfg.get("evening_threshold", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))),
+        "weekend_threshold": int(rule_cfg.get("weekend_threshold", rule_cfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))),
         "current_period": period,
         "period_threshold": period_threshold,
         "period_short_label": PERIOD_SHORT_LABELS.get(period, period.title()),
@@ -551,20 +556,23 @@ def get_alarm2_config_page_data() -> list[dict]:
     """Return all known rules with their current settings for the config form."""
     cfg = load_alarm2_config()
     rules_cfg = cfg.get("rules", {})
-    return [
-        {
-            "id": r["id"],
-            "display_name": rules_cfg.get(r["id"], {}).get("display_name") or r.get("display_name", r["id"]),
-            "alarm_enabled": rules_cfg.get(r["id"], {}).get("alarm_enabled", False),
-            "workflow_id": rules_cfg.get(r["id"], {}).get("workflow_id", r.get("workflow_id", "")),
-            "window_duration_minutes": int(
-                rules_cfg.get(r["id"], {}).get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)
-            ),
-            "day_threshold": int(rules_cfg.get(r["id"], {}).get("day_threshold", DEFAULT_DAY_THRESHOLD)),
-            "evening_threshold": int(rules_cfg.get(r["id"], {}).get("evening_threshold", DEFAULT_EVENING_THRESHOLD)),
-            "weekend_threshold": int(rules_cfg.get(r["id"], {}).get("weekend_threshold", DEFAULT_WEEKEND_THRESHOLD)),
-            "alerting_gap_minutes": int(rules_cfg.get(r["id"], {}).get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
-            "email_alerts_enabled": rules_cfg.get(r["id"], {}).get("email_alerts_enabled", False),
-        }
-        for r in _all_known_rules(rules_cfg)
-    ]
+    result = []
+    for r in _all_known_rules(rules_cfg):
+        rcfg = rules_cfg.get(r["id"], {})
+        # Legacy configs store a single ``threshold``; use it as fallback for all periods.
+        legacy = rcfg.get("threshold", None)
+        result.append(
+            {
+                "id": r["id"],
+                "display_name": rcfg.get("display_name") or r.get("display_name", r["id"]),
+                "alarm_enabled": rcfg.get("alarm_enabled", False),
+                "workflow_id": rcfg.get("workflow_id", r.get("workflow_id", "")),
+                "window_duration_minutes": int(rcfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
+                "day_threshold": int(rcfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD)),
+                "evening_threshold": int(rcfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD)),
+                "weekend_threshold": int(rcfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD)),
+                "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
+                "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
+            }
+        )
+    return result

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -498,8 +498,12 @@ def _build_row(
         "window_duration_minutes": window,
         "window_label": _window_label(window),
         "day_threshold": int(rule_cfg.get("day_threshold", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
-        "evening_threshold": int(rule_cfg.get("evening_threshold", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))),
-        "weekend_threshold": int(rule_cfg.get("weekend_threshold", rule_cfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))),
+        "evening_threshold": int(
+            rule_cfg.get("evening_threshold", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
+        ),
+        "weekend_threshold": int(
+            rule_cfg.get("weekend_threshold", rule_cfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))
+        ),
         "current_period": period,
         "period_threshold": period_threshold,
         "period_short_label": PERIOD_SHORT_LABELS.get(period, period.title()),
@@ -568,9 +572,15 @@ def get_alarm2_config_page_data() -> list[dict]:
                 "alarm_enabled": rcfg.get("alarm_enabled", False),
                 "workflow_id": rcfg.get("workflow_id", r.get("workflow_id", "")),
                 "window_duration_minutes": int(rcfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
-                "day_threshold": int(rcfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD)),
-                "evening_threshold": int(rcfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD)),
-                "weekend_threshold": int(rcfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD)),
+                "day_threshold": int(
+                    rcfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD)
+                ),
+                "evening_threshold": int(
+                    rcfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD)
+                ),
+                "weekend_threshold": int(
+                    rcfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD)
+                ),
                 "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
                 "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
             }

--- a/dashboard/dashboard/services/alarm_time_utils.py
+++ b/dashboard/dashboard/services/alarm_time_utils.py
@@ -55,7 +55,7 @@ def get_current_period(now: datetime) -> str:
 
 PERIOD_LABELS: dict[str, str] = {
     "day": "Day (Mon–Fri 08:00–17:00 UTC)",
-    "evening": "Evening (Mon–Thu 17:00–08:00 + Fri 08:00–17:00 UTC)",
+    "evening": "Evening (Mon–Fri 17:00–08:00 UTC; excluding Weekend)",
     "weekend": "Weekend (Fri 17:00–Mon 08:00 UTC)",
 }
 

--- a/dashboard/dashboard/services/alarm_time_utils.py
+++ b/dashboard/dashboard/services/alarm_time_utils.py
@@ -20,7 +20,7 @@ def get_current_period(now: datetime) -> str:
 
     Weekend : Friday 17:00 → Monday 08:00 (UTC)
     Day     : Monday–Friday 08:00–17:00 (UTC)
-    Evening : Monday–Thursday 17:00–08:00 + Friday 08:00–17:00 (UTC)
+    Evening : Monday–Friday 17:00–08:00 (UTC), excluding the Weekend window
 
     Args:
         now: A timezone-aware or naive (UTC) datetime to evaluate.

--- a/dashboard/dashboard/services/alarm_time_utils.py
+++ b/dashboard/dashboard/services/alarm_time_utils.py
@@ -1,0 +1,62 @@
+"""Shared time-period utilities for the Integration Hub alarm services.
+
+Provides a single, canonical implementation of the time-period classification
+logic used by alarms that need to vary their thresholds across Day, Evening,
+and Weekend windows.
+
+Time windows (all UTC):
+    Weekend : Friday 17:00 → Monday 08:00
+    Day     : Monday–Friday 08:00–17:00
+    Evening : all other times (Mon–Fri outside day hours)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def get_current_period(now: datetime) -> str:
+    """Return the current time period: ``'day'``, ``'evening'``, or ``'weekend'``.
+
+    Weekend : Friday 17:00 → Monday 08:00 (UTC)
+    Day     : Monday–Friday 08:00–17:00 (UTC)
+    Evening : Monday–Friday 17:00–08:00, excluding weekend window (UTC)
+
+    Args:
+        now: A timezone-aware (or naive UTC) datetime to evaluate.
+
+    Returns:
+        One of ``'day'``, ``'evening'``, or ``'weekend'``.
+    """
+    weekday = now.weekday()  # 0 = Monday … 4 = Friday, 5 = Sat, 6 = Sun
+    time_mins = now.hour * 60 + now.minute
+    DAY_START = 8 * 60  # 08:00
+    DAY_END = 17 * 60  # 17:00
+
+    # Weekend window: Fri 17:00 → Mon 08:00
+    if weekday == 4 and time_mins >= DAY_END:  # Friday after 17:00
+        return "weekend"
+    if weekday in (5, 6):  # Saturday, Sunday
+        return "weekend"
+    if weekday == 0 and time_mins < DAY_START:  # Monday before 08:00
+        return "weekend"
+
+    # Day window: Mon–Fri 08:00–17:00
+    if 0 <= weekday <= 4 and DAY_START <= time_mins < DAY_END:
+        return "day"
+
+    # Everything else is evening
+    return "evening"
+
+
+PERIOD_LABELS: dict[str, str] = {
+    "day": "Day (Mon–Fri 08:00–17:00 UTC)",
+    "evening": "Evening (Mon–Fri 17:00–08:00 UTC)",
+    "weekend": "Weekend (Fri 17:00–Mon 08:00 UTC)",
+}
+
+PERIOD_SHORT_LABELS: dict[str, str] = {
+    "day": "Day",
+    "evening": "Evening",
+    "weekend": "Weekend",
+}

--- a/dashboard/dashboard/services/alarm_time_utils.py
+++ b/dashboard/dashboard/services/alarm_time_utils.py
@@ -12,7 +12,7 @@ Time windows (all UTC):
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def get_current_period(now: datetime) -> str:
@@ -20,14 +20,18 @@ def get_current_period(now: datetime) -> str:
 
     Weekend : Friday 17:00 → Monday 08:00 (UTC)
     Day     : Monday–Friday 08:00–17:00 (UTC)
-    Evening : Monday–Friday 17:00–08:00, excluding weekend window (UTC)
+    Evening : Monday–Thursday 17:00–08:00 + Friday 08:00–17:00 (UTC)
 
     Args:
-        now: A timezone-aware (or naive UTC) datetime to evaluate.
+        now: A timezone-aware or naive (UTC) datetime to evaluate.
+             Timezone-aware datetimes are normalised to UTC before classification.
 
     Returns:
         One of ``'day'``, ``'evening'``, or ``'weekend'``.
     """
+    # Normalise to UTC so non-UTC aware datetimes are classified correctly.
+    if now.tzinfo is not None:
+        now = now.astimezone(timezone.utc)
     weekday = now.weekday()  # 0 = Monday … 4 = Friday, 5 = Sat, 6 = Sun
     time_mins = now.hour * 60 + now.minute
     DAY_START = 8 * 60  # 08:00
@@ -51,7 +55,7 @@ def get_current_period(now: datetime) -> str:
 
 PERIOD_LABELS: dict[str, str] = {
     "day": "Day (Mon–Fri 08:00–17:00 UTC)",
-    "evening": "Evening (Mon–Fri 17:00–08:00 UTC)",
+    "evening": "Evening (Mon–Thu 17:00–08:00 + Fri 08:00–17:00 UTC)",
     "weekend": "Weekend (Fri 17:00–Mon 08:00 UTC)",
 }
 

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -195,7 +195,12 @@
 
             <td style="font-size:0.82rem; color:var(--text-muted); white-space:nowrap;">
               &lt;= {{ row.period_threshold }}
-              <span class="a2-period-badge a2-badge-{{ row.current_period }}">{{ row.period_short_label }}</span>
+              <span class="a2-period-badge a2-badge-{{ row.current_period }}">
+                {%- if row.current_period == 'day' %}{{ _("Day") }}
+                {%- elif row.current_period == 'evening' %}{{ _("Evening") }}
+                {%- else %}{{ _("Weekend") }}
+                {%- endif -%}
+              </span>
             </td>
 
             <td style="font-size:0.82rem; color:var(--text-muted);">

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -193,8 +193,9 @@
               {% endif %}
             </td>
 
-            <td style="font-size:0.82rem; color:var(--text-muted);">
-              &lt;= {{ row.threshold }}
+            <td style="font-size:0.82rem; color:var(--text-muted); white-space:nowrap;">
+              &lt;= {{ row.period_threshold }}
+              <span class="a2-period-badge a2-badge-{{ row.current_period }}">{{ row.period_short_label }}</span>
             </td>
 
             <td style="font-size:0.82rem; color:var(--text-muted);">
@@ -276,6 +277,21 @@
     vertical-align: middle;
   }
   .dash-table tbody tr:hover { background: rgba(255,255,255,0.025); }
+
+  .a2-period-badge {
+    display: inline-block;
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    margin-left: 0.3rem;
+    vertical-align: middle;
+  }
+  .a2-badge-day     { background: rgba(18,163,201,0.15); color: var(--accent-cyan); }
+  .a2-badge-evening { background: rgba(248,202,77,0.15);  color: var(--accent-amber); }
+  .a2-badge-weekend { background: rgba(99,102,241,0.15);  color: #818cf8; }
 
   .alarm-row--critical {
     background: rgba(239,68,68,0.04);

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -45,7 +45,7 @@
         {{ _("over the configured") }} <strong>{{ _("Window") }}</strong>.
         {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period") }}
         (<strong>{{ _("Day") }}</strong> Mon–Fri 08:00–17:00 /
-         <strong>{{ _("Evening") }}</strong> Mon–Thu 17:00–08:00 + Fri 08:00–17:00 /
+         <strong>{{ _("Evening") }}</strong> Mon–Fri 17:00–08:00 (excluding Weekend) /
          <strong>{{ _("Weekend") }}</strong> Fri 17:00–Mon 08:00 UTC).
         {{ _("Once fired, it will not re-fire until the") }} <strong>{{ _("Alerting Gap") }}</strong> {{ _("has elapsed.") }}
       </div>

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -43,11 +43,17 @@
         {{ _("The alarm queries") }} <code>AppMetrics</code> {{ _("in Log Analytics for the") }} <code>messages_sent</code>
         {{ _("metric, filtered by") }} <strong>{{ _("Workflow ID") }}</strong>
         {{ _("over the configured") }} <strong>{{ _("Window") }}</strong>.
-        {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period") }}
-        (<strong>{{ _("Day") }}</strong> Mon–Fri 08:00–17:00 /
-         <strong>{{ _("Evening") }}</strong> Mon–Fri 17:00–08:00 (excluding Weekend) /
-         <strong>{{ _("Weekend") }}</strong> Fri 17:00–Mon 08:00 UTC).
+        {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period.") }}
         {{ _("Once fired, it will not re-fire until the") }} <strong>{{ _("Alerting Gap") }}</strong> {{ _("has elapsed.") }}
+        <div class="mt-2 d-flex gap-4 flex-wrap" style="font-size:0.75rem;">
+          <span><i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
+            <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 08:00\u201317:00") }}</span>
+          <span><i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
+            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00") }}</span>
+          <span><i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
+            <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 08:00") }}</span>
+        </div>
+        
       </div>
     </div>
   </div>

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -45,7 +45,7 @@
         {{ _("over the configured") }} <strong>{{ _("Window") }}</strong>.
         {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period") }}
         (<strong>{{ _("Day") }}</strong> Mon–Fri 08:00–17:00 /
-         <strong>{{ _("Evening") }}</strong> Mon–Fri 17:00–08:00 /
+         <strong>{{ _("Evening") }}</strong> Mon–Thu 17:00–08:00 + Fri 08:00–17:00 /
          <strong>{{ _("Weekend") }}</strong> Fri 17:00–Mon 08:00 UTC).
         {{ _("Once fired, it will not re-fire until the") }} <strong>{{ _("Alerting Gap") }}</strong> {{ _("has elapsed.") }}
       </div>

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -43,7 +43,10 @@
         {{ _("The alarm queries") }} <code>AppMetrics</code> {{ _("in Log Analytics for the") }} <code>messages_sent</code>
         {{ _("metric, filtered by") }} <strong>{{ _("Workflow ID") }}</strong>
         {{ _("over the configured") }} <strong>{{ _("Window") }}</strong>.
-        {{ _("It fires when the total count of messages sent is at or below the") }} <strong>{{ _("Threshold") }}</strong>.
+        {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period") }}
+        (<strong>{{ _("Day") }}</strong> Mon–Fri 08:00–17:00 /
+         <strong>{{ _("Evening") }}</strong> Mon–Fri 17:00–08:00 /
+         <strong>{{ _("Weekend") }}</strong> Fri 17:00–Mon 08:00 UTC).
         {{ _("Once fired, it will not re-fire until the") }} <strong>{{ _("Alerting Gap") }}</strong> {{ _("has elapsed.") }}
       </div>
     </div>
@@ -159,20 +162,31 @@
             <div class="cfg-hint">{{ _("Time window for the messages_sent query (e.g. 2880 = 2 days)") }}</div>
           </div>
 
-          <!-- Threshold -->
+          <!-- Thresholds (Day / Evening / Weekend) -->
           <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="threshold_{{ r.id }}">
+            <label class="cfg-label">
               <i class="bi bi-arrow-down-circle me-1" style="color:var(--accent-red)"></i>
-              {{ _("Threshold") }}
+              {{ _("Thresholds") }}
             </label>
-            <div class="cfg-input-row">
+            <div class="d-flex align-items-center gap-1 flex-wrap">
+              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
               <input type="number" class="dash-input cfg-num"
-                     id="threshold_{{ r.id }}" name="threshold_{{ r.id }}"
-                     value="{{ r.threshold }}"
+                     id="day_threshold_{{ r.id }}" name="day_threshold_{{ r.id }}"
+                     value="{{ r.day_threshold }}"
+                     min="0" max="9999999" step="1">
+              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <input type="number" class="dash-input cfg-num"
+                     id="evening_threshold_{{ r.id }}" name="evening_threshold_{{ r.id }}"
+                     value="{{ r.evening_threshold }}"
+                     min="0" max="9999999" step="1">
+              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <input type="number" class="dash-input cfg-num"
+                     id="weekend_threshold_{{ r.id }}" name="weekend_threshold_{{ r.id }}"
+                     value="{{ r.weekend_threshold }}"
                      min="0" max="9999999" step="1">
               <span class="cfg-unit">msgs</span>
             </div>
-            <div class="cfg-hint">{{ _("Alarm fires when messages sent &lt;= this value") }}</div>
+            <div class="cfg-hint">{{ _("Alarm fires when messages sent &lt;= threshold for the current period") }}</div>
           </div>
 
           <!-- Alerting gap -->
@@ -264,13 +278,22 @@
           </div>
 
           <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="new_threshold">
+            <label class="cfg-label">
               <i class="bi bi-arrow-down-circle me-1" style="color:var(--accent-red)"></i>
-              {{ _("Threshold") }}
+              {{ _("Thresholds") }}
             </label>
-            <div class="cfg-input-row">
+            <div class="d-flex align-items-center gap-1 flex-wrap">
+              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
               <input type="number" class="dash-input cfg-num"
-                     id="new_threshold" name="new_threshold"
+                     id="new_day_threshold" name="new_day_threshold"
+                     value="0" min="0" max="9999999" step="1">
+              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <input type="number" class="dash-input cfg-num"
+                     id="new_evening_threshold" name="new_evening_threshold"
+                     value="0" min="0" max="9999999" step="1">
+              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <input type="number" class="dash-input cfg-num"
+                     id="new_weekend_threshold" name="new_weekend_threshold"
                      value="0" min="0" max="9999999" step="1">
               <span class="cfg-unit">msgs</span>
             </div>
@@ -336,8 +359,20 @@
     align-items: center;
     gap: 0.4rem;
   }
-  .cfg-num { width: 88px; text-align: right; }
+  .cfg-num { width: 76px; text-align: right; }
   .cfg-unit { font-size: 0.78rem; color: var(--text-muted); }
+  .cfg-period-badge {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+  .badge-day  { background: rgba(18,163,201,0.15); color: var(--accent-cyan); }
+  .badge-eve  { background: rgba(248,202,77,0.15);  color: var(--accent-amber); }
+  .badge-wkd  { background: rgba(99,102,241,0.15);  color: #818cf8; }
   .btn-dash--primary {
     background: var(--accent-cyan);
     color: #fff;

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -169,17 +169,17 @@
               {{ _("Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
-              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
+              <label for="day_threshold_{{ r.id }}" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="day_threshold_{{ r.id }}" name="day_threshold_{{ r.id }}"
                      value="{{ r.day_threshold }}"
                      min="0" max="9999999" step="1">
-              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <label for="evening_threshold_{{ r.id }}" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="evening_threshold_{{ r.id }}" name="evening_threshold_{{ r.id }}"
                      value="{{ r.evening_threshold }}"
                      min="0" max="9999999" step="1">
-              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <label for="weekend_threshold_{{ r.id }}" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="weekend_threshold_{{ r.id }}" name="weekend_threshold_{{ r.id }}"
                      value="{{ r.weekend_threshold }}"
@@ -283,15 +283,15 @@
               {{ _("Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
-              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
+              <label for="new_day_threshold" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_day_threshold" name="new_day_threshold"
                      value="0" min="0" max="9999999" step="1">
-              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <label for="new_evening_threshold" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_evening_threshold" name="new_evening_threshold"
                      value="0" min="0" max="9999999" step="1">
-              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <label for="new_weekend_threshold" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_weekend_threshold" name="new_weekend_threshold"
                      value="0" min="0" max="9999999" step="1">

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -160,17 +160,17 @@
               {{ _("Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
-              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
+              <label for="day_threshold_{{ s.id }}" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="day_threshold_{{ s.id }}" name="day_threshold_{{ s.id }}"
                      value="{{ s.day_threshold_minutes }}"
                      min="1" max="44640" step="1">
-              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <label for="evening_threshold_{{ s.id }}" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="evening_threshold_{{ s.id }}" name="evening_threshold_{{ s.id }}"
                      value="{{ s.evening_threshold_minutes }}"
                      min="1" max="44640" step="1">
-              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <label for="weekend_threshold_{{ s.id }}" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="weekend_threshold_{{ s.id }}" name="weekend_threshold_{{ s.id }}"
                      value="{{ s.weekend_threshold_minutes }}"
@@ -261,15 +261,15 @@
               {{ _("Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
-              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
+              <label for="new_day_threshold" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_day_threshold" name="new_day_threshold"
                      value="60" min="1" max="44640" step="1">
-              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
+              <label for="new_evening_threshold" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_evening_threshold" name="new_evening_threshold"
                      value="120" min="1" max="44640" step="1">
-              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
+              <label for="new_weekend_threshold" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_weekend_threshold" name="new_weekend_threshold"
                      value="240" min="1" max="44640" step="1">

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -48,7 +48,7 @@
           <span><i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
             <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 08:00\u201317:00") }}</span>
           <span><i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00 + Fri 08:00–17:00") }}</span>
+            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00") }}</span>
           <span><i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
             <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 08:00") }}</span>
         </div>

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -153,52 +153,31 @@
             <div class="cfg-hint">parse_json(Properties)["workflow_id"] filter value</div>
           </div>
 
-          <!-- Day threshold -->
+          <!-- Thresholds (Day / Evening / Weekend) -->
           <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="day_threshold_{{ s.id }}">
-              <i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
-              {{ _("Day Threshold") }}
+            <label class="cfg-label">
+              <i class="bi bi-clock-fill me-1" style="color:var(--accent-amber)"></i>
+              {{ _("Thresholds") }}
             </label>
-            <div class="cfg-input-row">
+            <div class="d-flex align-items-center gap-1 flex-wrap">
+              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="day_threshold_{{ s.id }}" name="day_threshold_{{ s.id }}"
                      value="{{ s.day_threshold_minutes }}"
                      min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-            <div class="cfg-hint">{{ _("No messages for this long (Mon\u2013Fri 08:00\u201317:00) \u2192 alarm fires") }}</div>
-          </div>
-
-          <!-- Evening threshold -->
-          <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="evening_threshold_{{ s.id }}">
-              <i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-              {{ _("Evening Threshold") }}
-            </label>
-            <div class="cfg-input-row">
+              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="evening_threshold_{{ s.id }}" name="evening_threshold_{{ s.id }}"
                      value="{{ s.evening_threshold_minutes }}"
                      min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-            <div class="cfg-hint">{{ _("No messages for this long (Mon\u2013Fri 17:00\u201308:00) \u2192 alarm fires") }}</div>
-          </div>
-
-          <!-- Weekend threshold -->
-          <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="weekend_threshold_{{ s.id }}">
-              <i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
-              {{ _("Weekend Threshold") }}
-            </label>
-            <div class="cfg-input-row">
+              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="weekend_threshold_{{ s.id }}" name="weekend_threshold_{{ s.id }}"
                      value="{{ s.weekend_threshold_minutes }}"
                      min="1" max="44640" step="1">
               <span class="cfg-unit">{{ _("min") }}</span>
             </div>
-            <div class="cfg-hint">{{ _("No messages for this long (Fri 17:00\u2013Mon 08:00) \u2192 alarm fires") }}</div>
+            <div class="cfg-hint">{{ _("Inactivity duration before alarm fires for the current time period") }}</div>
           </div>
 
           <!-- Alerting gap -->
@@ -277,37 +256,20 @@
           </div>
 
           <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="new_day_threshold">
-              <i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
-              {{ _("Day Threshold") }}
+            <label class="cfg-label">
+              <i class="bi bi-clock-fill me-1" style="color:var(--accent-amber)"></i>
+              {{ _("Thresholds") }}
             </label>
-            <div class="cfg-input-row">
+            <div class="d-flex align-items-center gap-1 flex-wrap">
+              <span class="cfg-period-badge badge-day">{{ _("Day") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="new_day_threshold" name="new_day_threshold"
                      value="60" min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-          </div>
-
-          <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="new_evening_threshold">
-              <i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-              {{ _("Evening Threshold") }}
-            </label>
-            <div class="cfg-input-row">
+              <span class="cfg-period-badge badge-eve">{{ _("Eve") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="new_evening_threshold" name="new_evening_threshold"
                      value="120" min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-          </div>
-
-          <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="new_weekend_threshold">
-              <i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
-              {{ _("Weekend Threshold") }}
-            </label>
-            <div class="cfg-input-row">
+              <span class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</span>
               <input type="number" class="dash-input cfg-num"
                      id="new_weekend_threshold" name="new_weekend_threshold"
                      value="240" min="1" max="44640" step="1">
@@ -414,8 +376,20 @@
     align-items: center;
     gap: 0.4rem;
   }
-  .cfg-num { width: 88px; text-align: right; }
+  .cfg-num { width: 76px; text-align: right; }
   .cfg-unit { font-size: 0.78rem; color: var(--text-muted); }
+  .cfg-period-badge {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+  .badge-day  { background: rgba(18,163,201,0.15); color: var(--accent-cyan); }
+  .badge-eve  { background: rgba(248,202,77,0.15);  color: var(--accent-amber); }
+  .badge-wkd  { background: rgba(99,102,241,0.15);  color: #818cf8; }
   .btn-dash--primary {
     background: var(--accent-cyan);
     color: #fff;

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -48,7 +48,7 @@
           <span><i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
             <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 08:00\u201317:00") }}</span>
           <span><i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-            <strong>{{ _("Evening") }}</strong>: {{ _("Mon\u2013Fri 17:00\u201308:00") }}</span>
+            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00 + Fri 08:00–17:00") }}</span>
           <span><i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
             <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 08:00") }}</span>
         </div>

--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -11,16 +11,12 @@ Tests cover:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from dashboard.services.alarm2 import (
-    DEFAULT_ALERTING_GAP,
     DEFAULT_DAY_THRESHOLD,
     DEFAULT_EVENING_THRESHOLD,
     DEFAULT_WEEKEND_THRESHOLD,
-    DEFAULT_WINDOW_MINUTES,
     _applicable_threshold,
     _build_row,
     _window_label,
@@ -43,10 +39,10 @@ def _utc(weekday_offset: int, hour: int) -> datetime:
     return datetime(2026, 6, base_day, hour, 0, tzinfo=timezone.utc)
 
 
-MON_DAY = _utc(0, 12)       # Monday 12:00 UTC → day
-MON_EVE = _utc(0, 18)       # Monday 18:00 UTC → evening
-FRI_EVE = _utc(4, 18)       # Friday 18:00 UTC → weekend
-SAT_MID = _utc(5, 12)       # Saturday 12:00 UTC → weekend
+MON_DAY = _utc(0, 12)  # Monday 12:00 UTC → day
+MON_EVE = _utc(0, 18)  # Monday 18:00 UTC → evening
+FRI_EVE = _utc(4, 18)  # Friday 18:00 UTC → weekend
+SAT_MID = _utc(5, 12)  # Saturday 12:00 UTC → weekend
 
 
 # ---------------------------------------------------------------------------
@@ -120,8 +116,9 @@ class TestBuildRow:
 
     def _row(self, now: datetime, **overrides) -> dict:
         cfg = {**self._CFG, **overrides}
-        return _build_row("phw-to-mpi-outgoing", self._SEED, cfg, total=100, status="healthy",
-                          cooldown_remaining=None, now=now)
+        return _build_row(
+            "phw-to-mpi-outgoing", self._SEED, cfg, total=100, status="healthy", cooldown_remaining=None, now=now
+        )
 
     def test_period_threshold_matches_day(self) -> None:
         row = self._row(MON_DAY)
@@ -146,10 +143,21 @@ class TestBuildRow:
 
     def test_legacy_threshold_fallback_in_display_fields(self) -> None:
         """Rows built from legacy config expose the legacy value for all three fields."""
-        legacy_cfg = {"threshold": 77, "workflow_id": "phw-to-mpi",
-                      "window_duration_minutes": 1440, "alerting_gap_minutes": 60}
-        row = _build_row("phw-to-mpi-outgoing", self._SEED, legacy_cfg, total=50, status="healthy",
-                         cooldown_remaining=None, now=MON_DAY)
+        legacy_cfg = {
+            "threshold": 77,
+            "workflow_id": "phw-to-mpi",
+            "window_duration_minutes": 1440,
+            "alerting_gap_minutes": 60,
+        }
+        row = _build_row(
+            "phw-to-mpi-outgoing",
+            self._SEED,
+            legacy_cfg,
+            total=50,
+            status="healthy",
+            cooldown_remaining=None,
+            now=MON_DAY,
+        )
         assert row["day_threshold"] == 77
         assert row["evening_threshold"] == 77
         assert row["weekend_threshold"] == 77
@@ -160,8 +168,15 @@ class TestBuildRow:
         assert row["messages_display"] == "100"
 
     def test_messages_display_dash_when_none(self) -> None:
-        row = _build_row("phw-to-mpi-outgoing", self._SEED, self._CFG, total=None, status="unknown",
-                         cooldown_remaining=None, now=MON_DAY)
+        row = _build_row(
+            "phw-to-mpi-outgoing",
+            self._SEED,
+            self._CFG,
+            total=None,
+            status="unknown",
+            cooldown_remaining=None,
+            now=MON_DAY,
+        )
         assert row["messages_display"] == "—"
 
     def test_status_preserved(self) -> None:
@@ -217,7 +232,7 @@ class TestGetAlarm2ConfigPageData:
                 "phw-to-mpi-outgoing": {
                     "alarm_enabled": True,
                     "workflow_id": "phw-to-mpi",
-                    "threshold": 42,          # Legacy single value
+                    "threshold": 42,  # Legacy single value
                     "window_duration_minutes": 1440,
                     "alerting_gap_minutes": 60,
                 }

--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -1,0 +1,286 @@
+"""Unit tests for Alarm 2 service logic.
+
+Tests cover:
+  - _applicable_threshold()  : period selection and legacy config fallback
+  - _build_row()             : per-period threshold display fields and legacy fallback
+  - get_alarm2_config_page_data() : legacy 'threshold' fallback for all three periods
+  - _window_label()          : minute-to-label formatting
+  - generate_rule_id()       : unique ID generation
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dashboard.services.alarm2 import (
+    DEFAULT_ALERTING_GAP,
+    DEFAULT_DAY_THRESHOLD,
+    DEFAULT_EVENING_THRESHOLD,
+    DEFAULT_WEEKEND_THRESHOLD,
+    DEFAULT_WINDOW_MINUTES,
+    _applicable_threshold,
+    _build_row,
+    _window_label,
+    generate_rule_id,
+    get_alarm2_config_page_data,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(weekday_offset: int, hour: int) -> datetime:
+    """Return a UTC datetime for a specific weekday in the anchor week (2026-06-22 = Mon).
+
+    weekday_offset 0=Mon … 4=Fri, 5=Sat, 6=Sun
+    """
+    # Monday anchor
+    base_day = 22 + weekday_offset
+    return datetime(2026, 6, base_day, hour, 0, tzinfo=timezone.utc)
+
+
+MON_DAY = _utc(0, 12)       # Monday 12:00 UTC → day
+MON_EVE = _utc(0, 18)       # Monday 18:00 UTC → evening
+FRI_EVE = _utc(4, 18)       # Friday 18:00 UTC → weekend
+SAT_MID = _utc(5, 12)       # Saturday 12:00 UTC → weekend
+
+
+# ---------------------------------------------------------------------------
+# _applicable_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestApplicableThreshold:
+    """Threshold selection by current period, with legacy fallback."""
+
+    def test_returns_day_threshold_during_day(self) -> None:
+        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        assert _applicable_threshold(cfg, MON_DAY) == 50
+
+    def test_returns_evening_threshold_during_evening(self) -> None:
+        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        assert _applicable_threshold(cfg, MON_EVE) == 20
+
+    def test_returns_weekend_threshold_during_weekend(self) -> None:
+        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        assert _applicable_threshold(cfg, SAT_MID) == 5
+
+    def test_legacy_threshold_used_as_day_fallback(self) -> None:
+        """Old config with only 'threshold' key → all periods fall back to that value."""
+        cfg = {"threshold": 99}
+        assert _applicable_threshold(cfg, MON_DAY) == 99
+
+    def test_legacy_threshold_used_as_evening_fallback(self) -> None:
+        cfg = {"threshold": 99}
+        assert _applicable_threshold(cfg, MON_EVE) == 99
+
+    def test_legacy_threshold_used_as_weekend_fallback(self) -> None:
+        cfg = {"threshold": 99}
+        assert _applicable_threshold(cfg, SAT_MID) == 99
+
+    def test_per_period_takes_precedence_over_legacy(self) -> None:
+        """Explicit per-period key wins over legacy 'threshold'."""
+        cfg = {"threshold": 99, "day_threshold": 10}
+        assert _applicable_threshold(cfg, MON_DAY) == 10
+
+    def test_missing_config_returns_default(self) -> None:
+        assert _applicable_threshold({}, MON_DAY) == DEFAULT_DAY_THRESHOLD
+        assert _applicable_threshold({}, MON_EVE) == DEFAULT_EVENING_THRESHOLD
+        assert _applicable_threshold({}, SAT_MID) == DEFAULT_WEEKEND_THRESHOLD
+
+    def test_friday_17_is_weekend(self) -> None:
+        """Friday 17:00 should be classified as weekend (priority rule)."""
+        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        fri_17 = datetime(2026, 6, 26, 17, 0, tzinfo=timezone.utc)
+        assert _applicable_threshold(cfg, fri_17) == 5
+
+
+# ---------------------------------------------------------------------------
+# _build_row
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRow:
+    """_build_row() assembles the status dict shown in the alarm 2 table."""
+
+    _SEED = {"id": "phw-to-mpi-outgoing", "display_name": "PHW → MPI Outgoing", "workflow_id": "phw-to-mpi"}
+    _CFG = {
+        "display_name": "PHW → MPI Outgoing",
+        "workflow_id": "phw-to-mpi",
+        "day_threshold": 30,
+        "evening_threshold": 15,
+        "weekend_threshold": 5,
+        "window_duration_minutes": 1440,
+        "alerting_gap_minutes": 60,
+    }
+
+    def _row(self, now: datetime, **overrides) -> dict:
+        cfg = {**self._CFG, **overrides}
+        return _build_row("phw-to-mpi-outgoing", self._SEED, cfg, total=100, status="healthy",
+                          cooldown_remaining=None, now=now)
+
+    def test_period_threshold_matches_day(self) -> None:
+        row = self._row(MON_DAY)
+        assert row["current_period"] == "day"
+        assert row["period_threshold"] == 30
+
+    def test_period_threshold_matches_evening(self) -> None:
+        row = self._row(MON_EVE)
+        assert row["current_period"] == "evening"
+        assert row["period_threshold"] == 15
+
+    def test_period_threshold_matches_weekend(self) -> None:
+        row = self._row(SAT_MID)
+        assert row["current_period"] == "weekend"
+        assert row["period_threshold"] == 5
+
+    def test_all_three_threshold_fields_present(self) -> None:
+        row = self._row(MON_DAY)
+        assert row["day_threshold"] == 30
+        assert row["evening_threshold"] == 15
+        assert row["weekend_threshold"] == 5
+
+    def test_legacy_threshold_fallback_in_display_fields(self) -> None:
+        """Rows built from legacy config expose the legacy value for all three fields."""
+        legacy_cfg = {"threshold": 77, "workflow_id": "phw-to-mpi",
+                      "window_duration_minutes": 1440, "alerting_gap_minutes": 60}
+        row = _build_row("phw-to-mpi-outgoing", self._SEED, legacy_cfg, total=50, status="healthy",
+                         cooldown_remaining=None, now=MON_DAY)
+        assert row["day_threshold"] == 77
+        assert row["evening_threshold"] == 77
+        assert row["weekend_threshold"] == 77
+
+    def test_messages_display_formats_with_commas(self) -> None:
+        row = self._row(MON_DAY, **{})
+        # total=100 passed above
+        assert row["messages_display"] == "100"
+
+    def test_messages_display_dash_when_none(self) -> None:
+        row = _build_row("phw-to-mpi-outgoing", self._SEED, self._CFG, total=None, status="unknown",
+                         cooldown_remaining=None, now=MON_DAY)
+        assert row["messages_display"] == "—"
+
+    def test_status_preserved(self) -> None:
+        row = self._row(MON_DAY)
+        assert row["status"] == "healthy"
+
+    def test_period_short_label_day(self) -> None:
+        row = self._row(MON_DAY)
+        assert row["period_short_label"] == "Day"
+
+    def test_period_short_label_evening(self) -> None:
+        row = self._row(MON_EVE)
+        assert row["period_short_label"] == "Evening"
+
+    def test_period_short_label_weekend(self) -> None:
+        row = self._row(SAT_MID)
+        assert row["period_short_label"] == "Weekend"
+
+
+# ---------------------------------------------------------------------------
+# get_alarm2_config_page_data — legacy fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGetAlarm2ConfigPageData:
+    """Config page data builder correctly handles both new-style and legacy configs."""
+
+    def test_new_style_config_returns_per_period_values(self) -> None:
+        fake_cfg = {
+            "rules": {
+                "phw-to-mpi-outgoing": {
+                    "alarm_enabled": True,
+                    "workflow_id": "phw-to-mpi",
+                    "day_threshold": 10,
+                    "evening_threshold": 5,
+                    "weekend_threshold": 2,
+                    "window_duration_minutes": 1440,
+                    "alerting_gap_minutes": 60,
+                }
+            }
+        }
+        with patch("dashboard.services.alarm2.load_alarm2_config", return_value=fake_cfg):
+            data = get_alarm2_config_page_data()
+
+        rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
+        assert rule["day_threshold"] == 10
+        assert rule["evening_threshold"] == 5
+        assert rule["weekend_threshold"] == 2
+
+    def test_legacy_config_fans_out_threshold_to_all_periods(self) -> None:
+        fake_cfg = {
+            "rules": {
+                "phw-to-mpi-outgoing": {
+                    "alarm_enabled": True,
+                    "workflow_id": "phw-to-mpi",
+                    "threshold": 42,          # Legacy single value
+                    "window_duration_minutes": 1440,
+                    "alerting_gap_minutes": 60,
+                }
+            }
+        }
+        with patch("dashboard.services.alarm2.load_alarm2_config", return_value=fake_cfg):
+            data = get_alarm2_config_page_data()
+
+        rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
+        assert rule["day_threshold"] == 42
+        assert rule["evening_threshold"] == 42
+        assert rule["weekend_threshold"] == 42
+
+    def test_missing_config_returns_defaults(self) -> None:
+        with patch("dashboard.services.alarm2.load_alarm2_config", return_value={"rules": {}}):
+            data = get_alarm2_config_page_data()
+
+        rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
+        assert rule["day_threshold"] == DEFAULT_DAY_THRESHOLD
+        assert rule["evening_threshold"] == DEFAULT_EVENING_THRESHOLD
+        assert rule["weekend_threshold"] == DEFAULT_WEEKEND_THRESHOLD
+        assert rule["alarm_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# _window_label
+# ---------------------------------------------------------------------------
+
+
+class TestWindowLabel:
+    def test_minutes_below_hour(self) -> None:
+        assert _window_label(30) == "30 min"
+
+    def test_exactly_one_hour(self) -> None:
+        assert _window_label(60) == "1 hr"
+
+    def test_multiple_hours(self) -> None:
+        assert _window_label(120) == "2 hrs"
+
+    def test_exactly_one_day(self) -> None:
+        assert _window_label(1440) == "1 day"
+
+    def test_multiple_days(self) -> None:
+        assert _window_label(2880) == "2 days"
+
+
+# ---------------------------------------------------------------------------
+# generate_rule_id
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateRuleId:
+    def test_basic_id_generation(self) -> None:
+        assert generate_rule_id("phw-to-mpi", set()) == "phw-to-mpi-outgoing"
+
+    def test_avoids_duplicate_ids(self) -> None:
+        existing = {"phw-to-mpi-outgoing"}
+        assert generate_rule_id("phw-to-mpi", existing) == "phw-to-mpi-outgoing-2"
+
+    def test_increments_further_on_collision(self) -> None:
+        existing = {"phw-to-mpi-outgoing", "phw-to-mpi-outgoing-2"}
+        assert generate_rule_id("phw-to-mpi", existing) == "phw-to-mpi-outgoing-3"
+
+    def test_workflow_id_normalised_to_kebab(self) -> None:
+        rid = generate_rule_id("PHW to MPI", set())
+        assert rid == "phw-to-mpi-outgoing"

--- a/dashboard/tests/test_alarm_time_utils.py
+++ b/dashboard/tests/test_alarm_time_utils.py
@@ -1,0 +1,171 @@
+"""Unit tests for alarm_time_utils.get_current_period().
+
+All boundary cases for the three time periods:
+  Weekend : Fri 17:00 → Mon 08:00 (UTC)
+  Day     : Mon–Fri 08:00–17:00 (UTC)
+  Evening : everything else (weeknights)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dashboard.services.alarm_time_utils import get_current_period
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Return a UTC-aware datetime for the given components."""
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+# Anchor dates (all 2026):
+#   Mon 22 Jun, Tue 23 Jun, Wed 24 Jun, Thu 25 Jun, Fri 26 Jun, Sat 27 Jun, Sun 28 Jun
+MON = (2026, 6, 22)
+TUE = (2026, 6, 23)
+WED = (2026, 6, 24)
+THU = (2026, 6, 25)
+FRI = (2026, 6, 26)
+SAT = (2026, 6, 27)
+SUN = (2026, 6, 28)
+# Next Monday
+NEXT_MON = (2026, 6, 29)
+
+
+# ---------------------------------------------------------------------------
+# Weekend period
+# ---------------------------------------------------------------------------
+
+class TestWeekendPeriod:
+    """Fri 17:00 through Mon 08:00 (exclusive) is always 'weekend'."""
+
+    def test_friday_at_day_end_is_weekend(self) -> None:
+        assert get_current_period(_utc(*FRI, 17, 0)) == "weekend"
+
+    def test_friday_evening_is_weekend(self) -> None:
+        assert get_current_period(_utc(*FRI, 20, 0)) == "weekend"
+
+    def test_friday_midnight_is_weekend(self) -> None:
+        assert get_current_period(_utc(*FRI, 23, 59)) == "weekend"
+
+    def test_saturday_midnight_is_weekend(self) -> None:
+        assert get_current_period(_utc(*SAT, 0, 0)) == "weekend"
+
+    def test_saturday_midday_is_weekend(self) -> None:
+        assert get_current_period(_utc(*SAT, 12, 0)) == "weekend"
+
+    def test_sunday_midday_is_weekend(self) -> None:
+        assert get_current_period(_utc(*SUN, 12, 0)) == "weekend"
+
+    def test_monday_00_00_is_weekend(self) -> None:
+        """Mon 00:00 is still inside the Fri 17:00 → Mon 08:00 window."""
+        assert get_current_period(_utc(*NEXT_MON, 0, 0)) == "weekend"
+
+    def test_monday_07_59_is_weekend(self) -> None:
+        assert get_current_period(_utc(*NEXT_MON, 7, 59)) == "weekend"
+
+    def test_friday_16_59_is_not_weekend(self) -> None:
+        """One minute before 17:00 on Friday is still Day."""
+        assert get_current_period(_utc(*FRI, 16, 59)) == "day"
+
+    def test_monday_08_00_is_not_weekend(self) -> None:
+        """Mon 08:00 marks the start of Day — weekend ends here."""
+        assert get_current_period(_utc(*NEXT_MON, 8, 0)) == "day"
+
+
+# ---------------------------------------------------------------------------
+# Day period
+# ---------------------------------------------------------------------------
+
+class TestDayPeriod:
+    """Mon–Fri 08:00–16:59 (UTC) is 'day'."""
+
+    def test_monday_day_start(self) -> None:
+        assert get_current_period(_utc(*MON, 8, 0)) == "day"
+
+    def test_monday_midday(self) -> None:
+        assert get_current_period(_utc(*MON, 12, 0)) == "day"
+
+    def test_monday_last_minute(self) -> None:
+        assert get_current_period(_utc(*MON, 16, 59)) == "day"
+
+    def test_tuesday_midday(self) -> None:
+        assert get_current_period(_utc(*TUE, 12, 0)) == "day"
+
+    def test_wednesday_midday(self) -> None:
+        assert get_current_period(_utc(*WED, 12, 0)) == "day"
+
+    def test_thursday_midday(self) -> None:
+        assert get_current_period(_utc(*THU, 12, 0)) == "day"
+
+    def test_friday_day_start(self) -> None:
+        assert get_current_period(_utc(*FRI, 8, 0)) == "day"
+
+    def test_friday_midday(self) -> None:
+        assert get_current_period(_utc(*FRI, 12, 0)) == "day"
+
+    def test_friday_last_minute(self) -> None:
+        assert get_current_period(_utc(*FRI, 16, 59)) == "day"
+
+
+# ---------------------------------------------------------------------------
+# Evening period
+# ---------------------------------------------------------------------------
+
+class TestEveningPeriod:
+    """Weeknights (Mon–Thu 17:00 → next day 08:00) are 'evening'."""
+
+    def test_monday_17_00_is_evening(self) -> None:
+        assert get_current_period(_utc(*MON, 17, 0)) == "evening"
+
+    def test_monday_midnight_is_evening(self) -> None:
+        assert get_current_period(_utc(*MON, 23, 59)) == "evening"
+
+    def test_tuesday_00_00_is_evening(self) -> None:
+        """Tue 00:00 is the overnight tail of Mon evening."""
+        assert get_current_period(_utc(*TUE, 0, 0)) == "evening"
+
+    def test_tuesday_07_59_is_evening(self) -> None:
+        assert get_current_period(_utc(*TUE, 7, 59)) == "evening"
+
+    def test_tuesday_17_00_is_evening(self) -> None:
+        assert get_current_period(_utc(*TUE, 17, 0)) == "evening"
+
+    def test_wednesday_17_00_is_evening(self) -> None:
+        assert get_current_period(_utc(*WED, 17, 0)) == "evening"
+
+    def test_thursday_17_00_is_evening(self) -> None:
+        assert get_current_period(_utc(*THU, 17, 0)) == "evening"
+
+    def test_friday_00_00_is_evening(self) -> None:
+        """Fri 00:00–07:59 is the tail of Thu evening (not yet weekend)."""
+        assert get_current_period(_utc(*FRI, 0, 0)) == "evening"
+
+    def test_friday_07_59_is_evening(self) -> None:
+        assert get_current_period(_utc(*FRI, 7, 59)) == "evening"
+
+
+# ---------------------------------------------------------------------------
+# UTC normalisation
+# ---------------------------------------------------------------------------
+
+class TestUTCNormalisation:
+    """Timezone-aware non-UTC datetimes should be normalised before classification."""
+
+    def test_bst_aware_datetime_normalised_to_utc(self) -> None:
+        """A BST (+01:00) datetime that is 17:30 local = 16:30 UTC → 'day'."""
+        from datetime import timezone as tz
+        from datetime import timedelta
+        bst = tz(timedelta(hours=1))
+        # Tue 16 Jun 2026, 17:30 BST = 16:30 UTC → day
+        aware_bst = datetime(2026, 6, 23, 17, 30, tzinfo=bst)  # Tuesday
+        assert get_current_period(aware_bst) == "day"
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        """A naive datetime (no tzinfo) is treated as UTC."""
+        naive_midday_mon = datetime(2026, 6, 22, 12, 0)  # Monday
+        assert get_current_period(naive_midday_mon) == "day"

--- a/dashboard/tests/test_alarm_time_utils.py
+++ b/dashboard/tests/test_alarm_time_utils.py
@@ -8,15 +8,15 @@ All boundary cases for the three time periods:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
-import pytest
+from datetime import datetime, timedelta, timezone
+from datetime import timezone as tz
 
 from dashboard.services.alarm_time_utils import get_current_period
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
     """Return a UTC-aware datetime for the given components."""
@@ -39,6 +39,7 @@ NEXT_MON = (2026, 6, 29)
 # ---------------------------------------------------------------------------
 # Weekend period
 # ---------------------------------------------------------------------------
+
 
 class TestWeekendPeriod:
     """Fri 17:00 through Mon 08:00 (exclusive) is always 'weekend'."""
@@ -81,6 +82,7 @@ class TestWeekendPeriod:
 # Day period
 # ---------------------------------------------------------------------------
 
+
 class TestDayPeriod:
     """Mon–Fri 08:00–16:59 (UTC) is 'day'."""
 
@@ -115,6 +117,7 @@ class TestDayPeriod:
 # ---------------------------------------------------------------------------
 # Evening period
 # ---------------------------------------------------------------------------
+
 
 class TestEveningPeriod:
     """Weeknights (Mon–Thu 17:00 → next day 08:00) are 'evening'."""
@@ -153,13 +156,12 @@ class TestEveningPeriod:
 # UTC normalisation
 # ---------------------------------------------------------------------------
 
+
 class TestUTCNormalisation:
     """Timezone-aware non-UTC datetimes should be normalised before classification."""
 
     def test_bst_aware_datetime_normalised_to_utc(self) -> None:
         """A BST (+01:00) datetime that is 17:30 local = 16:30 UTC → 'day'."""
-        from datetime import timezone as tz
-        from datetime import timedelta
         bst = tz(timedelta(hours=1))
         # Tue 16 Jun 2026, 17:30 BST = 16:30 UTC → day
         aware_bst = datetime(2026, 6, 23, 17, 30, tzinfo=bst)  # Tuesday


### PR DESCRIPTION
This pull request introduces time-period-based thresholds for Alarm 2, allowing separate message count thresholds for Day, Evening, and Weekend periods. It refactors the backend to support these new fields, updates the logic for evaluating alarms, and enhances the UI to display and configure thresholds per time period. A shared utility for time period classification is also added.

**Backend logic and data model changes:**

* Alarm 2 rules now support three separate thresholds: `day_threshold`, `evening_threshold`, and `weekend_threshold`, replacing the single `threshold` field throughout the backend code and configuration forms. [[1]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77L1095-R1097) [[2]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77L1108-R1112) [[3]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487L42-R45) [[4]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487L536-R565)
* The logic for determining which threshold applies at any given time is centralized in a new shared utility, `alarm_time_utils.py`, which provides the `get_current_period()` function and period label mappings. [[1]](diffhunk://#diff-24aeac323cb3296ea13038fa6f8e6aa42bbadaeb0fe04e0f8bac3ec942420766R1-R62) [[2]](diffhunk://#diff-822c34542d6603729c4884cf2b88fafa3c3ce19df45f7dd12d122875142bb9abR31) [[3]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R34)
* Alarm evaluation now uses the correct threshold for the current period, and this period/threshold is passed through to email notifications and status rows. [[1]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R170-R179) [[2]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R260) [[3]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R272-R275) [[4]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487L283-R301) [[5]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487L351-R369) [[6]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R436) [[7]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R454) [[8]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R487-R500)

**User interface updates:**

* The Alarm 2 rules table now displays the current period and its associated threshold, with a colored badge indicating the active period. [[1]](diffhunk://#diff-ab19a2d079b19a2bf7b77ef4d8de86bcb8e1bde4a81c3234fe24af6eaabff0fbL196-R198) [[2]](diffhunk://#diff-ab19a2d079b19a2bf7b77ef4d8de86bcb8e1bde4a81c3234fe24af6eaabff0fbR281-R295)
* The configuration page allows users to set Day, Evening, and Weekend thresholds for each rule, with clear labeling and color-coded badges for each period. [[1]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfL46-R49) [[2]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfL162-R189) [[3]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfL267-R296) [[4]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfL339-R375)

**Code organization:**

* The time period classification logic was moved from `alarm1.py` to the new `alarm_time_utils.py` module for reuse and maintainability. [[1]](diffhunk://#diff-822c34542d6603729c4884cf2b88fafa3c3ce19df45f7dd12d122875142bb9abL90-L117) [[2]](diffhunk://#diff-24aeac323cb3296ea13038fa6f8e6aa42bbadaeb0fe04e0f8bac3ec942420766R1-R62)

These changes provide more granular control over alarm sensitivity based on the time of day and week, improving alert accuracy and flexibility.