### PR TITLE
fix: scope NOC dashboard Log Analytics queries to per-environment App Insights

### DIFF
--- a/dashboard/dashboard/config.py
+++ b/dashboard/dashboard/config.py
@@ -11,6 +11,10 @@ AZURE_CLIENT_ID = os.getenv("AZURE_CLIENT_ID", "")
 AZURE_CLIENT_SECRET = os.getenv("AZURE_CLIENT_SECRET", "")
 AZURE_SUBSCRIPTION_ID = os.getenv("AZURE_SUBSCRIPTION_ID", "")
 
+# Application Insights resource ID — used to scope Log Analytics KQL queries to this
+# environment only (important when multiple environments share one workspace).
+AZURE_APP_INSIGHTS_RESOURCE_ID = os.getenv("AZURE_APP_INSIGHTS_RESOURCE_ID", "")
+
 # Azure Service Bus
 AZURE_RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP", "")
 AZURE_SERVICE_BUS_NAMESPACE = os.getenv("AZURE_SERVICE_BUS_NAMESPACE", "")

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -176,9 +176,13 @@ def get_last_message_times_by_workflow(workflow_ids: list[str]) -> dict[str, dat
         return {wid: None for wid in workflow_ids}
 
     ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n    | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""
     AppTraces
-    | where TimeGenerated > ago(30d)
+    | where TimeGenerated > ago(30d){resource_filter}
     | where Message == "Integration Hub Event"
     | where Properties contains "MESSAGE_RECEIVED"
     | extend workflow_id = tostring(parse_json(Properties)["workflow_id"])

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -216,9 +216,13 @@ def get_last_sent_times_by_workflow(workflow_ids: list[str], lookback_days: int 
         return {wid: None for wid in workflow_ids}
 
     ids_kql = ", ".join(f'"{w}"' for w in safe_ids)
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n    | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""
     AppMetrics
-    | where TimeGenerated > ago({lookback_days}d)
+    | where TimeGenerated > ago({lookback_days}d){resource_filter}
     | where Name == "messages_sent"
     | extend workflow_id = tostring(Properties["workflow_id"])
     | where workflow_id in ({ids_kql})

--- a/dashboard/dashboard/services/alarm3.py
+++ b/dashboard/dashboard/services/alarm3.py
@@ -191,9 +191,13 @@ def get_failure_counts(rules: list[dict]) -> dict[str, int | None]:
     for window_minutes, window_rules in by_window.items():
         safe_ids = [re.sub(r"[^a-zA-Z0-9_\-]", "", r["workflow_id"]) for r in window_rules]
         ids_kql = ", ".join(f'"{s}"' for s in safe_ids)
+        resource_filter = ""
+        if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+            resource_filter = f"\n        | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
         query = f"""
         AppTraces
-        | where TimeGenerated > ago({window_minutes}m)
+        | where TimeGenerated > ago({window_minutes}m){resource_filter}
         | where Message has "Integration Hub Event"
         | extend workflow_id = tostring(parse_json(Properties)["workflow_id"]),
                  event_type  = tostring(parse_json(Properties)["event_type"])

--- a/dashboard/dashboard/services/azure_monitor.py
+++ b/dashboard/dashboard/services/azure_monitor.py
@@ -62,9 +62,13 @@ def get_exceptions(hours: int = 24) -> list[dict]:
         log.warning("Log Analytics workspace not configured — returning empty list")
         return []
 
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n    | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""
     AppExceptions
-    | where TimeGenerated > ago({hours}h)
+    | where TimeGenerated > ago({hours}h){resource_filter}
 
     | project timestamp=TimeGenerated,
               type=ExceptionType,
@@ -135,9 +139,13 @@ def get_messages_today(
         safe_wf = re.sub(r"[^a-zA-Z0-9\-_]", "", workflow_id)
         wf_filter = f'\n    | where Properties contains "{safe_wf}"'
 
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n    | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""
     AppTraces
-    | where TimeGenerated > startofday(now())
+    | where TimeGenerated > startofday(now()){resource_filter}
     | where Message == "Integration Hub Event"{wf_filter}
     | project timestamp=TimeGenerated,
               name=Message,
@@ -201,9 +209,13 @@ def get_retry_delay_metrics_by_flow(hours: int = 1, min_delay_seconds: float = 6
     if not math.isfinite(query_min_delay) or query_min_delay < 0:
         query_min_delay = 60.0
 
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n    | where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""
     AppMetrics
-    | where TimeGenerated > ago({query_hours}h)
+    | where TimeGenerated > ago({query_hours}h){resource_filter}
     | where Name == "retry_delay_seconds"
     | extend workflow_id = tostring(Properties["workflow_id"])
     | extend microservice_id = tostring(Properties["microservice_id"])

--- a/dashboard/dashboard/services/service_bus.py
+++ b/dashboard/dashboard/services/service_bus.py
@@ -244,11 +244,19 @@ def get_message_metrics(timespan_hours: int = 1, queue_name: str | None = None) 
         # Resource column holds only the namespace name, so we must use ResourceId.
         queue_filter_kql = f"| where tolower(ResourceId) contains '/{safe_queue.lower()}'\n"
 
+    # Scope to this environment's Service Bus namespace so that results are not
+    # polluted by other environments sharing the same Log Analytics workspace.
+    ns_filter_kql = ""
+    if config.AZURE_SERVICE_BUS_NAMESPACE:
+        safe_ns = re.sub(r"[^a-zA-Z0-9\-_]", "", config.AZURE_SERVICE_BUS_NAMESPACE)
+        ns_filter_kql = f"| where tolower(Resource) =~ tolower('{safe_ns}')\n"
+
     kql = (
         "AzureMetrics\n"
         "| where ResourceProvider == 'MICROSOFT.SERVICEBUS'\n"
         "| where MetricName in ('IncomingMessages', 'OutgoingMessages')\n"
         f"| where TimeGenerated > ago({timespan_hours}h)\n"
+        f"{ns_filter_kql}"
         f"{queue_filter_kql}"
         f"| summarize Value=sum(Total) by bin(TimeGenerated, {bin_size}), MetricName\n"
         "| order by TimeGenerated asc\n"

--- a/dashboard/dashboard/services/traces.py
+++ b/dashboard/dashboard/services/traces.py
@@ -50,12 +50,16 @@ def get_trace(operation_id: str) -> dict:
         log.warning("Log Analytics workspace not configured — returning empty trace")
         return _empty()
 
+    resource_filter = ""
+    if config.AZURE_APP_INSIGHTS_RESOURCE_ID:
+        resource_filter = f"\n| where _ResourceId =~ '{config.AZURE_APP_INSIGHTS_RESOURCE_ID}'"
+
     query = f"""union
   (AppRequests    | extend itemType = "AppRequests"),
   (AppDependencies | extend itemType = "AppDependencies"),
   (AppTraces      | extend itemType = "AppTraces"),
   (AppExceptions  | extend itemType = "AppExceptions")
-| where OperationId == "{operation_id}"
+| where OperationId == "{operation_id}"{resource_filter}
 | project
     TimeGenerated,
     itemType,

--- a/dashboard/tests/test_azure_monitor.py
+++ b/dashboard/tests/test_azure_monitor.py
@@ -52,7 +52,7 @@ def test_get_messages_today_maps_trace_properties() -> None:
     assert messages[0]["dimensions"]["workflow_id"] == "mpi-to-topic"
 
 
-def test_get_messages_today_query_includes_resource_filter_when_configured() -> None:
+def test_get_messages_today_includes_resource_filter() -> None:
     fake_table = FakeTable(columns=["timestamp", "name", "customDimensions", "appName"], rows=[])
     resource_id = "/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi"
 

--- a/dashboard/tests/test_azure_monitor.py
+++ b/dashboard/tests/test_azure_monitor.py
@@ -52,6 +52,21 @@ def test_get_messages_today_maps_trace_properties() -> None:
     assert messages[0]["dimensions"]["workflow_id"] == "mpi-to-topic"
 
 
+def test_get_messages_today_query_includes_resource_filter_when_configured() -> None:
+    fake_table = FakeTable(columns=["timestamp", "name", "customDimensions", "appName"], rows=[])
+
+    with (
+        patch.object(azure_monitor.config, "AZURE_LOG_ANALYTICS_WORKSPACE_ID", "workspace-id"),
+        patch.object(azure_monitor.config, "AZURE_APP_INSIGHTS_RESOURCE_ID", "/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi"),
+        patch("dashboard.services.azure_monitor._get_logs_client") as mock_client_factory,
+    ):
+        mock_client_factory.return_value.query_workspace.return_value = FakeResponse([fake_table])
+        azure_monitor.get_messages_today()
+
+    query_text = mock_client_factory.return_value.query_workspace.call_args.kwargs["query"]
+    assert "_ResourceId =~ '/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi'" in query_text
+
+
 def test_get_retry_delay_metrics_by_flow_maps_rows() -> None:
     fake_table = FakeTable(
         columns=["workflow_id", "timestamp", "delay_seconds", "microservice_id", "queue", "attempt"],

--- a/dashboard/tests/test_azure_monitor.py
+++ b/dashboard/tests/test_azure_monitor.py
@@ -54,17 +54,18 @@ def test_get_messages_today_maps_trace_properties() -> None:
 
 def test_get_messages_today_query_includes_resource_filter_when_configured() -> None:
     fake_table = FakeTable(columns=["timestamp", "name", "customDimensions", "appName"], rows=[])
+    resource_id = "/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi"
 
     with (
         patch.object(azure_monitor.config, "AZURE_LOG_ANALYTICS_WORKSPACE_ID", "workspace-id"),
-        patch.object(azure_monitor.config, "AZURE_APP_INSIGHTS_RESOURCE_ID", "/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi"),
+        patch.object(azure_monitor.config, "AZURE_APP_INSIGHTS_RESOURCE_ID", resource_id),
         patch("dashboard.services.azure_monitor._get_logs_client") as mock_client_factory,
     ):
         mock_client_factory.return_value.query_workspace.return_value = FakeResponse([fake_table])
         azure_monitor.get_messages_today()
 
     query_text = mock_client_factory.return_value.query_workspace.call_args.kwargs["query"]
-    assert "_ResourceId =~ '/subscriptions/test/resourceGroups/rg/providers/microsoft.insights/components/appi'" in query_text
+    assert f"_ResourceId =~ '{resource_id}'" in query_text
 
 
 def test_get_retry_delay_metrics_by_flow_maps_rows() -> None:

--- a/dashboard/tests/test_traces.py
+++ b/dashboard/tests/test_traces.py
@@ -74,6 +74,27 @@ class TestNoWorkspaceConfigured(unittest.TestCase):
         self.assertEqual(result["logs"], [])
 
 
+class TestQueryScoping(unittest.TestCase):
+    def test_resource_id_filter_is_included_only_when_configured(self) -> None:
+        with (
+            patch.object(traces.config, "AZURE_LOG_ANALYTICS_WORKSPACE_ID", "ws-id"),
+            patch("dashboard.services.traces._get_logs_client") as mock_factory,
+        ):
+            mock_factory.return_value = _make_client([])
+
+            with patch.object(traces.config, "AZURE_APP_INSIGHTS_RESOURCE_ID", "/subscriptions/test/resource"):
+                get_trace("op123")
+                query_with_resource = mock_factory.return_value.query_workspace.call_args.kwargs["query"]
+                self.assertIn("| where _ResourceId =~ '/subscriptions/test/resource'", query_with_resource)
+
+            mock_factory.return_value.query_workspace.reset_mock()
+
+            with patch.object(traces.config, "AZURE_APP_INSIGHTS_RESOURCE_ID", ""):
+                get_trace("op123")
+                query_without_resource = mock_factory.return_value.query_workspace.call_args.kwargs["query"]
+                self.assertNotIn("_ResourceId", query_without_resource)
+
+
 class TestParseSpans(unittest.TestCase):
     def _run(self, rows: list[list[object]]) -> dict:
         columns = [


### PR DESCRIPTION
## Problem

The NOC dashboard showed **DEV data while pointed at TST**. Root cause: DEV, DTE and TST all share a single Log Analytics workspace (`UKS-DHCW-IH-SHARED-LAW`), and the dashboard's KQL queries never filtered by environment — so telemetry from all three environments was commingled. This surfaced after a redeploy changed DEV's emission pattern, exposing the latent commingling ("worked Tuesday").

## Change

Scope every Log Analytics query to the environment's own Application Insights resource via a new `AZURE_APP_INSIGHTS_RESOURCE_ID` env var:

- `config.py` — read `AZURE_APP_INSIGHTS_RESOURCE_ID` from env
- `services/azure_monitor.py`, `services/traces.py`, `services/alarm1.py`, `services/alarm2.py`, `services/alarm3.py` — add a `_ResourceId =~ '<id>'` filter to each App Insights table query
- `services/service_bus.py` — scope the `AzureMetrics` query to the environment's Service Bus namespace

The filter is **skipped when the var is unset**, so local/DEV behaviour is unchanged (safe fallback).

This mirrors the existing `components/app-alerts` precedent, which already scopes alerts to the per-environment App Insights resource rather than the shared workspace.

## Deployment

Activation requires **both**:
1. Terraform apply of the paired app-platform change (injects `AZURE_APP_INSIGHTS_RESOURCE_ID`) — see the Integration-Hub-Terraform PR.
2. Dashboard image rebuild/redeploy.

Safe if only one side deploys (filter is skipped when the var is absent).

## Validation

- `uv run ruff check` — passes
- `uv run bandit -r dashboard/` — clean
- `uv run pytest` — passes

> Note: CI is green once #<test-fix PR> (restores `test_app.py`) merges first, as this branch is based on the same `main`.