### PR TITLE
fix: restore dropped test_healthz method header in test_app.py

### DIFF
--- a/dashboard/tests/test_app.py
+++ b/dashboard/tests/test_app.py
@@ -138,6 +138,7 @@ class TestNavEnvLabel:
 
 
 class TestApiRoutes:
+    def test_healthz_does_not_query_azure(self, client: FlaskClient) -> None:
         with patch("dashboard.app._get_cached_status", side_effect=AssertionError("healthz should not query Azure")):
             response = client.get("/healthz")
 


### PR DESCRIPTION
## Summary

PR #277 ("Fix/dashboard/auth") dropped a method header under `class TestApiRoutes:` in `dashboard/tests/test_app.py`, leaving a bare `with patch(...)` block directly beneath the class. This was a syntax error (`unindent does not match any outer indentation level`) that broke parsing of the **entire module**, blocking both `ruff` and `pytest` collection on `main`.

## Change

Restored the missing `def test_healthz_does_not_query_azure(self, client: FlaskClient) -> None:` header. The test body (asserting `/healthz` returns `{"status": "ok"}` without querying Azure) was already present and correct.

## Validation

- `uv run ruff check tests/test_app.py` — passes
- `uv run pytest` — **198 passed** (previously the suite could not be collected)

Isolated, one-line fix with no behavioural change.