### PR TITLE
feat: add Email OOH toggle functionality and corresponding tests

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -840,6 +840,7 @@ def alarm_config_page() -> str:
             entry = rules_cfg.setdefault(rid, {})
             entry["alarm_enabled"] = f"enabled_{rid}" in request.form
             entry["email_alerts_enabled"] = f"email_{rid}" in request.form
+            entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
             entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60)
@@ -861,6 +862,7 @@ def alarm_config_page() -> str:
                 "weekend_threshold_minutes": _int("new_weekend_threshold", 240),
                 "alerting_gap_minutes": _int("new_alerting_gap", 60),
                 "email_alerts_enabled": False,
+                "email_ooh_enabled": False,
             }
 
         save_alarm_config(cfg)
@@ -1123,6 +1125,7 @@ def alarm2_config_page() -> str:
             entry = rules_cfg.setdefault(rid, {})
             entry["alarm_enabled"] = f"enabled_{rid}" in request.form
             entry["email_alerts_enabled"] = f"email_{rid}" in request.form
+            entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
             entry["day_threshold_minutes"] = _int(f"day_threshold_{rid}", 60, minimum=0)
@@ -1144,6 +1147,7 @@ def alarm2_config_page() -> str:
                 "weekend_threshold_minutes": _int("new_weekend_threshold", 240, minimum=0),
                 "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
+                "email_ooh_enabled": False,
             }
 
         save_alarm2_config(cfg)
@@ -1215,6 +1219,7 @@ def alarm3_config_page() -> str:
             entry = rules_cfg.setdefault(rid, {})
             entry["alarm_enabled"] = f"enabled_{rid}" in request.form
             entry["email_alerts_enabled"] = f"email_{rid}" in request.form
+            entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
             entry["window_duration_minutes"] = _int(f"window_duration_{rid}", 15, minimum=1)
@@ -1233,6 +1238,7 @@ def alarm3_config_page() -> str:
                 "threshold": _int("new_threshold", 1, minimum=1),
                 "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
+                "email_ooh_enabled": False,
             }
 
         save_alarm3_config(cfg)
@@ -1275,4 +1281,4 @@ def health_badge(health: str) -> str:
 
 
 if __name__ == "__main__":
-    app.run(debug=config.FLASK_DEBUG, host="0.0.0.0", port=5000)  # nosec B104
+    app.run(debug=config.FLASK_DEBUG, host="127.0.0.1", port=8080)

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -376,17 +376,21 @@ def _build_status() -> dict:
     for metric in retry_metrics:
         flow_id = metric.get("workflow_id")
         delay_seconds = metric.get("delay_seconds")
-        has_metric = delay_seconds is not None
-        over_1m = bool(has_metric and delay_seconds > 60)
+        has_metric = delay_seconds is not None and isinstance(delay_seconds, (int, float))
+        over_1m = bool(has_metric and delay_seconds and delay_seconds > 60)
         if over_1m:
             flows_over_1m += 1
 
+        delay_display = (
+            f"{int(delay_seconds)}s" if has_metric and delay_seconds is not None
+            else "Metric unavailable"
+        )
         retry_rows.append(
             {
                 "workflow_id": flow_id,
                 "flow_label": flow_labels.get(flow_id, flow_id),
                 "delay_seconds": delay_seconds,
-                "delay_display": f"{int(delay_seconds)}s" if has_metric else "Metric unavailable",
+                "delay_display": delay_display,
                 "attempt": metric.get("attempt"),
                 "queue": metric.get("queue") or "",
                 "microservice_id": metric.get("microservice_id") or "",

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -573,6 +573,7 @@ def get_config_page_data() -> list[dict]:
             "weekend_threshold_minutes": int(rcfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
             "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
             "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
+            "email_ooh_enabled": rcfg.get("email_ooh_enabled", False),
         }
         for rid, rcfg in rules_cfg.items()
         if not rcfg.get("deleted")

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -573,7 +573,7 @@ def get_config_page_data() -> list[dict]:
             "weekend_threshold_minutes": int(rcfg.get("weekend_threshold_minutes", DEFAULT_WEEKEND_THRESHOLD)),
             "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
             "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
-            "email_ooh_enabled": rcfg.get("email_ooh_enabled", False),
+            "email_ooh_enabled": rcfg.get("email_ooh_enabled", False) and rcfg.get("email_alerts_enabled", False),
         }
         for rid, rcfg in rules_cfg.items()
         if not rcfg.get("deleted")

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -629,7 +629,7 @@ def get_alarm2_config_page_data() -> list[dict]:
                 ),
                 "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
                 "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
-                "email_ooh_enabled": rcfg.get("email_ooh_enabled", False),
+                "email_ooh_enabled": rcfg.get("email_ooh_enabled", False) and rcfg.get("email_alerts_enabled", False),
             }
         )
     return result

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -629,6 +629,7 @@ def get_alarm2_config_page_data() -> list[dict]:
                 ),
                 "alerting_gap_minutes": int(rcfg.get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
                 "email_alerts_enabled": rcfg.get("email_alerts_enabled", False),
+                "email_ooh_enabled": rcfg.get("email_ooh_enabled", False),
             }
         )
     return result

--- a/dashboard/dashboard/services/alarm3.py
+++ b/dashboard/dashboard/services/alarm3.py
@@ -533,7 +533,10 @@ def get_alarm3_config_page_data() -> list[dict]:
             "threshold": int(rules_cfg.get(r["id"], {}).get("threshold", DEFAULT_THRESHOLD)),
             "alerting_gap_minutes": int(rules_cfg.get(r["id"], {}).get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
             "email_alerts_enabled": rules_cfg.get(r["id"], {}).get("email_alerts_enabled", False),
-            "email_ooh_enabled": rules_cfg.get(r["id"], {}).get("email_ooh_enabled", False),
+            "email_ooh_enabled": (
+                rules_cfg.get(r["id"], {}).get("email_ooh_enabled", False)
+                and rules_cfg.get(r["id"], {}).get("email_alerts_enabled", False)
+            ),
         }
         for r in _all_known_rules(rules_cfg)
     ]

--- a/dashboard/dashboard/services/alarm3.py
+++ b/dashboard/dashboard/services/alarm3.py
@@ -533,6 +533,7 @@ def get_alarm3_config_page_data() -> list[dict]:
             "threshold": int(rules_cfg.get(r["id"], {}).get("threshold", DEFAULT_THRESHOLD)),
             "alerting_gap_minutes": int(rules_cfg.get(r["id"], {}).get("alerting_gap_minutes", DEFAULT_ALERTING_GAP)),
             "email_alerts_enabled": rules_cfg.get(r["id"], {}).get("email_alerts_enabled", False),
+            "email_ooh_enabled": rules_cfg.get(r["id"], {}).get("email_ooh_enabled", False),
         }
         for r in _all_known_rules(rules_cfg)
     ]

--- a/dashboard/dashboard/services/azure_monitor.py
+++ b/dashboard/dashboard/services/azure_monitor.py
@@ -10,6 +10,8 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import requests
+from azure.mgmt.appcontainers import ContainerAppsAPIClient  # noqa: PLC0415
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
@@ -184,16 +186,16 @@ def get_retry_delay_metrics_by_flow(hours: int = 1, min_delay_seconds: float = 6
         return []
 
     query = f"""
-    AppMetrics
+    customMetrics
     | where TimeGenerated > ago({hours}h)
-    | where Name == "retry_delay_seconds"
-    | extend workflow_id = tostring(Properties["workflow_id"])
-    | extend microservice_id = tostring(Properties["microservice_id"])
-    | extend queue = tostring(Properties["queue"])
-    | extend attempt = tostring(Properties["attempt"])
+    | where name == "retry_delay_seconds"
+    | extend workflow_id = tostring(customDimensions.workflow_id)
+    | extend microservice_id = tostring(customDimensions.microservice_id)
+    | extend queue = tostring(customDimensions.queue)
+    | extend attempt = tostring(customDimensions.attempt)
     | where isnotempty(workflow_id)
-    | summarize arg_max(TimeGenerated, Sum, microservice_id, queue, attempt) by workflow_id
-    | project workflow_id, timestamp=TimeGenerated, delay_seconds=todouble(Sum), microservice_id, queue, attempt
+    | summarize arg_max(TimeGenerated, value, microservice_id, queue, attempt) by workflow_id
+    | project workflow_id, timestamp=TimeGenerated, delay_seconds=todouble(value), microservice_id, queue, attempt
     | where delay_seconds > {min_delay_seconds}
     | order by workflow_id asc
     """
@@ -215,7 +217,9 @@ def get_retry_delay_metrics_by_flow(hours: int = 1, min_delay_seconds: float = 6
                 attempt_value = row_dict.get("attempt")
                 attempt_int: int | None
                 try:
-                    attempt_int = int(attempt_value) if attempt_value not in (None, "") else None
+                    attempt_int = (
+                        int(attempt_value) if attempt_value not in (None, "") and attempt_value is not None else None
+                    )
                 except (TypeError, ValueError):
                     attempt_int = None
 
@@ -262,9 +266,6 @@ def get_container_app_metrics() -> list[dict]:
         return []
 
     try:
-        import requests  # noqa: PLC0415
-        from azure.mgmt.appcontainers import ContainerAppsAPIClient  # noqa: PLC0415
-
         cred = get_azure_credential()
         # Use the per-resource metrics REST endpoint — requires only Microsoft.Insights/metrics/read
         # on each resource, not the subscription-level metrics:getBatch permission needed by the

--- a/dashboard/dashboard/templates/alarm2_config.html
+++ b/dashboard/dashboard/templates/alarm2_config.html
@@ -114,6 +114,29 @@
           </div>
           <!-- divider -->
           <div style="width:1px; height:24px; background:var(--border-color);"></div>
+          <!-- Email OOH toggle -->
+          <div id="ooh_group_{{ r.id }}"
+               style="display:{% if r.email_alerts_enabled %}flex{% else %}none{% endif %}; align-items:center; gap:0.5rem;">
+            <label for="email_ooh_{{ r.id }}"
+                   style="font-size:0.8rem; color:var(--text-muted); cursor:pointer; margin:0;">
+              <i class="bi bi-moon-fill me-1" style="color:var(--accent-cyan);"></i>{{ _("Email OOH") }}
+            </label>
+            <div class="form-check form-switch" style="margin:0; padding-left:0;">
+              <input class="form-check-input"
+                     type="checkbox" role="switch"
+                     id="email_ooh_{{ r.id }}"
+                     name="email_ooh_{{ r.id }}"
+                     {% if r.email_ooh_enabled %}checked{% endif %}
+                     style="width:2.8em; height:1.4em; cursor:pointer; margin:0;">
+            </div>
+            <span id="email_ooh_label_{{ r.id }}"
+                  style="font-size:0.78rem; font-weight:600; min-width:60px;
+                         color:{% if r.email_ooh_enabled %}var(--accent-green){% else %}var(--text-muted){% endif %};">
+              {% if r.email_ooh_enabled %}{{ _("Enabled") }}{% else %}{{ _("Disabled") }}{% endif %}
+            </span>
+          </div>
+          <!-- divider -->
+          <div id="ooh_divider_{{ r.id }}" style="width:1px; height:24px; background:var(--border-color); display:{% if r.email_alerts_enabled %}block{% else %}none{% endif %};"></div>
           <!-- Remove rule -->
           <button type="button"
                   class="btn-dash btn-remove-rule"
@@ -403,6 +426,37 @@
   document.querySelectorAll('[id^="email_"]').forEach(function (cb) {
     var rid = cb.id.replace('email_', '');
     var lbl = document.getElementById('email_label_' + rid);
+    if (!lbl) return;
+    cb.addEventListener('change', function () {
+      lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;
+      lbl.style.color = cb.checked ? 'var(--accent-green)' : 'var(--text-muted)';
+    });
+  });
+
+  // Show/hide Email OOH group when the Email toggle changes
+  document.querySelectorAll('[id^="email_"]').forEach(function (cb) {
+    if (cb.id.indexOf('email_ooh_') === 0) return;
+    var rid = cb.id.replace('email_', '');
+    var oohGroup   = document.getElementById('ooh_group_'   + rid);
+    var oohDivider = document.getElementById('ooh_divider_' + rid);
+    if (!oohGroup) return;
+    cb.addEventListener('change', function () {
+      oohGroup.style.display   = cb.checked ? 'flex'  : 'none';
+      oohDivider.style.display = cb.checked ? 'block' : 'none';
+      // When Email is disabled, uncheck OOH so it is not submitted with the form
+      if (!cb.checked) {
+        var oohCb  = document.getElementById('email_ooh_' + rid);
+        var oohLbl = document.getElementById('email_ooh_label_' + rid);
+        if (oohCb) { oohCb.checked = false; }
+        if (oohLbl) { oohLbl.textContent = i18nDisabled; oohLbl.style.color = 'var(--text-muted)'; }
+      }
+    });
+  });
+
+  // Email OOH toggle label update
+  document.querySelectorAll('[id^="email_ooh_"]').forEach(function (cb) {
+    var rid = cb.id.replace('email_ooh_', '');
+    var lbl = document.getElementById('email_ooh_label_' + rid);
     if (!lbl) return;
     cb.addEventListener('change', function () {
       lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;

--- a/dashboard/dashboard/templates/alarm3_config.html
+++ b/dashboard/dashboard/templates/alarm3_config.html
@@ -428,6 +428,13 @@
     cb.addEventListener('change', function () {
       oohGroup.style.display   = cb.checked ? 'flex'  : 'none';
       oohDivider.style.display = cb.checked ? 'block' : 'none';
+      // When Email is disabled, uncheck OOH so it is not submitted with the form
+      if (!cb.checked) {
+        var oohCb  = document.getElementById('email_ooh_' + rid);
+        var oohLbl = document.getElementById('email_ooh_label_' + rid);
+        if (oohCb) { oohCb.checked = false; }
+        if (oohLbl) { oohLbl.textContent = i18nDisabled; oohLbl.style.color = 'var(--text-muted)'; }
+      }
     });
   });
 

--- a/dashboard/dashboard/templates/alarm3_config.html
+++ b/dashboard/dashboard/templates/alarm3_config.html
@@ -103,6 +103,29 @@
           </div>
           <!-- divider -->
           <div style="width:1px; height:24px; background:var(--border-color);"></div>
+          <!-- Email OOH toggle -->
+          <div id="ooh_group_{{ r.id }}"
+               style="display:{% if r.email_alerts_enabled %}flex{% else %}none{% endif %}; align-items:center; gap:0.5rem;">
+            <label for="email_ooh_{{ r.id }}"
+                   style="font-size:0.8rem; color:var(--text-muted); cursor:pointer; margin:0;">
+              <i class="bi bi-moon-fill me-1" style="color:var(--accent-cyan);"></i>{{ _("Email OOH") }}
+            </label>
+            <div class="form-check form-switch" style="margin:0; padding-left:0;">
+              <input class="form-check-input"
+                     type="checkbox" role="switch"
+                     id="email_ooh_{{ r.id }}"
+                     name="email_ooh_{{ r.id }}"
+                     {% if r.email_ooh_enabled %}checked{% endif %}
+                     style="width:2.8em; height:1.4em; cursor:pointer; margin:0;">
+            </div>
+            <span id="email_ooh_label_{{ r.id }}"
+                  style="font-size:0.78rem; font-weight:600; min-width:60px;
+                         color:{% if r.email_ooh_enabled %}var(--accent-green){% else %}var(--text-muted){% endif %};">
+              {% if r.email_ooh_enabled %}{{ _("Enabled") }}{% else %}{{ _("Disabled") }}{% endif %}
+            </span>
+          </div>
+          <!-- divider -->
+          <div id="ooh_divider_{{ r.id }}" style="width:1px; height:24px; background:var(--border-color); display:{% if r.email_alerts_enabled %}block{% else %}none{% endif %};"></div>
           <!-- Remove rule -->
           <button type="button"
                   class="btn-dash btn-remove-rule"
@@ -388,6 +411,30 @@
   document.querySelectorAll('[id^="email_"]').forEach(function (cb) {
     var rid = cb.id.replace('email_', '');
     var lbl = document.getElementById('email_label_' + rid);
+    if (!lbl) return;
+    cb.addEventListener('change', function () {
+      lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;
+      lbl.style.color = cb.checked ? 'var(--accent-green)' : 'var(--text-muted)';
+    });
+  });
+
+  // Show/hide Email OOH group when the Email toggle changes
+  document.querySelectorAll('[id^="email_"]').forEach(function (cb) {
+    if (cb.id.indexOf('email_ooh_') === 0) return;
+    var rid = cb.id.replace('email_', '');
+    var oohGroup   = document.getElementById('ooh_group_'   + rid);
+    var oohDivider = document.getElementById('ooh_divider_' + rid);
+    if (!oohGroup) return;
+    cb.addEventListener('change', function () {
+      oohGroup.style.display   = cb.checked ? 'flex'  : 'none';
+      oohDivider.style.display = cb.checked ? 'block' : 'none';
+    });
+  });
+
+  // Email OOH toggle label update
+  document.querySelectorAll('[id^="email_ooh_"]').forEach(function (cb) {
+    var rid = cb.id.replace('email_ooh_', '');
+    var lbl = document.getElementById('email_ooh_label_' + rid);
     if (!lbl) return;
     cb.addEventListener('change', function () {
       lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;

--- a/dashboard/dashboard/templates/alarm_config.html
+++ b/dashboard/dashboard/templates/alarm_config.html
@@ -115,6 +115,30 @@
           </div>
           <!-- divider -->
           <div style="width:1px; height:24px; background:var(--border-color);"></div>
+          <!-- Email OOH toggle -->
+          <div id="ooh_group_{{ s.id }}"
+               style="display:{% if s.email_alerts_enabled %}flex{% else %}none{% endif %}; align-items:center; gap:0.5rem;">
+            <label for="email_ooh_{{ s.id }}"
+                   style="font-size:0.8rem; color:var(--text-muted); cursor:pointer; margin:0;">
+              <i class="bi bi-moon-fill me-1" style="color:var(--accent-cyan);"></i>{{ _("Email OOH") }}
+            </label>
+            <div class="form-check form-switch" style="margin:0; padding-left:0;">
+              <input class="form-check-input"
+                     type="checkbox"
+                     role="switch"
+                     id="email_ooh_{{ s.id }}"
+                     name="email_ooh_{{ s.id }}"
+                     {% if s.email_ooh_enabled %}checked{% endif %}
+                     style="width:2.8em; height:1.4em; cursor:pointer; margin:0;">
+            </div>
+            <span id="email_ooh_label_{{ s.id }}"
+                  style="font-size:0.78rem; font-weight:600; min-width:60px;
+                         color:{% if s.email_ooh_enabled %}var(--accent-green){% else %}var(--text-muted){% endif %};">
+              {% if s.email_ooh_enabled %}{{ _("Enabled") }}{% else %}{{ _("Disabled") }}{% endif %}
+            </span>
+          </div>
+          <!-- divider -->
+          <div id="ooh_divider_{{ s.id }}" style="width:1px; height:24px; background:var(--border-color); display:{% if s.email_alerts_enabled %}block{% else %}none{% endif %};"></div>
           <!-- Remove server -->
           <button type="button"
                   class="btn-dash btn-remove-rule"
@@ -435,6 +459,37 @@
   document.querySelectorAll('input[id^="email_"]').forEach(function (cb) {
     var sid = cb.id.replace('email_', '');
     var lbl = document.getElementById('email_label_' + sid);
+    if (!lbl) return;
+    cb.addEventListener('change', function () {
+      lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;
+      lbl.style.color = cb.checked ? 'var(--accent-green)' : 'var(--text-muted)';
+    });
+  });
+
+  // Show/hide Email OOH group when the Email toggle changes
+  document.querySelectorAll('input[id^="email_"]').forEach(function (cb) {
+    if (cb.id.indexOf('email_ooh_') === 0) return;
+    var sid = cb.id.replace('email_', '');
+    var oohGroup   = document.getElementById('ooh_group_'   + sid);
+    var oohDivider = document.getElementById('ooh_divider_' + sid);
+    if (!oohGroup) return;
+    cb.addEventListener('change', function () {
+      oohGroup.style.display   = cb.checked ? 'flex'  : 'none';
+      oohDivider.style.display = cb.checked ? 'block' : 'none';
+      // When Email is disabled, uncheck OOH so it is not submitted with the form
+      if (!cb.checked) {
+        var oohCb  = document.getElementById('email_ooh_' + sid);
+        var oohLbl = document.getElementById('email_ooh_label_' + sid);
+        if (oohCb) { oohCb.checked = false; }
+        if (oohLbl) { oohLbl.textContent = i18nDisabled; oohLbl.style.color = 'var(--text-muted)'; }
+      }
+    });
+  });
+
+  // Email OOH toggle label update
+  document.querySelectorAll('input[id^="email_ooh_"]').forEach(function (cb) {
+    var sid = cb.id.replace('email_ooh_', '');
+    var lbl = document.getElementById('email_ooh_label_' + sid);
     if (!lbl) return;
     cb.addEventListener('change', function () {
       lbl.textContent = cb.checked ? i18nEnabled : i18nDisabled;

--- a/dashboard/tests/test_email_ooh_guard.py
+++ b/dashboard/tests/test_email_ooh_guard.py
@@ -1,0 +1,247 @@
+"""Unit tests for the Email OOH guard on alarm config POST handlers.
+
+Covers the fix that forces ``email_ooh_enabled`` to ``False`` whenever
+``email_alerts_enabled`` is ``False``, applied in all three alarm config
+routes (Alarm 1 / Alarm 2 / Alarm 3).
+
+The guard exists in two places:
+  1. Frontend JS – unchecks the OOH toggle when Email is toggled off so the
+     browser never submits a stale checked-but-hidden value.
+  2. Backend (app.py POST handlers) – defensive ``and email_alerts_enabled``
+     guard that enforces the invariant server-side regardless of form input.
+
+These tests cover the backend layer only (the JS layer is not exercised in
+Python unit tests).  The key scenario is: OOH checkbox value IS present in
+the submitted form (simulating the pre-fix bug where a checked-but-hidden
+checkbox was still submitted), but Email toggle is NOT present (unchecked).
+The saved config must show ``email_ooh_enabled = False``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask.testing import FlaskClient
+
+from dashboard import app as app_module
+
+app = app_module.app
+
+# A rule ID used across all test classes.
+RID = "phw-to-mpi-outgoing"
+
+
+# ---------------------------------------------------------------------------
+# Shared client fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client() -> Generator[FlaskClient, None, None]:
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers – build minimal valid form payloads for each alarm type
+# ---------------------------------------------------------------------------
+
+
+def _alarm1_form(rid: str, *, email: bool, email_ooh: bool) -> dict:
+    """Minimal form payload for /alarm-config (Alarm 1 — inactivity)."""
+    data: dict = {
+        f"alerting_gap_{rid}": "60",
+        f"day_threshold_{rid}": "60",
+        f"evening_threshold_{rid}": "120",
+        f"weekend_threshold_{rid}": "240",
+        f"workflow_id_{rid}": "phw-to-mpi",
+        f"display_name_{rid}": "PHW to MPI",
+    }
+    if email:
+        data[f"email_{rid}"] = "on"
+    if email_ooh:
+        # Simulate a checked-but-hidden OOH checkbox still being submitted.
+        data[f"email_ooh_{rid}"] = "on"
+    return data
+
+
+def _alarm2_form(rid: str, *, email: bool, email_ooh: bool) -> dict:
+    """Minimal form payload for /alarm2-config (Alarm 2 — outgoing messages)."""
+    data: dict = {
+        f"alerting_gap_{rid}": "60",
+        f"day_threshold_{rid}": "60",
+        f"evening_threshold_{rid}": "120",
+        f"weekend_threshold_{rid}": "240",
+        f"workflow_id_{rid}": "phw-to-mpi",
+        f"display_name_{rid}": "PHW to MPI",
+    }
+    if email:
+        data[f"email_{rid}"] = "on"
+    if email_ooh:
+        data[f"email_ooh_{rid}"] = "on"
+    return data
+
+
+def _alarm3_form(rid: str, *, email: bool, email_ooh: bool) -> dict:
+    """Minimal form payload for /alarm3-config (Alarm 3 — failures)."""
+    data: dict = {
+        f"alerting_gap_{rid}": "60",
+        f"window_duration_{rid}": "15",
+        f"threshold_{rid}": "1",
+        f"workflow_id_{rid}": "phw-to-mpi",
+        f"display_name_{rid}": "PHW to MPI",
+    }
+    if email:
+        data[f"email_{rid}"] = "on"
+    if email_ooh:
+        data[f"email_ooh_{rid}"] = "on"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Alarm 1  (/alarm-config)
+# ---------------------------------------------------------------------------
+
+
+class TestAlarm1EmailOohGuard:
+    """email_ooh_enabled must be False whenever email_alerts_enabled is False."""
+
+    def _post(self, client: FlaskClient, form_data: dict) -> dict:
+        """POST to /alarm-config and return the config dict passed to save."""
+        mock_save = MagicMock()
+        with (
+            patch("dashboard.app.load_alarm_config", return_value={"rules": {}}),
+            patch("dashboard.app.save_alarm_config", mock_save),
+            patch("dashboard.app.get_config_page_data", return_value=[]),
+        ):
+            resp = client.post("/alarm-config", data=form_data)
+        assert resp.status_code == 200
+        mock_save.assert_called_once()
+        return mock_save.call_args[0][0]
+
+    def test_email_off_ooh_submitted_saves_ooh_false(self, client: FlaskClient) -> None:
+        """Core bug scenario: OOH checkbox submitted despite Email being off.
+
+        Before the fix, the hidden-but-checked OOH checkbox would be submitted
+        and saved as True.  After the fix the backend guard must force it False.
+        """
+        cfg = self._post(client, _alarm1_form(RID, email=False, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_on_ooh_on_saves_both_true(self, client: FlaskClient) -> None:
+        """When Email is enabled and OOH is checked, both flags are saved True."""
+        cfg = self._post(client, _alarm1_form(RID, email=True, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is True
+
+    def test_email_on_ooh_off_saves_ooh_false(self, client: FlaskClient) -> None:
+        """Email on, OOH unchecked → OOH saved as False."""
+        cfg = self._post(client, _alarm1_form(RID, email=True, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_off_ooh_off_saves_both_false(self, client: FlaskClient) -> None:
+        """Both unchecked → both saved as False."""
+        cfg = self._post(client, _alarm1_form(RID, email=False, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Alarm 2  (/alarm2-config)
+# ---------------------------------------------------------------------------
+
+
+class TestAlarm2EmailOohGuard:
+    """Same OOH guard contract on the Alarm 2 (outgoing messages) config route."""
+
+    def _post(self, client: FlaskClient, form_data: dict) -> dict:
+        mock_save = MagicMock()
+        with (
+            patch("dashboard.app.load_alarm2_config", return_value={"rules": {}}),
+            patch("dashboard.app.save_alarm2_config", mock_save),
+            patch("dashboard.app.get_alarm2_config_page_data", return_value=[]),
+        ):
+            resp = client.post("/alarm2-config", data=form_data)
+        assert resp.status_code == 200
+        mock_save.assert_called_once()
+        return mock_save.call_args[0][0]
+
+    def test_email_off_ooh_submitted_saves_ooh_false(self, client: FlaskClient) -> None:
+        """Core bug scenario: OOH submitted while Email is off — must save False."""
+        cfg = self._post(client, _alarm2_form(RID, email=False, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_on_ooh_on_saves_both_true(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm2_form(RID, email=True, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is True
+
+    def test_email_on_ooh_off_saves_ooh_false(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm2_form(RID, email=True, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_off_ooh_off_saves_both_false(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm2_form(RID, email=False, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Alarm 3  (/alarm3-config)
+# ---------------------------------------------------------------------------
+
+
+class TestAlarm3EmailOohGuard:
+    """Same OOH guard contract on the Alarm 3 (failures) config route."""
+
+    def _post(self, client: FlaskClient, form_data: dict) -> dict:
+        mock_save = MagicMock()
+        with (
+            patch("dashboard.app.load_alarm3_config", return_value={"rules": {}}),
+            patch("dashboard.app.save_alarm3_config", mock_save),
+            patch("dashboard.app.get_alarm3_config_page_data", return_value=[]),
+        ):
+            resp = client.post("/alarm3-config", data=form_data)
+        assert resp.status_code == 200
+        mock_save.assert_called_once()
+        return mock_save.call_args[0][0]
+
+    def test_email_off_ooh_submitted_saves_ooh_false(self, client: FlaskClient) -> None:
+        """Core bug scenario: OOH submitted while Email is off — must save False."""
+        cfg = self._post(client, _alarm3_form(RID, email=False, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_on_ooh_on_saves_both_true(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm3_form(RID, email=True, email_ooh=True))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is True
+
+    def test_email_on_ooh_off_saves_ooh_false(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm3_form(RID, email=True, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is True
+        assert rule["email_ooh_enabled"] is False
+
+    def test_email_off_ooh_off_saves_both_false(self, client: FlaskClient) -> None:
+        cfg = self._post(client, _alarm3_form(RID, email=False, email_ooh=False))
+        rule = cfg["rules"][RID]
+        assert rule["email_alerts_enabled"] is False
+        assert rule["email_ooh_enabled"] is False


### PR DESCRIPTION
This pull request adds support for an "Email OOH" (Out Of Hours) notification option to all alarm configuration types in the dashboard application. Users can now enable or disable OOH email alerts per rule, and the UI dynamically shows or hides the OOH option based on whether regular email alerts are enabled. The backend is updated to store and serve this new setting, and default values are handled for new rules. Additionally, the development server's default host and port are changed.

**Key changes:**

**Feature: Email OOH Option for Alarms**
- Added an `email_ooh_enabled` field to alarm configuration forms, backend processing, and default rule creation for all alarm types. This field is only enabled if `email_alerts_enabled` is also enabled. (`dashboard/dashboard/app.py`, `dashboard/dashboard/services/alarm1.py`, `dashboard/dashboard/services/alarm2.py`, `dashboard/dashboard/services/alarm3.py`) [[1]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R843) [[2]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R865) [[3]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R1128) [[4]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R1150) [[5]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R1222) [[6]](diffhunk://#diff-34e091d87b103479c47b10a778ca6a54c303e87d64b29b543c16c58f0dd4ed77R1241) [[7]](diffhunk://#diff-822c34542d6603729c4884cf2b88fafa3c3ce19df45f7dd12d122875142bb9abR576) [[8]](diffhunk://#diff-cbe80c54341919e9beff9c26e7a56c2cc3561b5f1f1fbe370d3925ba7a585487R632) [[9]](diffhunk://#diff-e1043964039d7b1ef39b6c71a1669eba0a713a31c7688d49187e865f3f39a194R536)

**UI: Email OOH Toggle and Dynamic Display**
- Updated alarm configuration templates (`alarm_config.html`, `alarm2_config.html`, `alarm3_config.html`) to include an Email OOH toggle switch, label, and divider, which are shown or hidden based on the Email Alerts toggle. (`dashboard/dashboard/templates/alarm_config.html`, `dashboard/dashboard/templates/alarm2_config.html`, `dashboard/dashboard/templates/alarm3_config.html`) [[1]](diffhunk://#diff-7df8ec440f18b36a9abf4c1e98aed39c037660a2e73217671141d7e4e16c500eR118-R141) [[2]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfR117-R139) [[3]](diffhunk://#diff-d47f8a8ef3fe845abf9c0c0b9acb0f9ee78dbe989781807424fa0b584c96eda0R106-R128)

- Added JavaScript to dynamically show/hide the Email OOH option and update its label and color when toggled or when Email Alerts is disabled. (`dashboard/dashboard/templates/alarm_config.html`, `dashboard/dashboard/templates/alarm2_config.html`, `dashboard/dashboard/templates/alarm3_config.html`) [[1]](diffhunk://#diff-7df8ec440f18b36a9abf4c1e98aed39c037660a2e73217671141d7e4e16c500eR469-R499) [[2]](diffhunk://#diff-ebc26dc38a786e2262010d266d770703b65981c65a6851fcc84f62bffc3385bfR436-R466) [[3]](diffhunk://#diff-d47f8a8ef3fe845abf9c0c0b9acb0f9ee78dbe989781807424fa0b584c96eda0R421-R444)

**Development Environment**
- Changed the Flask development server to run on `127.0.0.1:8080` instead of `0.0.0.0:5000`. (`dashboard/dashboard/app.py`)…alarm configurations