### PR TITLE
fix: add type hint for overrides parameter in TestBuildRow class

### DIFF
--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -11,6 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import patch
 
 from dashboard.services.alarm2 import (
@@ -114,7 +115,7 @@ class TestBuildRow:
         "alerting_gap_minutes": 60,
     }
 
-    def _row(self, now: datetime, **overrides) -> dict:
+    def _row(self, now: datetime, **overrides: Any) -> dict:
         cfg = {**self._CFG, **overrides}
         return _build_row(
             "phw-to-mpi-outgoing", self._SEED, cfg, total=100, status="healthy", cooldown_remaining=None, now=now


### PR DESCRIPTION
This pull request makes minor improvements to type annotations in the test suite for `dashboard`. The changes clarify the types of function arguments to improve code readability and maintainability.

Test improvements:

* Added an explicit `Any` type annotation for `**overrides` in the `_row` method of `TestBuildRow` to clarify accepted argument types.
* Imported `Any` from the `typing` module to support the new type annotation.