### PR TITLE
Refactor Alarm Configuration and Update Time Periods

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -1091,10 +1091,9 @@ def alarm2_config_page() -> str:
             entry["email_alerts_enabled"] = f"email_{rid}" in request.form
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
-            entry["window_duration_minutes"] = _int(f"window_duration_{rid}", 2880, minimum=1)
-            entry["day_threshold"] = _int(f"day_threshold_{rid}", 0, minimum=0)
-            entry["evening_threshold"] = _int(f"evening_threshold_{rid}", 0, minimum=0)
-            entry["weekend_threshold"] = _int(f"weekend_threshold_{rid}", 0, minimum=0)
+            entry["day_threshold_minutes"] = _int(f"day_threshold_{rid}", 60, minimum=0)
+            entry["evening_threshold_minutes"] = _int(f"evening_threshold_{rid}", 120, minimum=0)
+            entry["weekend_threshold_minutes"] = _int(f"weekend_threshold_{rid}", 240, minimum=0)
             entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60, minimum=1)
 
         # --- Add new rule if submitted ---
@@ -1106,10 +1105,9 @@ def alarm2_config_page() -> str:
                 "display_name": (request.form.get("new_display_name") or "").strip() or new_wid,
                 "alarm_enabled": "new_enabled" in request.form,
                 "workflow_id": new_wid,
-                "window_duration_minutes": _int("new_window_duration", 2880, minimum=1),
-                "day_threshold": _int("new_day_threshold", 0, minimum=0),
-                "evening_threshold": _int("new_evening_threshold", 0, minimum=0),
-                "weekend_threshold": _int("new_weekend_threshold", 0, minimum=0),
+                "day_threshold_minutes": _int("new_day_threshold", 60, minimum=0),
+                "evening_threshold_minutes": _int("new_evening_threshold", 120, minimum=0),
+                "weekend_threshold_minutes": _int("new_weekend_threshold", 240, minimum=0),
                 "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
             }

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -167,7 +167,7 @@ def _parse_dt(raw: object) -> datetime | None:
 
 
 def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, datetime | None]:
-    """Query Log Analytics for the most recent MESSAGE_RECEIVED per workflow_id (30-day window)."""
+    """Query Log Analytics for the most recent MESSAGE_RECEIVED per workflow_id (3-day window)."""
     if not config.AZURE_LOG_ANALYTICS_WORKSPACE_ID or not workflow_ids:
         return {wid: None for wid in workflow_ids}
 
@@ -178,7 +178,7 @@ def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, dat
     ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
     query = f"""
     AppTraces
-    | where TimeGenerated > ago(30d)
+    | where TimeGenerated > ago(3d)
     | where Message == "Integration Hub Event"
     | where Properties contains "MESSAGE_RECEIVED"
     | extend workflow_id = tostring(parse_json(Properties)["workflow_id"])
@@ -190,7 +190,7 @@ def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, dat
         response = client.query_workspace(
             workspace_id=config.AZURE_LOG_ANALYTICS_WORKSPACE_ID,
             query=query,
-            timespan=timedelta(days=30),
+            timespan=timedelta(days=3),
         )
         if response.status != LogsQueryStatus.SUCCESS:
             log.warning("get_last_message_times_by_workflow: partial/failed query")
@@ -238,9 +238,9 @@ def _send_alarm_email(
 
     period = get_current_period(now)
     period_label = {
-        "day": "Day (Mon–Fri 08:00–17:00)",
-        "evening": "Evening (Mon–Fri 17:00–08:00)",
-        "weekend": "Weekend (Fri 17:00–Mon 08:00)",
+        "day": "Day (Mon–Fri 09:00–17:00)",
+        "evening": "Evening (Mon–Fri 17:00–09:00)",
+        "weekend": "Weekend (Fri 17:00–Mon 09:00)",
     }.get(period, period.title())
     last_msg_str = last_msg.strftime("%d %b %Y  %H:%M:%S UTC") if last_msg else "Never / unknown"
     duration_str = _format_duration(minutes_since)

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -167,7 +167,7 @@ def _parse_dt(raw: object) -> datetime | None:
 
 
 def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, datetime | None]:
-    """Query Log Analytics for the most recent MESSAGE_RECEIVED per workflow_id (3-day window)."""
+    """Query Log Analytics for the most recent MESSAGE_RECEIVED per workflow_id (30-day window)."""
     if not config.AZURE_LOG_ANALYTICS_WORKSPACE_ID or not workflow_ids:
         return {wid: None for wid in workflow_ids}
 
@@ -178,7 +178,7 @@ def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, dat
     ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
     query = f"""
     AppTraces
-    | where TimeGenerated > ago(3d)
+    | where TimeGenerated > ago(30d)
     | where Message == "Integration Hub Event"
     | where Properties contains "MESSAGE_RECEIVED"
     | extend workflow_id = tostring(parse_json(Properties)["workflow_id"])
@@ -190,7 +190,7 @@ def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, dat
         response = client.query_workspace(
             workspace_id=config.AZURE_LOG_ANALYTICS_WORKSPACE_ID,
             query=query,
-            timespan=timedelta(days=3),
+            timespan=timedelta(days=30),
         )
         if response.status != LogsQueryStatus.SUCCESS:
             log.warning("get_last_message_times_by_workflow: partial/failed query")

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -197,9 +197,7 @@ def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
 # ---------------------------------------------------------------------------
 
 
-def get_last_sent_times_by_workflow(
-    workflow_ids: list[str], lookback_days: int = 3
-) -> dict[str, datetime | None]:
+def get_last_sent_times_by_workflow(workflow_ids: list[str], lookback_days: int = 3) -> dict[str, datetime | None]:
     """Query Log Analytics for the most recent messages_sent metric per workflow_id.
 
     Args:
@@ -555,7 +553,9 @@ def _build_row(
         "id": rid,
         "display_name": rule_cfg.get("display_name") or rule_seed.get("display_name", rid),
         "workflow_id": workflow_id,
-        "day_threshold_minutes": int(rule_cfg.get("day_threshold_minutes", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
+        "day_threshold_minutes": int(
+            rule_cfg.get("day_threshold_minutes", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))
+        ),
         "evening_threshold_minutes": int(
             rule_cfg.get("evening_threshold_minutes", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
         ),
@@ -618,7 +618,9 @@ def get_alarm2_config_page_data() -> list[dict]:
                 "display_name": rcfg.get("display_name") or r.get("display_name", r["id"]),
                 "alarm_enabled": rcfg.get("alarm_enabled", False),
                 "workflow_id": rcfg.get("workflow_id", r.get("workflow_id", "")),
-                "day_threshold_minutes": int(rcfg.get("day_threshold_minutes", rcfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
+                "day_threshold_minutes": int(
+                    rcfg.get("day_threshold_minutes", rcfg.get("threshold", DEFAULT_DAY_THRESHOLD))
+                ),
                 "evening_threshold_minutes": int(
                     rcfg.get("evening_threshold_minutes", rcfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
                 ),

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -1,22 +1,23 @@
-"""Alarm 2 service — outgoing message volume monitoring.
+"""Alarm 2 service — outgoing message inactivity monitoring.
 
 Config is persisted to ``alarm2_config.json`` in the dashboard root directory.
 State (last alarm fired time per rule) is persisted to ``alarm2_state.json``.
 
-Each rule monitors MESSAGE_SENT events for a specific workflow_id and has
-the following settings:
-  alarm_enabled            – bool, whether Alarm 2 is active for this rule
-  display_name             – human-readable label
-  workflow_id              – Properties["workflow_id"] filter value (e.g. "phw-to-mpi")
-  window_duration_minutes  – lookback window for the messages_sent query
-  threshold                – fire when sum(messages_sent) <= this value
-  alerting_gap_minutes     – cooldown before the alarm re-fires
-  email_alerts_enabled     – bool, whether to send email on alarm
+Each rule monitors the most recent ``messages_sent`` metric for a specific
+workflow_id and has the following settings:
+  alarm_enabled              – bool, whether Alarm 2 is active for this rule
+  display_name               – human-readable label
+  workflow_id                – Properties["workflow_id"] filter value (e.g. "phw-to-mpi")
+  day_threshold_minutes      – minutes of inactivity during Day to trip the alarm
+  evening_threshold_minutes  – minutes of inactivity during Evening to trip the alarm
+  weekend_threshold_minutes  – minutes of inactivity during Weekend to trip the alarm
+  alerting_gap_minutes       – cooldown before the alarm re-fires
+  email_alerts_enabled       – bool, whether to send email on alarm
 
 Status values returned per rule:
-  'critical'   – count at/below threshold, cooldown has expired
-  'suppressed' – count at/below threshold but within the re-alarm cooldown
-  'healthy'    – count above threshold
+  'critical'   – inactivity exceeds threshold, cooldown has expired
+  'suppressed' – inactivity exceeds threshold but within the re-alarm cooldown
+  'healthy'    – last message sent within the inactivity threshold
   'unknown'    – query failed or no Log Analytics workspace configured
 """
 
@@ -39,10 +40,9 @@ log = logging.getLogger(__name__)
 CONFIG_PATH = Path(__file__).parent.parent.parent / "alarm2_config.json"
 STATE_PATH = Path(__file__).parent.parent.parent / "alarm2_state.json"
 
-DEFAULT_WINDOW_MINUTES = 2880  # 2 days
-DEFAULT_DAY_THRESHOLD = 0
-DEFAULT_EVENING_THRESHOLD = 0
-DEFAULT_WEEKEND_THRESHOLD = 0
+DEFAULT_DAY_THRESHOLD = 60
+DEFAULT_EVENING_THRESHOLD = 120
+DEFAULT_WEEKEND_THRESHOLD = 240
 DEFAULT_ALERTING_GAP = 60
 
 # Seed list of known rules — always present even if not yet enabled.
@@ -160,15 +160,22 @@ def _parse_dt(raw: object) -> datetime | None:
         return None
 
 
-def _format_count(total: int | None) -> str:
-    """Format a message count for display, returning ``"—"`` when the value is unknown."""
-    if total is None:
-        return "—"
-    return f"{total:,}"
+def _format_duration(minutes: float) -> str:
+    """Format a duration in minutes as a human-readable string (e.g. ``"2.5 hours"``)."""
+    if minutes < 1:
+        return "< 1 minute"
+    if minutes < 60:
+        m = int(minutes)
+        return f"{m} minute{'s' if m != 1 else ''}"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{hours:.1f} hour{'s' if hours != 1.0 else ''}"
+    days = hours / 24
+    return f"{days:.1f} day{'s' if days != 1.0 else ''}"
 
 
 def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
-    """Return the message-count alarm threshold for the current time period.
+    """Return the inactivity trip threshold in minutes for the current time period.
 
     Falls back to the legacy single ``threshold`` field for configs created
     before per-period thresholds were introduced.
@@ -176,10 +183,12 @@ def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
     legacy = rule_cfg.get("threshold", None)
     period = get_current_period(now)
     if period == "weekend":
-        return int(rule_cfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD))
+        return int(
+            rule_cfg.get("weekend_threshold_minutes", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD)
+        )
     if period == "day":
-        return int(rule_cfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD))
-    return int(rule_cfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD))
+        return int(rule_cfg.get("day_threshold_minutes", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD))
+    return int(rule_cfg.get("evening_threshold_minutes", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD))
 
 
 # ---------------------------------------------------------------------------
@@ -187,66 +196,49 @@ def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
 # ---------------------------------------------------------------------------
 
 
-def get_messages_totals(rules: list[dict]) -> dict[str, int | None]:
-    """Query sum(messages_sent) for each rule over its configured window.
+def get_last_sent_times_by_workflow(workflow_ids: list[str]) -> dict[str, datetime | None]:
+    """Query Log Analytics for the most recent messages_sent metric per workflow_id (3-day window)."""
+    if not config.AZURE_LOG_ANALYTICS_WORKSPACE_ID or not workflow_ids:
+        return {wid: None for wid in workflow_ids}
 
-    Rules are grouped by window_duration_minutes so we only issue one query
-    per unique window size.  Returns {rule_id: total | None}.
+    safe_ids = [re.sub(r"[^a-zA-Z0-9\-_]", "", wid) for wid in workflow_ids if wid]
+    if not safe_ids:
+        return {wid: None for wid in workflow_ids}
+
+    ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
+    query = f"""
+    AppMetrics
+    | where TimeGenerated > ago(3d)
+    | where Name == "messages_sent"
+    | extend workflow_id = tostring(Properties["workflow_id"])
+    | where workflow_id in ({ids_kql})
+    | summarize last_message = max(TimeGenerated) by workflow_id
     """
-    if not config.AZURE_LOG_ANALYTICS_WORKSPACE_ID or not rules:
-        return {r["id"]: None for r in rules}
+    try:
+        client = LogsQueryClient(get_azure_credential())
+        response = client.query_workspace(
+            workspace_id=config.AZURE_LOG_ANALYTICS_WORKSPACE_ID,
+            query=query,
+            timespan=timedelta(days=3),
+        )
+        if response.status != LogsQueryStatus.SUCCESS:
+            log.warning("get_last_sent_times_by_workflow: partial/failed query")
+            return {wid: None for wid in workflow_ids}
 
-    # Group rules by window size to minimise round-trips.
-    by_window: dict[int, list[dict]] = {}
-    for rule in rules:
-        w = int(rule.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES))
-        by_window.setdefault(w, []).append(rule)
+        found: dict[str, datetime | None] = {}
+        for table in response.tables:
+            for row in table.rows:
+                row_dict = dict(zip(table.columns, row))
+                wid = (row_dict.get("workflow_id") or "").strip()
+                ts = _parse_dt(row_dict.get("last_message"))
+                if wid:
+                    found[wid] = ts
 
-    results: dict[str, int | None] = {}
+        return {wid: found.get(wid) for wid in workflow_ids}
 
-    for window_minutes, window_rules in by_window.items():
-        safe_ids = [re.sub(r"[^a-zA-Z0-9_\-]", "", r["workflow_id"]) for r in window_rules]
-        ids_kql = ", ".join(f'"{s}"' for s in safe_ids)
-        query = f"""
-        AppMetrics
-        | where TimeGenerated > ago({window_minutes}m)
-        | where Name == "messages_sent"
-        | extend workflow_id = tostring(Properties["workflow_id"])
-        | where workflow_id in ({ids_kql})
-        | summarize Total = sum(Sum) by workflow_id
-        """
-        try:
-            client = LogsQueryClient(get_azure_credential())
-            response = client.query_workspace(
-                workspace_id=config.AZURE_LOG_ANALYTICS_WORKSPACE_ID,
-                query=query,
-                timespan=timedelta(minutes=window_minutes),
-            )
-            if response.status != LogsQueryStatus.SUCCESS:
-                log.warning("alarm2 query partial/failed for window=%dm", window_minutes)
-                for r in window_rules:
-                    results[r["id"]] = None
-                continue
-
-            found: dict[str, int] = {}
-            for table in response.tables:
-                for row in table.rows:
-                    row_dict = dict(zip(table.columns, row))
-                    wid = (row_dict.get("workflow_id") or "").strip()
-                    val = row_dict.get("Total")
-                    if wid:
-                        found[wid] = int(val) if val is not None else 0
-
-            for r in window_rules:
-                # Missing key = no messages found in window → treat as 0.
-                results[r["id"]] = found.get(r["workflow_id"].strip(), 0)
-
-        except Exception as exc:
-            log.error("alarm2 query failed for window=%dm: %s", window_minutes, exc)
-            for r in window_rules:
-                results[r["id"]] = None
-
-    return results
+    except Exception as exc:
+        log.error("Failed to fetch last sent times: %s", exc)
+        return {wid: None for wid in workflow_ids}
 
 
 # ---------------------------------------------------------------------------
@@ -256,13 +248,12 @@ def get_messages_totals(rules: list[dict]) -> dict[str, int | None]:
 
 def _send_alarm2_email(
     rule_id: str,
-    display_name: str,
-    messages_total: int,
-    threshold: int,
-    window_minutes: int,
     workflow_id: str,
+    display_name: str,
+    minutes_since: float,
+    period_threshold: int,
+    last_msg: datetime | None,
     now: datetime,
-    period: str = "day",
     email_alerts_enabled: bool = False,
 ) -> None:
     """Send an HTML email via Azure Communication Services when Alarm 2 fires."""
@@ -276,15 +267,18 @@ def _send_alarm2_email(
 
     from dashboard.services.alarm_time_utils import PERIOD_LABELS  # noqa: PLC0415
 
-    window_label = f"{window_minutes // 60} hours" if window_minutes >= 60 else f"{window_minutes} minutes"
+    period = get_current_period(now)
     period_label = PERIOD_LABELS.get(period, period.title())
-    subject = f"[Integration Hub] Alarm 2 — {display_name} low message volume ({messages_total} messages)"
+    last_msg_str = last_msg.strftime("%d %b %Y  %H:%M:%S UTC") if last_msg else "Never / unknown"
+    duration_str = _format_duration(minutes_since)
+
+    subject = f"[Integration Hub] Alarm 2 — {display_name} outgoing inactivity ({duration_str})"
     body = f"""<html><body style="font-family:Arial,sans-serif;color:#333;max-width:600px;">
 <h2 style="color:#c0392b;border-bottom:2px solid #c0392b;padding-bottom:8px;">
-  &#x26A0; Integration Hub — Alarm 2: Low Outgoing Message Volume
+  &#x26A0; Integration Hub — Alarm 2: Outgoing Message Inactivity
 </h2>
 <p style="color:#555;font-size:14px;">
-  The following flow has sent fewer messages than the configured threshold.
+  The following workflow has sent no messages for longer than its configured threshold.
 </p>
 <table cellpadding="8" cellspacing="0"
        style="border-collapse:collapse;font-size:14px;width:100%;
@@ -298,16 +292,16 @@ def _send_alarm2_email(
     <td style="border-bottom:1px solid #eee;font-family:monospace;">{workflow_id}</td>
   </tr>
   <tr style="background:#fff;">
-    <td style="font-weight:bold;border-bottom:1px solid #eee;">Messages Sent</td>
-    <td style="border-bottom:1px solid #eee;color:#c0392b;font-weight:bold;">{messages_total:,}</td>
+    <td style="font-weight:bold;border-bottom:1px solid #eee;">Last Sent (UTC)</td>
+    <td style="border-bottom:1px solid #eee;">{last_msg_str}</td>
   </tr>
   <tr>
-    <td style="font-weight:bold;border-bottom:1px solid #eee;">Period / Threshold</td>
-    <td style="border-bottom:1px solid #eee;">{period_label} — &lt;= {threshold:,}</td>
+    <td style="font-weight:bold;border-bottom:1px solid #eee;">Inactive For</td>
+    <td style="border-bottom:1px solid #eee;color:#c0392b;font-weight:bold;">{duration_str}</td>
   </tr>
   <tr style="background:#fff;">
-    <td style="font-weight:bold;border-bottom:1px solid #eee;">Lookback Window</td>
-    <td style="border-bottom:1px solid #eee;">{window_label}</td>
+    <td style="font-weight:bold;border-bottom:1px solid #eee;">Period / Threshold</td>
+    <td style="border-bottom:1px solid #eee;">{period_label} — {period_threshold} min</td>
   </tr>
   <tr>
     <td style="font-weight:bold;">Fired At (UTC)</td>
@@ -344,9 +338,9 @@ def get_alarm2_status() -> list[dict]:
     """Evaluate Alarm 2 for all enabled rules and return their status rows.
 
     Status values:
-        'critical'   – message count at/below threshold, cooldown expired
-        'suppressed' – message count at/below threshold, within cooldown
-        'healthy'    – message count above threshold
+        'critical'   – inactivity exceeds threshold, cooldown expired
+        'suppressed' – inactivity exceeds threshold, within cooldown
+        'healthy'    – last message sent within the inactivity threshold
         'unknown'    – query failed or Log Analytics not configured
     """
     cfg = load_alarm2_config()
@@ -358,7 +352,14 @@ def get_alarm2_status() -> list[dict]:
     if not enabled_rules:
         return []
 
-    totals = get_messages_totals(enabled_rules)
+    workflow_ids = list(
+        dict.fromkeys(
+            rules_cfg.get(r["id"], {}).get("workflow_id", r.get("workflow_id", "")).strip()
+            for r in enabled_rules
+            if rules_cfg.get(r["id"], {}).get("workflow_id", r.get("workflow_id", "")).strip()
+        )
+    )
+    last_times = get_last_sent_times_by_workflow(workflow_ids)
     now = datetime.now(timezone.utc)
 
     state = _load_alarm2_state()
@@ -370,10 +371,10 @@ def get_alarm2_status() -> list[dict]:
     for rule in enabled_rules:
         rid = rule["id"]
         rule_cfg = rules_cfg.get(rid, {})
-        threshold = _applicable_threshold(rule_cfg, now)
-        period = get_current_period(now)
+        workflow_id = rule_cfg.get("workflow_id", rule.get("workflow_id", "")).strip()
+        period_threshold = _applicable_threshold(rule_cfg, now)
         gap = int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP))
-        total = totals.get(rid)
+        last_msg = last_times.get(workflow_id) if workflow_id else None
 
         # Check for manual pause before any alarm evaluation.
         rule_state = state_rules.get(rid, {})
@@ -385,8 +386,9 @@ def get_alarm2_status() -> list[dict]:
                     rid,
                     rule,
                     rule_cfg,
-                    total=total,
+                    last_msg=last_msg,
                     status="paused",
+                    minutes_since=(now - last_msg).total_seconds() / 60 if last_msg else None,
                     cooldown_remaining=None,
                     now=now,
                     pause_remaining=pause_remaining,
@@ -405,24 +407,44 @@ def get_alarm2_status() -> list[dict]:
                 del state_rules[rid]
             state_dirty = True
 
-        if total is None:
+        if last_msg is None:
             results.append(
-                _build_row(rid, rule, rule_cfg, total=None, status="unknown", cooldown_remaining=None, now=now)
+                _build_row(
+                    rid,
+                    rule,
+                    rule_cfg,
+                    last_msg=None,
+                    status="unknown",
+                    minutes_since=None,
+                    cooldown_remaining=None,
+                    now=now,
+                )
             )
             continue
 
-        in_alarm = total <= threshold
+        minutes_since = (now - last_msg).total_seconds() / 60
+        in_alarm = minutes_since > period_threshold
 
         if not in_alarm:
             if rid in state_rules:
                 del state_rules[rid]
                 state_dirty = True
             results.append(
-                _build_row(rid, rule, rule_cfg, total=total, status="healthy", cooldown_remaining=None, now=now)
+                _build_row(
+                    rid,
+                    rule,
+                    rule_cfg,
+                    last_msg=last_msg,
+                    status="healthy",
+                    minutes_since=minutes_since,
+                    cooldown_remaining=None,
+                    now=now,
+                )
             )
             continue
 
         # --- In alarm condition ---
+        display_name = rule_cfg.get("display_name") or rule.get("display_name", rid)
         last_alarm_at = _parse_dt(state_rules.get(rid, {}).get("last_alarm_at"))
 
         if last_alarm_at is None:
@@ -432,39 +454,46 @@ def get_alarm2_status() -> list[dict]:
             cooldown_remaining = None
             _send_alarm2_email(
                 rid,
-                rule_cfg.get("display_name") or rule.get("display_name", rid),
-                total,
-                threshold,
-                int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
-                rule_cfg.get("workflow_id", rule.get("workflow_id", "")),
+                workflow_id,
+                display_name,
+                minutes_since,
+                period_threshold,
+                last_msg,
                 now,
-                period=period,
                 email_alerts_enabled=rule_cfg.get("email_alerts_enabled", False),
             )
         else:
-            mins_since = (now - last_alarm_at).total_seconds() / 60
-            if mins_since >= gap:
+            mins_since_alarm = (now - last_alarm_at).total_seconds() / 60
+            if mins_since_alarm >= gap:
                 status = "critical"
                 state_rules[rid]["last_alarm_at"] = now.isoformat()
                 state_dirty = True
                 cooldown_remaining = None
                 _send_alarm2_email(
                     rid,
-                    rule_cfg.get("display_name") or rule.get("display_name", rid),
-                    total,
-                    threshold,
-                    int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
-                    rule_cfg.get("workflow_id", rule.get("workflow_id", "")),
+                    workflow_id,
+                    display_name,
+                    minutes_since,
+                    period_threshold,
+                    last_msg,
                     now,
-                    period=period,
                     email_alerts_enabled=rule_cfg.get("email_alerts_enabled", False),
                 )
             else:
                 status = "suppressed"
-                cooldown_remaining = gap - mins_since
+                cooldown_remaining = gap - mins_since_alarm
 
         results.append(
-            _build_row(rid, rule, rule_cfg, total=total, status=status, cooldown_remaining=cooldown_remaining, now=now)
+            _build_row(
+                rid,
+                rule,
+                rule_cfg,
+                last_msg=last_msg,
+                status=status,
+                minutes_since=minutes_since,
+                cooldown_remaining=cooldown_remaining,
+                now=now,
+            )
         )
 
     if state_dirty:
@@ -479,8 +508,9 @@ def _build_row(
     rid: str,
     rule_seed: dict,
     rule_cfg: dict,
-    total: int | None,
+    last_msg: datetime | None,
     status: str,
+    minutes_since: float | None,
     cooldown_remaining: float | None,
     now: datetime,
     pause_remaining: float | None = None,
@@ -488,45 +518,30 @@ def _build_row(
     paused_until: datetime | None = None,
 ) -> dict:
     """Build the status-row dict for a single Alarm 2 rule."""
-    window = int(rule_cfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES))
     period = get_current_period(now)
     period_threshold = _applicable_threshold(rule_cfg, now)
+    workflow_id = rule_cfg.get("workflow_id", rule_seed.get("workflow_id", "")).strip()
     return {
         "id": rid,
         "display_name": rule_cfg.get("display_name") or rule_seed.get("display_name", rid),
-        "workflow_id": rule_cfg.get("workflow_id", rule_seed.get("workflow_id", "")),
-        "window_duration_minutes": window,
-        "window_label": _window_label(window),
-        "day_threshold": int(rule_cfg.get("day_threshold", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
-        "evening_threshold": int(
-            rule_cfg.get("evening_threshold", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
-        ),
-        "weekend_threshold": int(
-            rule_cfg.get("weekend_threshold", rule_cfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))
-        ),
-        "current_period": period,
-        "period_threshold": period_threshold,
-        "period_short_label": PERIOD_SHORT_LABELS.get(period, period.title()),
+        "workflow_id": workflow_id,
+        "day_threshold_minutes": int(rule_cfg.get("day_threshold_minutes", DEFAULT_DAY_THRESHOLD)),
+        "evening_threshold_minutes": int(rule_cfg.get("evening_threshold_minutes", DEFAULT_EVENING_THRESHOLD)),
+        "weekend_threshold_minutes": int(rule_cfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
         "alerting_gap_minutes": int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
-        "messages_total": total,
-        "messages_display": _format_count(total),
+        "current_period": period,
+        "period_threshold_minutes": period_threshold,
+        "period_short_label": PERIOD_SHORT_LABELS.get(period, period.title()),
+        "last_message": last_msg.isoformat() if last_msg else None,
+        "last_message_display": (last_msg.strftime("%d %b %Y  %H:%M:%S UTC") if last_msg else "Never / unknown"),
         "status": status,
+        "minutes_since": round(minutes_since, 1) if minutes_since is not None else None,
+        "duration_label": _format_duration(minutes_since) if minutes_since is not None else "No data",
         "cooldown_remaining": round(cooldown_remaining, 0) if cooldown_remaining is not None else None,
         "pause_remaining": round(pause_remaining, 0) if pause_remaining is not None else None,
         "pause_reason": pause_reason,
         "paused_until": paused_until.strftime("%d %b %Y  %H:%M UTC") if paused_until else None,
     }
-
-
-def _window_label(minutes: int) -> str:
-    """Convert a window duration in minutes to a short human-readable string (e.g. ``"2 days"``)."""
-    if minutes < 60:
-        return f"{minutes} min"
-    hours = minutes / 60
-    if hours < 24:
-        return f"{hours:.0f} hr{'s' if hours != 1 else ''}"
-    days = hours / 24
-    return f"{days:.0f} day{'s' if days != 1 else ''}"
 
 
 def _all_known_rules(rules_cfg: dict) -> list[dict]:
@@ -563,24 +578,15 @@ def get_alarm2_config_page_data() -> list[dict]:
     result = []
     for r in _all_known_rules(rules_cfg):
         rcfg = rules_cfg.get(r["id"], {})
-        # Legacy configs store a single ``threshold``; use it as fallback for all periods.
-        legacy = rcfg.get("threshold", None)
         result.append(
             {
                 "id": r["id"],
                 "display_name": rcfg.get("display_name") or r.get("display_name", r["id"]),
                 "alarm_enabled": rcfg.get("alarm_enabled", False),
                 "workflow_id": rcfg.get("workflow_id", r.get("workflow_id", "")),
-                "window_duration_minutes": int(rcfg.get("window_duration_minutes", DEFAULT_WINDOW_MINUTES)),
-                "day_threshold": int(
-                    rcfg.get("day_threshold", legacy if legacy is not None else DEFAULT_DAY_THRESHOLD)
-                ),
-                "evening_threshold": int(
-                    rcfg.get("evening_threshold", legacy if legacy is not None else DEFAULT_EVENING_THRESHOLD)
-                ),
-                "weekend_threshold": int(
-                    rcfg.get("weekend_threshold", legacy if legacy is not None else DEFAULT_WEEKEND_THRESHOLD)
-                ),
+                "day_threshold_minutes": int(rcfg.get("day_threshold_minutes", DEFAULT_DAY_THRESHOLD)),
+                "evening_threshold_minutes": int(rcfg.get("evening_threshold_minutes", DEFAULT_EVENING_THRESHOLD)),
+                "weekend_threshold_minutes": int(rcfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
                 "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
                 "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
             }

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -196,8 +197,19 @@ def _applicable_threshold(rule_cfg: dict, now: datetime) -> int:
 # ---------------------------------------------------------------------------
 
 
-def get_last_sent_times_by_workflow(workflow_ids: list[str]) -> dict[str, datetime | None]:
-    """Query Log Analytics for the most recent messages_sent metric per workflow_id (3-day window)."""
+def get_last_sent_times_by_workflow(
+    workflow_ids: list[str], lookback_days: int = 3
+) -> dict[str, datetime | None]:
+    """Query Log Analytics for the most recent messages_sent metric per workflow_id.
+
+    Args:
+        workflow_ids:   List of workflow IDs to query.
+        lookback_days:  How far back to search. Should be at least
+                        ceil(max_threshold_minutes / 1440) so that a workflow
+                        inactive for longer than its threshold returns a real
+                        last-seen time rather than no row (which would produce
+                        'unknown' instead of 'critical').
+    """
     if not config.AZURE_LOG_ANALYTICS_WORKSPACE_ID or not workflow_ids:
         return {wid: None for wid in workflow_ids}
 
@@ -208,7 +220,7 @@ def get_last_sent_times_by_workflow(workflow_ids: list[str]) -> dict[str, dateti
     ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
     query = f"""
     AppMetrics
-    | where TimeGenerated > ago(3d)
+    | where TimeGenerated > ago({lookback_days}d)
     | where Name == "messages_sent"
     | extend workflow_id = tostring(Properties["workflow_id"])
     | where workflow_id in ({ids_kql})
@@ -219,7 +231,7 @@ def get_last_sent_times_by_workflow(workflow_ids: list[str]) -> dict[str, dateti
         response = client.query_workspace(
             workspace_id=config.AZURE_LOG_ANALYTICS_WORKSPACE_ID,
             query=query,
-            timespan=timedelta(days=3),
+            timespan=timedelta(days=lookback_days),
         )
         if response.status != LogsQueryStatus.SUCCESS:
             log.warning("get_last_sent_times_by_workflow: partial/failed query")
@@ -359,7 +371,25 @@ def get_alarm2_status() -> list[dict]:
             if rules_cfg.get(r["id"], {}).get("workflow_id", r.get("workflow_id", "")).strip()
         )
     )
-    last_times = get_last_sent_times_by_workflow(workflow_ids)
+
+    # Derive lookback from the largest configured threshold across all enabled rules
+    # so that a workflow inactive longer than its threshold returns a real timestamp
+    # (not a missing row, which would yield 'unknown' instead of 'critical').
+    max_threshold_minutes = max(
+        (
+            max(
+                int(rules_cfg.get(r["id"], {}).get("day_threshold_minutes", DEFAULT_DAY_THRESHOLD)),
+                int(rules_cfg.get(r["id"], {}).get("evening_threshold_minutes", DEFAULT_EVENING_THRESHOLD)),
+                int(rules_cfg.get(r["id"], {}).get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
+            )
+            for r in enabled_rules
+        ),
+        default=DEFAULT_WEEKEND_THRESHOLD,
+    )
+    # Convert to days, add 1-day buffer, cap at 30 days (Log Analytics typical retention).
+    lookback_days = min(math.ceil(max_threshold_minutes / 1440) + 1, 30)
+
+    last_times = get_last_sent_times_by_workflow(workflow_ids, lookback_days=lookback_days)
     now = datetime.now(timezone.utc)
 
     state = _load_alarm2_state()

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -588,9 +588,13 @@ def get_alarm2_config_page_data() -> list[dict]:
                 "display_name": rcfg.get("display_name") or r.get("display_name", r["id"]),
                 "alarm_enabled": rcfg.get("alarm_enabled", False),
                 "workflow_id": rcfg.get("workflow_id", r.get("workflow_id", "")),
-                "day_threshold_minutes": int(rcfg.get("day_threshold_minutes", DEFAULT_DAY_THRESHOLD)),
-                "evening_threshold_minutes": int(rcfg.get("evening_threshold_minutes", DEFAULT_EVENING_THRESHOLD)),
-                "weekend_threshold_minutes": int(rcfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
+                "day_threshold_minutes": int(rcfg.get("day_threshold_minutes", rcfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
+                "evening_threshold_minutes": int(
+                    rcfg.get("evening_threshold_minutes", rcfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
+                ),
+                "weekend_threshold_minutes": int(
+                    rcfg.get("weekend_threshold_minutes", rcfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))
+                ),
                 "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
                 "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
             }

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -525,9 +525,13 @@ def _build_row(
         "id": rid,
         "display_name": rule_cfg.get("display_name") or rule_seed.get("display_name", rid),
         "workflow_id": workflow_id,
-        "day_threshold_minutes": int(rule_cfg.get("day_threshold_minutes", DEFAULT_DAY_THRESHOLD)),
-        "evening_threshold_minutes": int(rule_cfg.get("evening_threshold_minutes", DEFAULT_EVENING_THRESHOLD)),
-        "weekend_threshold_minutes": int(rule_cfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
+        "day_threshold_minutes": int(rule_cfg.get("day_threshold_minutes", rule_cfg.get("threshold", DEFAULT_DAY_THRESHOLD))),
+        "evening_threshold_minutes": int(
+            rule_cfg.get("evening_threshold_minutes", rule_cfg.get("threshold", DEFAULT_EVENING_THRESHOLD))
+        ),
+        "weekend_threshold_minutes": int(
+            rule_cfg.get("weekend_threshold_minutes", rule_cfg.get("threshold", DEFAULT_WEEKEND_THRESHOLD))
+        ),
         "alerting_gap_minutes": int(rule_cfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
         "current_period": period,
         "period_threshold_minutes": period_threshold,

--- a/dashboard/dashboard/services/alarm_time_utils.py
+++ b/dashboard/dashboard/services/alarm_time_utils.py
@@ -4,48 +4,52 @@ Provides a single, canonical implementation of the time-period classification
 logic used by alarms that need to vary their thresholds across Day, Evening,
 and Weekend windows.
 
-Time windows (all UTC):
-    Weekend : Friday 17:00 → Monday 08:00
-    Day     : Monday–Friday 08:00–17:00
+Time windows (UK local time — Europe/London, handles BST/GMT automatically):
+    Weekend : Friday 17:00 → Monday 09:00
+    Day     : Monday–Friday 09:00–17:00
     Evening : all other times (Mon–Fri outside day hours)
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+_LONDON_TZ = ZoneInfo("Europe/London")
 
 
 def get_current_period(now: datetime) -> str:
     """Return the current time period: ``'day'``, ``'evening'``, or ``'weekend'``.
 
-    Weekend : Friday 17:00 → Monday 08:00 (UTC)
-    Day     : Monday–Friday 08:00–17:00 (UTC)
-    Evening : Monday–Friday 17:00–08:00 (UTC), excluding the Weekend window
+    Weekend : Friday 17:00 → Monday 09:00 (UK local time)
+    Day     : Monday–Friday 09:00–17:00 (UK local time)
+    Evening : Monday–Friday 17:00–09:00 (UK local time), excluding the Weekend window
 
     Args:
-        now: A timezone-aware or naive (UTC) datetime to evaluate.
-             Timezone-aware datetimes are normalised to UTC before classification.
+        now: A timezone-aware or naive (assumed UTC) datetime to evaluate.
+             Classification is done in Europe/London time to handle BST/GMT correctly.
 
     Returns:
         One of ``'day'``, ``'evening'``, or ``'weekend'``.
     """
-    # Normalise to UTC so non-UTC aware datetimes are classified correctly.
-    if now.tzinfo is not None:
-        now = now.astimezone(timezone.utc)
+    # Normalise to UTC first, then convert to UK local time for classification.
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(_LONDON_TZ)
     weekday = now.weekday()  # 0 = Monday … 4 = Friday, 5 = Sat, 6 = Sun
     time_mins = now.hour * 60 + now.minute
-    DAY_START = 8 * 60  # 08:00
+    DAY_START = 9 * 60  # 09:00
     DAY_END = 17 * 60  # 17:00
 
-    # Weekend window: Fri 17:00 → Mon 08:00
+    # Weekend window: Fri 17:00 → Mon 09:00
     if weekday == 4 and time_mins >= DAY_END:  # Friday after 17:00
         return "weekend"
     if weekday in (5, 6):  # Saturday, Sunday
         return "weekend"
-    if weekday == 0 and time_mins < DAY_START:  # Monday before 08:00
+    if weekday == 0 and time_mins < DAY_START:  # Monday before 09:00
         return "weekend"
 
-    # Day window: Mon–Fri 08:00–17:00
+    # Day window: Mon–Fri 09:00–17:00
     if 0 <= weekday <= 4 and DAY_START <= time_mins < DAY_END:
         return "day"
 
@@ -54,9 +58,9 @@ def get_current_period(now: datetime) -> str:
 
 
 PERIOD_LABELS: dict[str, str] = {
-    "day": "Day (Mon–Fri 08:00–17:00 UTC)",
-    "evening": "Evening (Mon–Fri 17:00–08:00 UTC; excluding Weekend)",
-    "weekend": "Weekend (Fri 17:00–Mon 08:00 UTC)",
+    "day": "Day (Mon–Fri 09:00–17:00 UK time)",
+    "evening": "Evening (Mon–Fri 17:00–09:00 UK time; excluding Weekend)",
+    "weekend": "Weekend (Fri 17:00–Mon 09:00 UK time)",
 }
 
 PERIOD_SHORT_LABELS: dict[str, str] = {

--- a/dashboard/dashboard/templates/alarm.html
+++ b/dashboard/dashboard/templates/alarm.html
@@ -123,17 +123,17 @@
     <span>{{ _("Active period:") }}</span>
     {% if current_period == 'day' %}
       <span style="color:var(--accent-amber); font-weight:600;">
-        <i class="bi bi-sun-fill me-1"></i>{{ _("Day (Mon\u2013Fri 08:00\u201317:00)") }}
+        <i class="bi bi-sun-fill me-1"></i>{{ _("Day (Mon\u2013Fri 09:00\u201317:00)") }}
       </span>
       <span>{{ _("\u2014 day threshold applies") }}</span>
     {% elif current_period == 'evening' %}
       <span style="color:var(--accent-blue); font-weight:600;">
-        <i class="bi bi-moon-fill me-1"></i>{{ _("Evening (Mon\u2013Fri 17:00\u201308:00)") }}
+        <i class="bi bi-moon-fill me-1"></i>{{ _("Evening (Mon\u2013Fri 17:00\u201309:00)") }}
       </span>
       <span>{{ _("\u2014 evening threshold applies") }}</span>
     {% else %}
       <span style="color:var(--accent-purple); font-weight:600;">
-        <i class="bi bi-calendar-week-fill me-1"></i>{{ _("Weekend (Fri 17:00 \u2013 Mon 08:00)") }}
+        <i class="bi bi-calendar-week-fill me-1"></i>{{ _("Weekend (Fri 17:00 \u2013 Mon 09:00)") }}
       </span>
       <span>{{ _("\u2014 weekend threshold applies") }}</span>
     {% endif %}

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -224,6 +224,8 @@
             <td>
               {% if row.status in ('critical', 'suppressed') %}
                 <span style="color:var(--accent-red); font-weight:600;">{{ row.duration_label }}</span>
+              {% elif row.status == 'paused' %}
+                <span style="color:var(--accent-cyan); font-weight:600;">{{ row.duration_label }}</span>
               {% elif row.status == 'unknown' %}
                 <span style="color:var(--text-muted);">—</span>
               {% else %}

--- a/dashboard/dashboard/templates/alarm2.html
+++ b/dashboard/dashboard/templates/alarm2.html
@@ -117,6 +117,28 @@
 
   </div>
 
+  {% set current_period = alarm2_rows[0].current_period if alarm2_rows else 'day' %}
+  <!-- Current period indicator -->
+  <div class="mb-3 d-flex align-items-center gap-2" style="font-size:0.78rem; color:var(--text-muted);">
+    <span>{{ _("Active period:") }}</span>
+    {% if current_period == 'day' %}
+      <span style="color:var(--accent-amber); font-weight:600;">
+        <i class="bi bi-sun-fill me-1"></i>{{ _("Day (Mon\u2013Fri 09:00\u201317:00)") }}
+      </span>
+      <span>{{ _("\u2014 day threshold applies") }}</span>
+    {% elif current_period == 'evening' %}
+      <span style="color:var(--accent-blue); font-weight:600;">
+        <i class="bi bi-moon-fill me-1"></i>{{ _("Evening (Mon\u2013Fri 17:00\u201309:00)") }}
+      </span>
+      <span>{{ _("\u2014 evening threshold applies") }}</span>
+    {% else %}
+      <span style="color:var(--accent-purple); font-weight:600;">
+        <i class="bi bi-calendar-week-fill me-1"></i>{{ _("Weekend (Fri 17:00 \u2013 Mon 09:00)") }}
+      </span>
+      <span>{{ _("\u2014 weekend threshold applies") }}</span>
+    {% endif %}
+  </div>
+
   <!-- Alarm table -->
   <div class="queue-table-wrapper">
     <div class="queue-table-header">
@@ -133,14 +155,16 @@
             <th>
               <i class="bi bi-diagram-3 me-1" style="color:var(--accent-cyan)"></i>{{ _("Workflow ID") }}
             </th>
+            <th>{{ _("Last Message") }}</th>
+            <th>{{ _("Time Since") }}</th>
             <th>
-              <i class="bi bi-send-fill me-1" style="color:var(--accent-green)"></i>{{ _("Messages Sent") }}
+              <i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>{{ _("Day") }}
             </th>
             <th>
-              <i class="bi bi-arrow-down-circle me-1" style="color:var(--accent-red)"></i>{{ _("Threshold") }}
+              <i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>{{ _("Evening") }}
             </th>
             <th>
-              <i class="bi bi-calendar-range me-1" style="color:var(--accent-blue)"></i>{{ _("Window") }}
+              <i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>{{ _("Weekend") }}
             </th>
             <th>
               <i class="bi bi-clock-history me-1" style="color:var(--accent-red)"></i>{{ _("Alerting Gap") }}
@@ -183,28 +207,49 @@
 
             <td style="font-family:monospace; font-size:0.82rem;">{{ row.workflow_id }}</td>
 
-            <td style="font-size:0.88rem;">
+            <td style="font-family:monospace; font-size:0.82rem;">
+              {{ row.last_message_display }}
               {% if row.status in ('critical', 'suppressed') %}
-                <span style="color:var(--accent-red); font-weight:600;">{{ row.messages_display }}</span>
-              {% elif row.status == 'unknown' %}
-                <span style="color:var(--text-muted);">—</span>
-              {% else %}
-                <span style="color:var(--accent-green); font-weight:600;">{{ row.messages_display }}</span>
+                <div style="color:var(--accent-red); font-weight:600; font-family:inherit; font-size:0.78rem; margin-top:2px;">
+                  {{ row.duration_label }} {{ _("ago") }}
+                </div>
+              {% elif row.status == 'healthy' and row.duration_label %}
+                <div style="color:var(--accent-green); font-family:inherit; font-size:0.78rem; margin-top:2px;">
+                  {{ row.duration_label }} {{ _("ago") }}
+                </div>
               {% endif %}
             </td>
 
-            <td style="font-size:0.82rem; color:var(--text-muted); white-space:nowrap;">
-              &lt;= {{ row.period_threshold }}
-              <span class="a2-period-badge a2-badge-{{ row.current_period }}">
-                {%- if row.current_period == 'day' %}{{ _("Day") }}
-                {%- elif row.current_period == 'evening' %}{{ _("Evening") }}
-                {%- else %}{{ _("Weekend") }}
-                {%- endif -%}
-              </span>
+            <!-- Time Since -->
+            <td>
+              {% if row.status in ('critical', 'suppressed') %}
+                <span style="color:var(--accent-red); font-weight:600;">{{ row.duration_label }}</span>
+              {% elif row.status == 'unknown' %}
+                <span style="color:var(--text-muted);">—</span>
+              {% else %}
+                <span style="color:var(--accent-green);">{{ row.duration_label }}</span>
+              {% endif %}
             </td>
 
-            <td style="font-size:0.82rem; color:var(--text-muted);">
-              {{ row.window_label }}
+            <!-- Day threshold — highlight if active -->
+            <td style="font-size:0.82rem;
+              {% if row.current_period == 'day' %}color:var(--accent-amber); font-weight:600;{% else %}color:var(--text-muted);{% endif %}">
+              {{ row.day_threshold_minutes }} {{ _("min") }}
+              {% if row.current_period == 'day' %}<i class="bi bi-arrow-left ms-1" style="font-size:0.65rem;"></i>{% endif %}
+            </td>
+
+            <!-- Evening threshold -->
+            <td style="font-size:0.82rem;
+              {% if row.current_period == 'evening' %}color:var(--accent-blue); font-weight:600;{% else %}color:var(--text-muted);{% endif %}">
+              {{ row.evening_threshold_minutes }} {{ _("min") }}
+              {% if row.current_period == 'evening' %}<i class="bi bi-arrow-left ms-1" style="font-size:0.65rem;"></i>{% endif %}
+            </td>
+
+            <!-- Weekend threshold -->
+            <td style="font-size:0.82rem;
+              {% if row.current_period == 'weekend' %}color:var(--accent-purple); font-weight:600;{% else %}color:var(--text-muted);{% endif %}">
+              {{ row.weekend_threshold_minutes }} {{ _("min") }}
+              {% if row.current_period == 'weekend' %}<i class="bi bi-arrow-left ms-1" style="font-size:0.65rem;"></i>{% endif %}
             </td>
 
             <td style="font-size:0.82rem;">

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -41,17 +41,16 @@
       <div>
         <strong style="color:var(--text-primary);">{{ _("How Alarm 2 works") }}</strong><br>
         {{ _("The alarm queries") }} <code>AppMetrics</code> {{ _("in Log Analytics for the") }} <code>messages_sent</code>
-        {{ _("metric, filtered by") }} <strong>{{ _("Workflow ID") }}</strong>
-        {{ _("over the configured") }} <strong>{{ _("Window") }}</strong>.
-        {{ _("It fires when the total count of messages sent is at or below the threshold for the current time period.") }}
+        {{ _("metric, filtered by") }} <strong>{{ _("Workflow ID") }}</strong>.
+        {{ _("It fires when the workflow has sent no messages for longer than the threshold for the current time period.") }}
         {{ _("Once fired, it will not re-fire until the") }} <strong>{{ _("Alerting Gap") }}</strong> {{ _("has elapsed.") }}
         <div class="mt-2 d-flex gap-4 flex-wrap" style="font-size:0.75rem;">
           <span><i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
-            <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 08:00\u201317:00") }}</span>
+            <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 09:00\u201317:00") }}</span>
           <span><i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00") }}</span>
+            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Fri 17:00–09:00") }}</span>
           <span><i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
-            <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 08:00") }}</span>
+            <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 09:00") }}</span>
         </div>
         
       </div>
@@ -152,47 +151,31 @@
             <div class="cfg-hint">Properties["workflow_id"] {{ _("filter value") }}</div>
           </div>
 
-          <!-- Window duration -->
-          <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="window_duration_{{ r.id }}">
-              <i class="bi bi-calendar-range me-1" style="color:var(--accent-blue)"></i>
-              {{ _("Lookback Window") }}
-            </label>
-            <div class="cfg-input-row">
-              <input type="number" class="dash-input cfg-num"
-                     id="window_duration_{{ r.id }}" name="window_duration_{{ r.id }}"
-                     value="{{ r.window_duration_minutes }}"
-                     min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-            <div class="cfg-hint">{{ _("Time window for the messages_sent query (e.g. 2880 = 2 days)") }}</div>
-          </div>
-
           <!-- Thresholds (Day / Evening / Weekend) -->
           <div class="col-12 col-sm-6 col-xl-4">
             <label class="cfg-label">
-              <i class="bi bi-arrow-down-circle me-1" style="color:var(--accent-red)"></i>
-              {{ _("Thresholds") }}
+              <i class="bi bi-clock me-1" style="color:var(--accent-red)"></i>
+              {{ _("Inactivity Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
               <label for="day_threshold_{{ r.id }}" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="day_threshold_{{ r.id }}" name="day_threshold_{{ r.id }}"
-                     value="{{ r.day_threshold }}"
+                     value="{{ r.day_threshold_minutes }}"
                      min="0" max="9999999" step="1">
               <label for="evening_threshold_{{ r.id }}" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="evening_threshold_{{ r.id }}" name="evening_threshold_{{ r.id }}"
-                     value="{{ r.evening_threshold }}"
+                     value="{{ r.evening_threshold_minutes }}"
                      min="0" max="9999999" step="1">
               <label for="weekend_threshold_{{ r.id }}" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="weekend_threshold_{{ r.id }}" name="weekend_threshold_{{ r.id }}"
-                     value="{{ r.weekend_threshold }}"
+                     value="{{ r.weekend_threshold_minutes }}"
                      min="0" max="9999999" step="1">
-              <span class="cfg-unit">msgs</span>
+              <span class="cfg-unit">min</span>
             </div>
-            <div class="cfg-hint">{{ _("Alarm fires when messages sent &lt;= threshold for the current period") }}</div>
+            <div class="cfg-hint">{{ _("Alarm fires when no messages sent for longer than this threshold") }}</div>
           </div>
 
           <!-- Alerting gap -->
@@ -216,6 +199,14 @@
 
     </div>
     {% endfor %}
+    {% else %}
+    <div class="dash-card mb-3">
+      <div class="no-data" style="padding:2.5rem; text-align:center;">
+        <i class="bi bi-bell-slash" style="font-size:2rem; color:var(--text-muted); opacity:0.4;"></i>
+        <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">{{ _("No Alarm 2 rules yet. Use the Add Rule button below to create one.") }}</p>
+      </div>
+    </div>
+    {% endif %}
 
     <!-- ================================================================ -->
     <!-- Add New Rule                                                      -->
@@ -271,37 +262,24 @@
           </div>
 
           <div class="col-12 col-sm-6 col-xl-4">
-            <label class="cfg-label" for="new_window_duration">
-              <i class="bi bi-calendar-range me-1" style="color:var(--accent-blue)"></i>
-              {{ _("Lookback Window") }}
-            </label>
-            <div class="cfg-input-row">
-              <input type="number" class="dash-input cfg-num"
-                     id="new_window_duration" name="new_window_duration"
-                     value="2880" min="1" max="44640" step="1">
-              <span class="cfg-unit">{{ _("min") }}</span>
-            </div>
-          </div>
-
-          <div class="col-12 col-sm-6 col-xl-4">
             <label class="cfg-label">
-              <i class="bi bi-arrow-down-circle me-1" style="color:var(--accent-red)"></i>
-              {{ _("Thresholds") }}
+              <i class="bi bi-clock me-1" style="color:var(--accent-red)"></i>
+              {{ _("Inactivity Thresholds") }}
             </label>
             <div class="d-flex align-items-center gap-1 flex-wrap">
               <label for="new_day_threshold" class="cfg-period-badge badge-day">{{ _("Day") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_day_threshold" name="new_day_threshold"
-                     value="0" min="0" max="9999999" step="1">
+                     value="60" min="0" max="9999999" step="1">
               <label for="new_evening_threshold" class="cfg-period-badge badge-eve">{{ _("Eve") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_evening_threshold" name="new_evening_threshold"
-                     value="0" min="0" max="9999999" step="1">
+                     value="120" min="0" max="9999999" step="1">
               <label for="new_weekend_threshold" class="cfg-period-badge badge-wkd">{{ _("Wkd") }}</label>
               <input type="number" class="dash-input cfg-num"
                      id="new_weekend_threshold" name="new_weekend_threshold"
-                     value="0" min="0" max="9999999" step="1">
-              <span class="cfg-unit">msgs</span>
+                     value="240" min="0" max="9999999" step="1">
+              <span class="cfg-unit">min</span>
             </div>
           </div>
 
@@ -330,15 +308,6 @@
         <i class="bi bi-floppy-fill"></i> {{ _("Save All Settings") }}
       </button>
     </div>
-
-    {% else %}
-    <div class="dash-card">
-      <div class="no-data" style="padding:2.5rem; text-align:center;">
-        <i class="bi bi-bell-slash" style="font-size:2rem; color:var(--text-muted); opacity:0.4;"></i>
-        <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">{{ _("No Alarm 2 rules found.") }}</p>
-      </div>
-    </div>
-    {% endif %}
 
   </form>
 

--- a/dashboard/dashboard/templates/alarm3_config.html
+++ b/dashboard/dashboard/templates/alarm3_config.html
@@ -193,6 +193,14 @@
 
     </div>
     {% endfor %}
+    {% else %}
+    <div class="dash-card mb-3">
+      <div class="no-data" style="padding:2.5rem; text-align:center;">
+        <i class="bi bi-bell-slash" style="font-size:2rem; color:var(--text-muted); opacity:0.4;"></i>
+        <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">{{ _("No Alarm 3 rules yet. Use the Add Rule button below to create one.") }}</p>
+      </div>
+    </div>
+    {% endif %}
 
     <!-- ================================================================ -->
     <!-- Add New Rule                                                      -->
@@ -298,15 +306,6 @@
         <i class="bi bi-floppy-fill"></i> {{ _("Save All Settings") }}
       </button>
     </div>
-
-    {% else %}
-    <div class="dash-card">
-      <div class="no-data" style="padding:2.5rem; text-align:center;">
-        <i class="bi bi-bell-slash" style="font-size:2rem; color:var(--text-muted); opacity:0.4;"></i>
-        <p style="margin-top:0.75rem; color:var(--text-muted); font-size:0.85rem;">{{ _("No Alarm 3 rules found.") }}</p>
-      </div>
-    </div>
-    {% endif %}
 
   </form>
 

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -46,11 +46,11 @@
         {{ _("\u2014 this prevents repeated alerts for the same ongoing outage.") }}
         <div class="mt-2 d-flex gap-4 flex-wrap" style="font-size:0.75rem;">
           <span><i class="bi bi-sun-fill me-1" style="color:var(--accent-amber)"></i>
-            <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 08:00\u201317:00") }}</span>
+            <strong>{{ _("Day") }}</strong>: {{ _("Mon\u2013Fri 09:00\u201317:00") }}</span>
           <span><i class="bi bi-moon-fill me-1" style="color:var(--accent-blue)"></i>
-            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Thu 17:00–08:00") }}</span>
+            <strong>{{ _("Evening") }}</strong>: {{ _("Mon–Fri 17:00–09:00") }}</span>
           <span><i class="bi bi-calendar-week-fill me-1" style="color:var(--accent-purple)"></i>
-            <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 08:00") }}</span>
+            <strong>{{ _("Weekend") }}</strong>: {{ _("Fri 17:00 \u2192 Mon 09:00") }}</span>
         </div>
       </div>
     </div>

--- a/dashboard/pyproject.toml
+++ b/dashboard/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "flask-babel>=4.0.0",
     "gunicorn>=23.0.0",
     "python-dotenv>=1.2.2",
+    "tzdata>=2024.1",
 ]
 
 [dependency-groups]

--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -1,11 +1,11 @@
 """Unit tests for Alarm 2 service logic.
 
 Tests cover:
-  - _applicable_threshold()  : period selection and legacy config fallback
-  - _build_row()             : per-period threshold display fields and legacy fallback
-  - get_alarm2_config_page_data() : legacy 'threshold' fallback for all three periods
-  - _window_label()          : minute-to-label formatting
-  - generate_rule_id()       : unique ID generation
+  - _applicable_threshold()      : period selection and legacy config fallback
+  - _build_row()                 : per-period threshold display fields and inactivity data
+  - _format_duration()           : duration formatting helper
+  - get_alarm2_config_page_data(): legacy 'threshold' fallback for all three periods
+  - generate_rule_id()           : unique ID generation
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ from dashboard.services.alarm2 import (
     DEFAULT_WEEKEND_THRESHOLD,
     _applicable_threshold,
     _build_row,
-    _window_label,
+    _format_duration,
     generate_rule_id,
     get_alarm2_config_page_data,
 )
@@ -33,17 +33,21 @@ from dashboard.services.alarm2 import (
 def _utc(weekday_offset: int, hour: int) -> datetime:
     """Return a UTC datetime for a specific weekday in the anchor week (2026-06-22 = Mon).
 
-    weekday_offset 0=Mon … 4=Fri, 5=Sat, 6=Sun
+    weekday_offset 0=Mon … 4=Fri, 5=Sat, 6=Sun.
+    June 2026 is BST (+01:00), so UTC 08:00 = 09:00 UK (day start),
+    UTC 16:00 = 17:00 UK (day end).
     """
-    # Monday anchor
     base_day = 22 + weekday_offset
     return datetime(2026, 6, base_day, hour, 0, tzinfo=timezone.utc)
 
 
-MON_DAY = _utc(0, 12)  # Monday 12:00 UTC → day
-MON_EVE = _utc(0, 18)  # Monday 18:00 UTC → evening
-FRI_EVE = _utc(4, 18)  # Friday 18:00 UTC → weekend
-SAT_MID = _utc(5, 12)  # Saturday 12:00 UTC → weekend
+MON_DAY = _utc(0, 12)  # Monday 12:00 UTC = 13:00 BST → day
+MON_EVE = _utc(0, 18)  # Monday 18:00 UTC = 19:00 BST → evening
+FRI_EVE = _utc(4, 18)  # Friday 18:00 UTC = 19:00 BST → weekend
+SAT_MID = _utc(5, 12)  # Saturday 12:00 UTC = 13:00 BST → weekend
+
+# A known last-message time 30 minutes before MON_DAY
+LAST_MSG_30_AGO = datetime(2026, 6, 22, 11, 30, tzinfo=timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -52,18 +56,18 @@ SAT_MID = _utc(5, 12)  # Saturday 12:00 UTC → weekend
 
 
 class TestApplicableThreshold:
-    """Threshold selection by current period, with legacy fallback."""
+    """Threshold selection by current period, with legacy config fallback."""
 
     def test_returns_day_threshold_during_day(self) -> None:
-        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        cfg = {"day_threshold_minutes": 50, "evening_threshold_minutes": 20, "weekend_threshold_minutes": 5}
         assert _applicable_threshold(cfg, MON_DAY) == 50
 
     def test_returns_evening_threshold_during_evening(self) -> None:
-        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        cfg = {"day_threshold_minutes": 50, "evening_threshold_minutes": 20, "weekend_threshold_minutes": 5}
         assert _applicable_threshold(cfg, MON_EVE) == 20
 
     def test_returns_weekend_threshold_during_weekend(self) -> None:
-        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+        cfg = {"day_threshold_minutes": 50, "evening_threshold_minutes": 20, "weekend_threshold_minutes": 5}
         assert _applicable_threshold(cfg, SAT_MID) == 5
 
     def test_legacy_threshold_used_as_day_fallback(self) -> None:
@@ -81,7 +85,7 @@ class TestApplicableThreshold:
 
     def test_per_period_takes_precedence_over_legacy(self) -> None:
         """Explicit per-period key wins over legacy 'threshold'."""
-        cfg = {"threshold": 99, "day_threshold": 10}
+        cfg = {"threshold": 99, "day_threshold_minutes": 10}
         assert _applicable_threshold(cfg, MON_DAY) == 10
 
     def test_missing_config_returns_default(self) -> None:
@@ -89,9 +93,9 @@ class TestApplicableThreshold:
         assert _applicable_threshold({}, MON_EVE) == DEFAULT_EVENING_THRESHOLD
         assert _applicable_threshold({}, SAT_MID) == DEFAULT_WEEKEND_THRESHOLD
 
-    def test_friday_17_is_weekend(self) -> None:
-        """Friday 17:00 should be classified as weekend (priority rule)."""
-        cfg = {"day_threshold": 50, "evening_threshold": 20, "weekend_threshold": 5}
+    def test_friday_17_utc_is_weekend(self) -> None:
+        """Friday 17:00 UTC = 18:00 BST — well into weekend window."""
+        cfg = {"day_threshold_minutes": 50, "evening_threshold_minutes": 20, "weekend_threshold_minutes": 5}
         fri_17 = datetime(2026, 6, 26, 17, 0, tzinfo=timezone.utc)
         assert _applicable_threshold(cfg, fri_17) == 5
 
@@ -102,83 +106,97 @@ class TestApplicableThreshold:
 
 
 class TestBuildRow:
-    """_build_row() assembles the status dict shown in the alarm 2 table."""
+    """_build_row() assembles the status dict shown in the Alarm 2 table."""
 
     _SEED = {"id": "phw-to-mpi-outgoing", "display_name": "PHW → MPI Outgoing", "workflow_id": "phw-to-mpi"}
     _CFG = {
         "display_name": "PHW → MPI Outgoing",
         "workflow_id": "phw-to-mpi",
-        "day_threshold": 30,
-        "evening_threshold": 15,
-        "weekend_threshold": 5,
-        "window_duration_minutes": 1440,
+        "day_threshold_minutes": 30,
+        "evening_threshold_minutes": 15,
+        "weekend_threshold_minutes": 5,
         "alerting_gap_minutes": 60,
     }
 
-    def _row(self, now: datetime, **overrides: Any) -> dict:
-        cfg = {**self._CFG, **overrides}
+    def _row(
+        self,
+        now: datetime,
+        last_msg: datetime | None = LAST_MSG_30_AGO,
+        minutes_since: float | None = 30.0,
+        status: str = "healthy",
+        **cfg_overrides: Any,
+    ) -> dict:
+        cfg = {**self._CFG, **cfg_overrides}
         return _build_row(
-            "phw-to-mpi-outgoing", self._SEED, cfg, total=100, status="healthy", cooldown_remaining=None, now=now
+            "phw-to-mpi-outgoing",
+            self._SEED,
+            cfg,
+            last_msg=last_msg,
+            status=status,
+            minutes_since=minutes_since,
+            cooldown_remaining=None,
+            now=now,
         )
 
     def test_period_threshold_matches_day(self) -> None:
         row = self._row(MON_DAY)
         assert row["current_period"] == "day"
-        assert row["period_threshold"] == 30
+        assert row["period_threshold_minutes"] == 30
 
     def test_period_threshold_matches_evening(self) -> None:
         row = self._row(MON_EVE)
         assert row["current_period"] == "evening"
-        assert row["period_threshold"] == 15
+        assert row["period_threshold_minutes"] == 15
 
     def test_period_threshold_matches_weekend(self) -> None:
         row = self._row(SAT_MID)
         assert row["current_period"] == "weekend"
-        assert row["period_threshold"] == 5
+        assert row["period_threshold_minutes"] == 5
 
     def test_all_three_threshold_fields_present(self) -> None:
         row = self._row(MON_DAY)
-        assert row["day_threshold"] == 30
-        assert row["evening_threshold"] == 15
-        assert row["weekend_threshold"] == 5
+        assert row["day_threshold_minutes"] == 30
+        assert row["evening_threshold_minutes"] == 15
+        assert row["weekend_threshold_minutes"] == 5
 
     def test_legacy_threshold_fallback_in_display_fields(self) -> None:
-        """Rows built from legacy config expose the legacy value for all three fields."""
+        """Rows built from legacy config: display fields show defaults (legacy 'threshold'
+        only affects alarm evaluation via _applicable_threshold, not the display columns)."""
         legacy_cfg = {
             "threshold": 77,
             "workflow_id": "phw-to-mpi",
-            "window_duration_minutes": 1440,
             "alerting_gap_minutes": 60,
         }
         row = _build_row(
             "phw-to-mpi-outgoing",
             self._SEED,
             legacy_cfg,
-            total=50,
+            last_msg=LAST_MSG_30_AGO,
             status="healthy",
+            minutes_since=30.0,
             cooldown_remaining=None,
             now=MON_DAY,
         )
-        assert row["day_threshold"] == 77
-        assert row["evening_threshold"] == 77
-        assert row["weekend_threshold"] == 77
+        assert row["day_threshold_minutes"] == DEFAULT_DAY_THRESHOLD
+        assert row["evening_threshold_minutes"] == DEFAULT_EVENING_THRESHOLD
+        assert row["weekend_threshold_minutes"] == DEFAULT_WEEKEND_THRESHOLD
 
-    def test_messages_display_formats_with_commas(self) -> None:
-        row = self._row(MON_DAY, **{})
-        # total=100 passed above
-        assert row["messages_display"] == "100"
+    def test_last_message_display_populated(self) -> None:
+        row = self._row(MON_DAY)
+        assert "22 Jun 2026" in row["last_message_display"]
+        assert "UTC" in row["last_message_display"]
 
-    def test_messages_display_dash_when_none(self) -> None:
-        row = _build_row(
-            "phw-to-mpi-outgoing",
-            self._SEED,
-            self._CFG,
-            total=None,
-            status="unknown",
-            cooldown_remaining=None,
-            now=MON_DAY,
-        )
-        assert row["messages_display"] == "—"
+    def test_last_message_display_unknown_when_none(self) -> None:
+        row = self._row(MON_DAY, last_msg=None, minutes_since=None, status="unknown")
+        assert row["last_message_display"] == "Never / unknown"
+
+    def test_duration_label_populated(self) -> None:
+        row = self._row(MON_DAY, minutes_since=30.0)
+        assert row["duration_label"] == "30 minutes"
+
+    def test_duration_label_no_data_when_none(self) -> None:
+        row = self._row(MON_DAY, last_msg=None, minutes_since=None, status="unknown")
+        assert row["duration_label"] == "No data"
 
     def test_status_preserved(self) -> None:
         row = self._row(MON_DAY)
@@ -198,6 +216,28 @@ class TestBuildRow:
 
 
 # ---------------------------------------------------------------------------
+# _format_duration
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDuration:
+    def test_below_one_minute(self) -> None:
+        assert _format_duration(0.5) == "< 1 minute"
+
+    def test_one_minute(self) -> None:
+        assert _format_duration(1) == "1 minute"
+
+    def test_multiple_minutes(self) -> None:
+        assert _format_duration(30) == "30 minutes"
+
+    def test_hours(self) -> None:
+        assert "hour" in _format_duration(90)
+
+    def test_days(self) -> None:
+        assert "day" in _format_duration(1440)
+
+
+# ---------------------------------------------------------------------------
 # get_alarm2_config_page_data — legacy fallback
 # ---------------------------------------------------------------------------
 
@@ -211,10 +251,9 @@ class TestGetAlarm2ConfigPageData:
                 "phw-to-mpi-outgoing": {
                     "alarm_enabled": True,
                     "workflow_id": "phw-to-mpi",
-                    "day_threshold": 10,
-                    "evening_threshold": 5,
-                    "weekend_threshold": 2,
-                    "window_duration_minutes": 1440,
+                    "day_threshold_minutes": 10,
+                    "evening_threshold_minutes": 5,
+                    "weekend_threshold_minutes": 2,
                     "alerting_gap_minutes": 60,
                 }
             }
@@ -223,9 +262,9 @@ class TestGetAlarm2ConfigPageData:
             data = get_alarm2_config_page_data()
 
         rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
-        assert rule["day_threshold"] == 10
-        assert rule["evening_threshold"] == 5
-        assert rule["weekend_threshold"] == 2
+        assert rule["day_threshold_minutes"] == 10
+        assert rule["evening_threshold_minutes"] == 5
+        assert rule["weekend_threshold_minutes"] == 2
 
     def test_legacy_config_fans_out_threshold_to_all_periods(self) -> None:
         fake_cfg = {
@@ -234,7 +273,6 @@ class TestGetAlarm2ConfigPageData:
                     "alarm_enabled": True,
                     "workflow_id": "phw-to-mpi",
                     "threshold": 42,  # Legacy single value
-                    "window_duration_minutes": 1440,
                     "alerting_gap_minutes": 60,
                 }
             }
@@ -243,41 +281,20 @@ class TestGetAlarm2ConfigPageData:
             data = get_alarm2_config_page_data()
 
         rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
-        assert rule["day_threshold"] == 42
-        assert rule["evening_threshold"] == 42
-        assert rule["weekend_threshold"] == 42
+        # Legacy threshold fans out to defaults (config page reads _minutes keys directly)
+        assert rule["day_threshold_minutes"] == DEFAULT_DAY_THRESHOLD
+        assert rule["evening_threshold_minutes"] == DEFAULT_EVENING_THRESHOLD
+        assert rule["weekend_threshold_minutes"] == DEFAULT_WEEKEND_THRESHOLD
 
     def test_missing_config_returns_defaults(self) -> None:
         with patch("dashboard.services.alarm2.load_alarm2_config", return_value={"rules": {}}):
             data = get_alarm2_config_page_data()
 
         rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
-        assert rule["day_threshold"] == DEFAULT_DAY_THRESHOLD
-        assert rule["evening_threshold"] == DEFAULT_EVENING_THRESHOLD
-        assert rule["weekend_threshold"] == DEFAULT_WEEKEND_THRESHOLD
+        assert rule["day_threshold_minutes"] == DEFAULT_DAY_THRESHOLD
+        assert rule["evening_threshold_minutes"] == DEFAULT_EVENING_THRESHOLD
+        assert rule["weekend_threshold_minutes"] == DEFAULT_WEEKEND_THRESHOLD
         assert rule["alarm_enabled"] is False
-
-
-# ---------------------------------------------------------------------------
-# _window_label
-# ---------------------------------------------------------------------------
-
-
-class TestWindowLabel:
-    def test_minutes_below_hour(self) -> None:
-        assert _window_label(30) == "30 min"
-
-    def test_exactly_one_hour(self) -> None:
-        assert _window_label(60) == "1 hr"
-
-    def test_multiple_hours(self) -> None:
-        assert _window_label(120) == "2 hrs"
-
-    def test_exactly_one_day(self) -> None:
-        assert _window_label(1440) == "1 day"
-
-    def test_multiple_days(self) -> None:
-        assert _window_label(2880) == "2 days"
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -160,8 +160,8 @@ class TestBuildRow:
         assert row["weekend_threshold_minutes"] == 5
 
     def test_legacy_threshold_fallback_in_display_fields(self) -> None:
-        """Rows built from legacy config: display fields show defaults (legacy 'threshold'
-        only affects alarm evaluation via _applicable_threshold, not the display columns)."""
+        """Rows built from legacy config expose the legacy 'threshold' value for all three
+        display fields, so the table shows a meaningful number rather than the default."""
         legacy_cfg = {
             "threshold": 77,
             "workflow_id": "phw-to-mpi",
@@ -177,9 +177,9 @@ class TestBuildRow:
             cooldown_remaining=None,
             now=MON_DAY,
         )
-        assert row["day_threshold_minutes"] == DEFAULT_DAY_THRESHOLD
-        assert row["evening_threshold_minutes"] == DEFAULT_EVENING_THRESHOLD
-        assert row["weekend_threshold_minutes"] == DEFAULT_WEEKEND_THRESHOLD
+        assert row["day_threshold_minutes"] == 77
+        assert row["evening_threshold_minutes"] == 77
+        assert row["weekend_threshold_minutes"] == 77
 
     def test_last_message_display_populated(self) -> None:
         row = self._row(MON_DAY)

--- a/dashboard/tests/test_alarm2.py
+++ b/dashboard/tests/test_alarm2.py
@@ -281,10 +281,9 @@ class TestGetAlarm2ConfigPageData:
             data = get_alarm2_config_page_data()
 
         rule = next(r for r in data if r["id"] == "phw-to-mpi-outgoing")
-        # Legacy threshold fans out to defaults (config page reads _minutes keys directly)
-        assert rule["day_threshold_minutes"] == DEFAULT_DAY_THRESHOLD
-        assert rule["evening_threshold_minutes"] == DEFAULT_EVENING_THRESHOLD
-        assert rule["weekend_threshold_minutes"] == DEFAULT_WEEKEND_THRESHOLD
+        assert rule["day_threshold_minutes"] == 42
+        assert rule["evening_threshold_minutes"] == 42
+        assert rule["weekend_threshold_minutes"] == 42
 
     def test_missing_config_returns_defaults(self) -> None:
         with patch("dashboard.services.alarm2.load_alarm2_config", return_value={"rules": {}}):

--- a/dashboard/tests/test_alarm_time_utils.py
+++ b/dashboard/tests/test_alarm_time_utils.py
@@ -1,9 +1,13 @@
 """Unit tests for alarm_time_utils.get_current_period().
 
-All boundary cases for the three time periods:
-  Weekend : Fri 17:00 → Mon 08:00 (UTC)
-  Day     : Mon–Fri 08:00–17:00 (UTC)
+All boundary cases for the three time periods (UK local time — Europe/London):
+  Weekend : Fri 17:00 → Mon 09:00
+  Day     : Mon–Fri 09:00–17:00
   Evening : everything else (weeknights)
+
+UTC boundary notes (June — BST +01:00):
+  Day start : 08:00 UTC = 09:00 BST
+  Day end   : 16:00 UTC = 17:00 BST
 """
 
 from __future__ import annotations
@@ -42,7 +46,7 @@ NEXT_MON = (2026, 6, 29)
 
 
 class TestWeekendPeriod:
-    """Fri 17:00 through Mon 08:00 (exclusive) is always 'weekend'."""
+    """Fri 17:00 through Mon 09:00 BST (exclusive) is always 'weekend'."""
 
     def test_friday_at_day_end_is_weekend(self) -> None:
         assert get_current_period(_utc(*FRI, 17, 0)) == "weekend"
@@ -63,18 +67,18 @@ class TestWeekendPeriod:
         assert get_current_period(_utc(*SUN, 12, 0)) == "weekend"
 
     def test_monday_00_00_is_weekend(self) -> None:
-        """Mon 00:00 is still inside the Fri 17:00 → Mon 08:00 window."""
+        """Mon 00:00 is still inside the Fri 17:00 → Mon 09:00 BST window."""
         assert get_current_period(_utc(*NEXT_MON, 0, 0)) == "weekend"
 
     def test_monday_07_59_is_weekend(self) -> None:
         assert get_current_period(_utc(*NEXT_MON, 7, 59)) == "weekend"
 
-    def test_friday_16_59_is_not_weekend(self) -> None:
-        """One minute before 17:00 on Friday is still Day."""
-        assert get_current_period(_utc(*FRI, 16, 59)) == "day"
+    def test_friday_15_59_is_not_weekend(self) -> None:
+        """One minute before 17:00 UK on Friday (15:59 UTC = 16:59 BST) is still Day."""
+        assert get_current_period(_utc(*FRI, 15, 59)) == "day"
 
     def test_monday_08_00_is_not_weekend(self) -> None:
-        """Mon 08:00 marks the start of Day — weekend ends here."""
+        """Mon 09:00 BST marks the start of Day — weekend ends here."""
         assert get_current_period(_utc(*NEXT_MON, 8, 0)) == "day"
 
 
@@ -84,7 +88,7 @@ class TestWeekendPeriod:
 
 
 class TestDayPeriod:
-    """Mon–Fri 08:00–16:59 (UTC) is 'day'."""
+    """Mon–Fri 09:00–17:00 UK (08:00–16:00 UTC in BST) is 'day'."""
 
     def test_monday_day_start(self) -> None:
         assert get_current_period(_utc(*MON, 8, 0)) == "day"
@@ -93,7 +97,8 @@ class TestDayPeriod:
         assert get_current_period(_utc(*MON, 12, 0)) == "day"
 
     def test_monday_last_minute(self) -> None:
-        assert get_current_period(_utc(*MON, 16, 59)) == "day"
+        """15:59 UTC = 16:59 BST — one minute before 17:00 UK end of Day."""
+        assert get_current_period(_utc(*MON, 15, 59)) == "day"
 
     def test_tuesday_midday(self) -> None:
         assert get_current_period(_utc(*TUE, 12, 0)) == "day"
@@ -111,7 +116,8 @@ class TestDayPeriod:
         assert get_current_period(_utc(*FRI, 12, 0)) == "day"
 
     def test_friday_last_minute(self) -> None:
-        assert get_current_period(_utc(*FRI, 16, 59)) == "day"
+        """15:59 UTC = 16:59 BST — one minute before 17:00 UK end of Day."""
+        assert get_current_period(_utc(*FRI, 15, 59)) == "day"
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +126,7 @@ class TestDayPeriod:
 
 
 class TestEveningPeriod:
-    """Weeknights (Mon–Thu 17:00 → next day 08:00) are 'evening'."""
+    """Weeknights (Mon–Thu 17:00 → next day 09:00 BST) are 'evening'."""
 
     def test_monday_17_00_is_evening(self) -> None:
         assert get_current_period(_utc(*MON, 17, 0)) == "evening"
@@ -158,16 +164,22 @@ class TestEveningPeriod:
 
 
 class TestUTCNormalisation:
-    """Timezone-aware non-UTC datetimes should be normalised before classification."""
+    """Timezone-aware non-UTC datetimes should be classified in UK local time."""
 
-    def test_bst_aware_datetime_normalised_to_utc(self) -> None:
-        """A BST (+01:00) datetime that is 17:30 local = 16:30 UTC → 'day'."""
+    def test_bst_aware_datetime_classified_in_uk_time(self) -> None:
+        """A BST (+01:00) datetime of 16:00 BST = 16:00 UK time → 'day' (between 09:00–17:00 UK)."""
         bst = tz(timedelta(hours=1))
-        # Tue 16 Jun 2026, 17:30 BST = 16:30 UTC → day
-        aware_bst = datetime(2026, 6, 23, 17, 30, tzinfo=bst)  # Tuesday
+        # Tue 23 Jun 2026, 16:00 BST = 16:00 UK = day
+        aware_bst = datetime(2026, 6, 23, 16, 0, tzinfo=bst)  # Tuesday
         assert get_current_period(aware_bst) == "day"
+
+    def test_bst_aware_datetime_after_17_is_evening(self) -> None:
+        """A BST (+01:00) datetime of 17:30 BST = 17:30 UK time → 'evening' (after 17:00 UK)."""
+        bst = tz(timedelta(hours=1))
+        aware_bst = datetime(2026, 6, 23, 17, 30, tzinfo=bst)  # Tuesday
+        assert get_current_period(aware_bst) == "evening"
 
     def test_naive_datetime_treated_as_utc(self) -> None:
         """A naive datetime (no tzinfo) is treated as UTC."""
-        naive_midday_mon = datetime(2026, 6, 22, 12, 0)  # Monday
+        naive_midday_mon = datetime(2026, 6, 22, 12, 0)  # Monday 12:00 UTC = 13:00 BST → day
         assert get_current_period(naive_midday_mon) == "day"

--- a/dashboard/tests/test_flows.py
+++ b/dashboard/tests/test_flows.py
@@ -25,17 +25,20 @@ TEST_FLOWS = {
 }
 
 # Patch config thresholds to known values so tests are env-independent
-_THRESHOLD_PATCH = {
-    "dashboard.services.flows.config.QUEUE_WARNING_THRESHOLD": 10,
-    "dashboard.services.flows.config.QUEUE_CRITICAL_THRESHOLD": 50,
-    "dashboard.services.flows.config.DLQ_WARNING_THRESHOLD": 1,
+_THRESHOLD_KWARGS: dict[str, int] = {
+    "QUEUE_WARNING_THRESHOLD": 10,
+    "QUEUE_CRITICAL_THRESHOLD": 50,
+    "DLQ_WARNING_THRESHOLD": 1,
 }
 
 
 class TestQueueHealth:
     def test_healthy_when_empty(self) -> None:
         with patch.multiple(
-            "dashboard.services.flows.config", **{k.split(".")[-1]: v for k, v in _THRESHOLD_PATCH.items()}
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
         ):
             assert queue_health(0, 0) == "healthy"
 

--- a/dashboard/tests/test_flows.py
+++ b/dashboard/tests/test_flows.py
@@ -5,6 +5,8 @@ Pure logic — no Azure calls, no mocking needed.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from dashboard.services.flows import _FLOW_DEFS, flow_health, overall_health, queue_health
 
 # Test flows with hardcoded queue names - independent of config.py
@@ -22,25 +24,65 @@ TEST_FLOWS = {
     },
 }
 
+# Patch config thresholds to known values so tests are env-independent
+_THRESHOLD_PATCH = {
+    "dashboard.services.flows.config.QUEUE_WARNING_THRESHOLD": 10,
+    "dashboard.services.flows.config.QUEUE_CRITICAL_THRESHOLD": 50,
+    "dashboard.services.flows.config.DLQ_WARNING_THRESHOLD": 1,
+}
+
 
 class TestQueueHealth:
     def test_healthy_when_empty(self) -> None:
-        assert queue_health(0, 0) == "healthy"
+        with patch.multiple(
+            "dashboard.services.flows.config", **{k.split(".")[-1]: v for k, v in _THRESHOLD_PATCH.items()}
+        ):
+            assert queue_health(0, 0) == "healthy"
 
     def test_healthy_below_warning(self) -> None:
-        assert queue_health(9, 0) == "healthy"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert queue_health(9, 0) == "healthy"
 
     def test_warning_at_threshold(self) -> None:
-        assert queue_health(10, 0) == "warning"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert queue_health(10, 0) == "warning"
 
     def test_warning_with_dlq(self) -> None:
-        assert queue_health(0, 1) == "warning"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert queue_health(0, 1) == "warning"
 
     def test_critical_at_threshold(self) -> None:
-        assert queue_health(50, 0) == "critical"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert queue_health(50, 0) == "critical"
 
     def test_critical_overrides_dlq(self) -> None:
-        assert queue_health(50, 5) == "critical"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert queue_health(50, 5) == "critical"
 
 
 class TestFlowHealth:
@@ -52,14 +94,26 @@ class TestFlowHealth:
             "pre-phw-transform": self._make_queue("pre-phw-transform"),
             "post-phw-transform": self._make_queue("post-phw-transform"),
         }
-        assert flow_health("phw-to-mpi", queues_by_name, TEST_FLOWS) == "healthy"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert flow_health("phw-to-mpi", queues_by_name, TEST_FLOWS) == "healthy"
 
     def test_warning_when_pre_queue_at_threshold(self) -> None:
         queues_by_name = {
             "pre-phw-transform": self._make_queue("pre-phw-transform", active=15),
             "post-phw-transform": self._make_queue("post-phw-transform"),
         }
-        assert flow_health("phw-to-mpi", queues_by_name, TEST_FLOWS) == "warning"
+        with patch.multiple(
+            "dashboard.services.flows.config",
+            QUEUE_WARNING_THRESHOLD=10,
+            QUEUE_CRITICAL_THRESHOLD=50,
+            DLQ_WARNING_THRESHOLD=1,
+        ):
+            assert flow_health("phw-to-mpi", queues_by_name, TEST_FLOWS) == "warning"
 
     def test_critical_when_post_queue_critical(self) -> None:
         queues_by_name = {

--- a/dashboard/translations/cy/LC_MESSAGES/messages.po
+++ b/dashboard/translations/cy/LC_MESSAGES/messages.po
@@ -152,24 +152,24 @@ msgid "Active period:"
 msgstr "On the go now:"
 
 #: dashboard/templates/alarm.html:118
-msgid "Day (Mon–Fri 08:00–17:00)"
-msgstr "Daytime (Mon–Fri 08:00–17:00)"
+msgid "Day (Mon–Fri 09:00–17:00)"
+msgstr "Daytime (Mon–Fri 09:00–17:00)"
 
 #: dashboard/templates/alarm.html:120
 msgid "— day threshold applies"
 msgstr "— day limit's on, like"
 
 #: dashboard/templates/alarm.html:123
-msgid "Evening (Mon–Fri 17:00–08:00)"
-msgstr "Evening time (Mon–Fri 17:00–08:00)"
+msgid "Evening (Mon–Fri 17:00–09:00)"
+msgstr "Evening time (Mon–Fri 17:00–09:00)"
 
 #: dashboard/templates/alarm.html:125
 msgid "— evening threshold applies"
 msgstr "— evening limit's on, mun"
 
 #: dashboard/templates/alarm.html:128
-msgid "Weekend (Fri 17:00 – Mon 08:00)"
-msgstr "Weekend, like (Fri 17:00 – Mon 08:00)"
+msgid "Weekend (Fri 17:00 – Mon 09:00)"
+msgstr "Weekend, like (Fri 17:00 – Mon 09:00)"
 
 #: dashboard/templates/alarm.html:130
 msgid "— weekend threshold applies"
@@ -682,8 +682,8 @@ msgid "Mon–Fri 17:00–08:00"
 msgstr "Mon–Fri 17:00–08:00, mun"
 
 #: dashboard/templates/alarm_config.html:53
-msgid "Fri 17:00 → Mon 08:00"
-msgstr "Fri 17:00 → Mon 08:00, butt"
+msgid "Fri 17:00 → Mon 09:00"
+msgstr "Fri 17:00 → Mon 09:00, butt"
 
 #: dashboard/templates/alarm_config.html:75
 msgid "Alarm 1"
@@ -721,9 +721,9 @@ msgid "Weekend Threshold"
 msgstr "Weekend Limit, Mun"
 
 #: dashboard/templates/alarm_config.html:201
-msgid "No messages for this long (Fri 17:00–Mon 08:00) → alarm fires"
+msgid "No messages for this long (Fri 17:00–Mon 09:00) → alarm fires"
 msgstr ""
-"No messages for this long over the weekend (Fri 17:00–Mon 08:00) → goes "
+"No messages for this long over the weekend (Fri 17:00–Mon 09:00) → goes "
 "off, butt"
 
 #: dashboard/templates/alarm_config.html:255

--- a/dashboard/translations/en/LC_MESSAGES/messages.po
+++ b/dashboard/translations/en/LC_MESSAGES/messages.po
@@ -151,7 +151,7 @@ msgid "Active period:"
 msgstr ""
 
 #: dashboard/templates/alarm.html:118
-msgid "Day (Mon–Fri 08:00–17:00)"
+msgid "Day (Mon–Fri 09:00–17:00)"
 msgstr ""
 
 #: dashboard/templates/alarm.html:120
@@ -159,7 +159,7 @@ msgid "— day threshold applies"
 msgstr ""
 
 #: dashboard/templates/alarm.html:123
-msgid "Evening (Mon–Fri 17:00–08:00)"
+msgid "Evening (Mon–Fri 17:00–09:00)"
 msgstr ""
 
 #: dashboard/templates/alarm.html:125
@@ -167,7 +167,7 @@ msgid "— evening threshold applies"
 msgstr ""
 
 #: dashboard/templates/alarm.html:128
-msgid "Weekend (Fri 17:00 – Mon 08:00)"
+msgid "Weekend (Fri 17:00 – Mon 09:00)"
 msgstr ""
 
 #: dashboard/templates/alarm.html:130
@@ -666,7 +666,7 @@ msgid "— this prevents repeated alerts for the same ongoing outage."
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:49
-msgid "Mon–Fri 08:00–17:00"
+msgid "Mon–Fri 09:00–17:00"
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:51
@@ -674,7 +674,7 @@ msgid "Mon–Fri 17:00–08:00"
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:53
-msgid "Fri 17:00 → Mon 08:00"
+msgid "Fri 17:00 → Mon 09:00"
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:75
@@ -709,7 +709,7 @@ msgid "Weekend Threshold"
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:201
-msgid "No messages for this long (Fri 17:00–Mon 08:00) → alarm fires"
+msgid "No messages for this long (Fri 17:00–Mon 09:00) → alarm fires"
 msgstr ""
 
 #: dashboard/templates/alarm_config.html:255

--- a/dashboard/uv.lock
+++ b/dashboard/uv.lock
@@ -484,6 +484,7 @@ dependencies = [
     { name = "flask-babel" },
     { name = "gunicorn" },
     { name = "python-dotenv" },
+    { name = "tzdata" },
 ]
 
 [package.dev-dependencies]
@@ -507,6 +508,7 @@ requires-dist = [
     { name = "flask-babel", specifier = ">=4.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "tzdata", specifier = ">=2024.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -933,6 +935,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Updated Alarm 2, Alarm 3, and general alarm configuration templates to reflect new time periods:
  - Changed operational hours from Mon–Fri 08:00–17:00 to Mon–Fri 09:00–17:00.
  - Adjusted evening and weekend definitions accordingly.
- Removed the window duration input fields from the alarm configuration as they are no longer applicable.
- Renamed threshold fields in the configuration to reflect inactivity thresholds instead of message counts.
- Added new translations for updated time periods in Welsh and English.
- Updated unit tests to align with the new threshold naming conventions and time period definitions.
- Added tzdata dependency to handle timezone data more effectively.