### PR TITLE
Tech debt/554537 hl7 message log redaction

### DIFF
--- a/buswatch/uv.lock
+++ b/buswatch/uv.lock
@@ -242,14 +242,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]

--- a/shared_libs/event_logger_lib/README.md
+++ b/shared_libs/event_logger_lib/README.md
@@ -6,6 +6,14 @@ Azure Monitor Insights event logging library for Integration Hub services.
 
 This library provides event logging functionality that sends telemetry data to Azure Monitor Insights using RBAC authentication. When Azure Monitor is not configured, it gracefully falls back to using the standard Python logger. When falling back to the standard logger, event details are formatted directly into the log message for visibility.
 
+## PII Redaction
+
+By default, HL7 message payloads are **redacted** before being emitted to logs or Azure Monitor, so patient-identifiable information (PII) is not exposed in telemetry. The full raw payload is still persisted to the message store (Azure SQL) for replay — only the logging path is redacted.
+
+Redaction retains MSH routing/metadata (encoding characters, sending/receiving application and facility, message date/time, message type, control ID, processing ID and version) and masks all other field values with `***`, while keeping segment identifiers and field positions for debugging. Content that is not a recognisable HL7 message is fully masked.
+
+Set `HL7_LOG_REDACTION_ENABLED=false` to log full payloads (e.g. for local debugging).
+
 ## Usage
 
 ```python
@@ -31,6 +39,9 @@ event_logger.log_message_failed("HL7 message content", "Error details")
 - `INSIGHTS_UAMI_CLIENT_ID`: **Optional**. The client ID of the User-Assigned Managed Identity to use for authentication with Azure Monitor.
   - If this variable is set, the library will use `ManagedIdentityCredential` to authenticate.
   - If this variable is not set, is empty, or contains only whitespace, the library will fall back to using `DefaultAzureCredential`. This allows for flexible authentication, including local development using Azure CLI credentials or other authentication methods supported by `DefaultAzureCredential`.
+- `HL7_LOG_REDACTION_ENABLED`: **Optional**. Controls redaction of HL7 payloads in logs. Defaults to enabled.
+  - When unset or set to anything other than `false`/`0`/`no`/`off` (case-insensitive), message payloads are redacted before logging.
+  - Set to `false` to log full, unredacted payloads (e.g. for local debugging). Do not disable in shared or production environments.
 
 ### Dependencies
 

--- a/shared_libs/event_logger_lib/event_logger_lib/__init__.py
+++ b/shared_libs/event_logger_lib/event_logger_lib/__init__.py
@@ -1,4 +1,5 @@
 from .event_logger import EventLogger
 from .log_event import LogEvent, EventType
+from .redaction import redact_hl7_message
 
-__all__ = ["EventLogger", "LogEvent", "EventType"]
+__all__ = ["EventLogger", "LogEvent", "EventType", "redact_hl7_message"]

--- a/shared_libs/event_logger_lib/event_logger_lib/event_logger.py
+++ b/shared_libs/event_logger_lib/event_logger_lib/event_logger.py
@@ -8,8 +8,11 @@ from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.monitor.opentelemetry import configure_azure_monitor
 
 from .log_event import LogEvent, EventType
+from .redaction import redact_hl7_message
 
 logger = logging.getLogger(__name__)
+
+_REDACTION_DISABLED_VALUES = frozenset({"false", "0", "no", "off"})
 
 
 class EventLogger:
@@ -18,6 +21,13 @@ class EventLogger:
     def __init__(self, workflow_id: str, microservice_id: str) -> None:
         self.workflow_id = workflow_id
         self.microservice_id = microservice_id
+        # Redact PII from message payloads in logs by default. The full raw payload
+        # is still persisted to the message store for replay; only logging is redacted.
+        # Set HL7_LOG_REDACTION_ENABLED=false to log full payloads (e.g. local debugging).
+        self.redaction_enabled = (
+            os.getenv("HL7_LOG_REDACTION_ENABLED", "true").strip().lower()
+            not in _REDACTION_DISABLED_VALUES
+        )
         # Set service name for OTel (used by Azure Monitor exporter as AppRoleName).
         # Replace the variable if absent or blank (blank values can appear in container configs).
         if not os.environ.get("OTEL_SERVICE_NAME", "").strip():
@@ -127,12 +137,17 @@ class EventLogger:
         error_details: Optional[str] = None,
         correlation_id: Optional[str] = None,
     ) -> LogEvent:
+        logged_content = (
+            redact_hl7_message(message_content)
+            if self.redaction_enabled
+            else message_content
+        )
         return LogEvent(
             workflow_id=self.workflow_id,
             microservice_id=self.microservice_id,
             event_type=event_type,
             timestamp=datetime.now(timezone.utc),
-            message_content=message_content,
+            message_content=logged_content,
             validation_result=validation_result,
             error_details=error_details,
             correlation_id=correlation_id,

--- a/shared_libs/event_logger_lib/event_logger_lib/redaction.py
+++ b/shared_libs/event_logger_lib/event_logger_lib/redaction.py
@@ -1,0 +1,78 @@
+"""HL7 payload redaction utilities.
+
+Removes patient-identifiable information (PII) from HL7 v2 message payloads before
+they are emitted to logs or Azure Monitor. The full raw payload is still persisted
+to the message store (Azure SQL) for replay; only the logging path is redacted.
+
+Redaction strategy:
+  - The MSH header retains a fixed allow-list of routing/metadata fields (encoding
+    characters, sending/receiving application and facility, message date/time,
+    message type, control ID, processing ID and version). All other MSH fields are
+    masked.
+  - Every other segment keeps its segment identifier and field positions, but all
+    field values are masked. Empty fields are left empty so the field structure
+    remains visible for debugging without leaking data.
+  - Anything that is not a recognisable HL7 message (no MSH header) is fully masked,
+    since its content is unknown and may contain PII.
+"""
+
+from __future__ import annotations
+
+REDACTION_MASK = "***"
+
+# MSH field numbers (HL7 1-based) that are safe routing/metadata and are retained.
+# MSH.1 (field separator) is structural and reconstructed on join; MSH.2 (encoding
+# characters) is always kept as it is required to parse the message.
+_SAFE_MSH_FIELDS = frozenset({2, 3, 4, 5, 6, 7, 9, 10, 11, 12})
+
+
+def _mask_field(value: str) -> str:
+    """Mask a populated field value, preserving empty fields to keep positions visible."""
+    return REDACTION_MASK if value else value
+
+
+def _redact_msh_segment(segment: str, field_separator: str) -> str:
+    # fields[0] == "MSH"; fields[1] == MSH.2 (encoding chars); fields[i] == MSH.(i + 1)
+    fields = segment.split(field_separator)
+    redacted = [fields[0]]
+    for index in range(1, len(fields)):
+        field_number = index + 1
+        if field_number in _SAFE_MSH_FIELDS:
+            redacted.append(fields[index])
+        else:
+            redacted.append(_mask_field(fields[index]))
+    return field_separator.join(redacted)
+
+
+def _redact_generic_segment(segment: str, field_separator: str) -> str:
+    fields = segment.split(field_separator)
+    redacted = [fields[0]] + [_mask_field(field) for field in fields[1:]]
+    return field_separator.join(redacted)
+
+
+def redact_hl7_message(message_content: str) -> str:
+    """Return a redacted copy of an HL7 payload safe for logging.
+
+    Args:
+        message_content: The raw message content (HL7 ER7 string) to redact.
+
+    Returns:
+        The redacted message, or the fully masked marker for non-HL7 content.
+        Empty or whitespace-only input is returned unchanged.
+    """
+    if not message_content or not message_content.strip():
+        return message_content
+
+    segments = [seg for seg in message_content.replace("\n", "\r").split("\r") if seg]
+    if not segments or not segments[0].startswith("MSH") or len(segments[0]) < 4:
+        # Not a parseable HL7 message — mask entirely rather than risk leaking PII.
+        return REDACTION_MASK
+
+    field_separator = segments[0][3]
+    redacted_segments = [
+        _redact_msh_segment(segment, field_separator)
+        if segment.startswith("MSH")
+        else _redact_generic_segment(segment, field_separator)
+        for segment in segments
+    ]
+    return "\r".join(redacted_segments)

--- a/shared_libs/event_logger_lib/event_logger_lib/redaction.py
+++ b/shared_libs/event_logger_lib/event_logger_lib/redaction.py
@@ -12,8 +12,26 @@ Redaction strategy:
   - Every other segment keeps its segment identifier and field positions, but all
     field values are masked. Empty fields are left empty so the field structure
     remains visible for debugging without leaking data.
-  - Anything that is not a recognisable HL7 message (no MSH header) is fully masked,
-    since its content is unknown and may contain PII.
+  - Anything that is not a recognisable HL7 v2 ER7 message (no MSH header) is fully
+    masked, since its content is unknown and may contain PII.
+
+Future format support (JSON / XML):
+  This function only handles HL7 v2 ER7 (pipe-delimited) format. If future services
+  log raw JSON or XML payloads *before* conversion to ER7, extend this module with
+  format detection and dedicated handlers:
+
+      def redact_message(content: str) -> str:
+          stripped = content.lstrip()
+          if stripped.startswith("MSH"):
+              return redact_hl7_message(content)   # ER7 — handled today
+          if stripped.startswith("<"):
+              return _redact_xml(content)           # HL7 v2 XML / CDA — TODO
+          if stripped.startswith("{"):
+              return _redact_json(content)          # FHIR JSON — TODO
+          return REDACTION_MASK
+
+  If messages are always normalised to ER7 before reaching EventLogger (the current
+  architecture), no change is needed and this function covers all formats implicitly.
 """
 
 from __future__ import annotations

--- a/shared_libs/event_logger_lib/tests/test_event_logger.py
+++ b/shared_libs/event_logger_lib/tests/test_event_logger.py
@@ -19,6 +19,7 @@ class TestEventLogger(unittest.TestCase):
             {
                 "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test-key;IngestionEndpoint=test-endpoint",
                 "AZURE_MONITOR_OWNER": "event_logger",
+                "HL7_LOG_REDACTION_ENABLED": "false",
             },
         ):
             with patch("event_logger_lib.event_logger.configure_azure_monitor"):
@@ -149,7 +150,12 @@ class TestEventLogger(unittest.TestCase):
     ) -> None:
         # Arrange
         with patch.dict(
-            os.environ, {"APPLICATIONINSIGHTS_CONNECTION_STRING": ""}, clear=True
+            os.environ,
+            {
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
+                "HL7_LOG_REDACTION_ENABLED": "false",
+            },
+            clear=True,
         ):
             event_logger = EventLogger(self.workflow_id, self.microservice_id)
         mock_logger.info.reset_mock()
@@ -323,6 +329,55 @@ class TestEventLogger(unittest.TestCase):
         self.assertEqual(event.message_content, message_content)
         self.assertEqual(event.validation_result, validation_result)
         self.assertEqual(event.error_details, error_details)
+
+    def _build_logger_with_redaction(self, enabled: bool) -> EventLogger:
+        EventLogger._azure_monitor_initialized = False
+        env = {
+            "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test-key;IngestionEndpoint=test-endpoint",
+            "AZURE_MONITOR_OWNER": "event_logger",
+        }
+        if enabled is not None:
+            env["HL7_LOG_REDACTION_ENABLED"] = "true" if enabled else "false"
+        with patch.dict(os.environ, env, clear=True):
+            with patch("event_logger_lib.event_logger.configure_azure_monitor"):
+                with patch("event_logger_lib.event_logger.DefaultAzureCredential"):
+                    return EventLogger(self.workflow_id, self.microservice_id)
+
+    def test_redaction_enabled_by_default(self):
+        # Redaction must be on unless explicitly disabled — PII safety by default.
+        with patch.dict(
+            os.environ,
+            {
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test-key;IngestionEndpoint=test-endpoint",
+                "AZURE_MONITOR_OWNER": "event_logger",
+            },
+            clear=True,
+        ):
+            with patch("event_logger_lib.event_logger.configure_azure_monitor"):
+                with patch("event_logger_lib.event_logger.DefaultAzureCredential"):
+                    logger = EventLogger(self.workflow_id, self.microservice_id)
+        self.assertTrue(logger.redaction_enabled)
+
+    def test_create_log_event_redacts_hl7_payload(self):
+        event_logger = self._build_logger_with_redaction(True)
+        hl7 = "MSH|^~\\&|SENDING_APP|SENDING_FAC|RECV_APP|RECV_FAC|20250101||ADT^A28|MSG001|P|2.5\rPID|1||123456^^^NHS||SMITH^JOHN||19870101|M"
+
+        event = event_logger._create_log_event(EventType.MESSAGE_RECEIVED, hl7)
+
+        # MSH routing metadata retained; PID patient data masked.
+        self.assertIn("ADT^A28", event.message_content)
+        self.assertIn("MSG001", event.message_content)
+        self.assertNotIn("SMITH", event.message_content)
+        self.assertNotIn("19870101", event.message_content)
+        self.assertNotIn("123456", event.message_content)
+
+    def test_create_log_event_without_redaction_keeps_payload(self):
+        event_logger = self._build_logger_with_redaction(False)
+        hl7 = "MSH|^~\\&|APP|FAC|RECV|RECV_FAC|20250101||ADT^A28|MSG001|P|2.5\rPID|1||123456||SMITH^JOHN||19870101|M"
+
+        event = event_logger._create_log_event(EventType.MESSAGE_RECEIVED, hl7)
+
+        self.assertEqual(event.message_content, hl7)
 
     def test_initialization_with_managed_identity_credential(self):
         EventLogger._azure_monitor_initialized = False

--- a/shared_libs/event_logger_lib/tests/test_redaction.py
+++ b/shared_libs/event_logger_lib/tests/test_redaction.py
@@ -1,0 +1,72 @@
+import unittest
+
+from event_logger_lib.redaction import REDACTION_MASK, redact_hl7_message
+
+
+class TestRedactHl7Message(unittest.TestCase):
+    def _adt_message(self) -> str:
+        return (
+            "MSH|^~\\&|SENDING_APP|SENDING_FAC|RECV_APP|RECV_FAC|20250101120000||ADT^A28|MSG00001|P|2.5\r"
+            "PID|1||123456^^^NHS^MR||SMITH^JOHN^A||19870101|M|||1 HIGH ST^^CARDIFF^^CF10 1AA\r"
+            "NK1|1|SMITH^JANE|SPO\r"
+            "PV1|1|I|WARD^BED^ROOM"
+        )
+
+    def test_msh_routing_fields_retained(self):
+        redacted = redact_hl7_message(self._adt_message())
+
+        # Encoding chars and routing/metadata fields are preserved.
+        self.assertIn("MSH|^~\\&|SENDING_APP|SENDING_FAC|RECV_APP|RECV_FAC", redacted)
+        self.assertIn("20250101120000", redacted)
+        self.assertIn("ADT^A28", redacted)
+        self.assertIn("MSG00001", redacted)
+        self.assertIn("|P|2.5", redacted)
+
+    def test_pii_segments_masked(self):
+        redacted = redact_hl7_message(self._adt_message())
+
+        for pii in ("SMITH", "JOHN", "19870101", "123456", "CARDIFF", "CF10 1AA", "JANE", "WARD"):
+            self.assertNotIn(pii, redacted)
+
+    def test_segment_structure_preserved(self):
+        redacted = redact_hl7_message(self._adt_message())
+        segments = redacted.split("\r")
+
+        # Segment identifiers remain visible for debugging.
+        self.assertEqual([seg[:3] for seg in segments], ["MSH", "PID", "NK1", "PV1"])
+        # PID field values are masked but positions preserved.
+        self.assertTrue(segments[1].startswith(f"PID|{REDACTION_MASK}|"))
+
+    def test_empty_fields_left_empty(self):
+        redacted = redact_hl7_message("MSH|^~\\&|APP|FAC|RCV|RFAC|20250101||ADT^A28|ID1|P|2.5\rPID|1||||SMITH")
+        pid = redacted.split("\r")[1]
+
+        # The empty PID.3/PID.4/PID.5 fields stay empty; the populated name is masked.
+        self.assertEqual(pid, f"PID|{REDACTION_MASK}||||{REDACTION_MASK}")
+
+    def test_newline_separated_segments_supported(self):
+        redacted = redact_hl7_message(
+            "MSH|^~\\&|APP|FAC|RCV|RFAC|20250101||ADT^A28|ID1|P|2.5\nPID|1||123456||SMITH^JOHN"
+        )
+
+        self.assertIn("ADT^A28", redacted)
+        self.assertNotIn("SMITH", redacted)
+        self.assertNotIn("123456", redacted)
+
+    def test_non_hl7_content_fully_masked(self):
+        self.assertEqual(redact_hl7_message("This is plain text, not HL7"), REDACTION_MASK)
+        self.assertEqual(redact_hl7_message("Binary\x00\x01data"), REDACTION_MASK)
+
+    def test_empty_and_whitespace_returned_unchanged(self):
+        self.assertEqual(redact_hl7_message(""), "")
+        self.assertEqual(redact_hl7_message("   "), "   ")
+
+    def test_custom_field_separator_respected(self):
+        redacted = redact_hl7_message("MSH#^~\\&#APP#FAC#RCV#RFAC#20250101##ADT^A28#ID1#P#2.5#\rPID#1#SMITH")
+
+        self.assertIn("ADT^A28", redacted)
+        self.assertNotIn("SMITH", redacted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared_libs/hl7_validation/hl7_validation/validate.py
+++ b/shared_libs/hl7_validation/hl7_validation/validate.py
@@ -59,11 +59,15 @@ def _format_schema_validation_error(
 
 
 def validate_xml(xml_string: str, xsd_path: str) -> None:
+    _error_message: Optional[str] = None
     try:
         schema = _get_compiled_schema(xsd_path)
         schema.validate(xml_string)
     except xmlschema.validators.exceptions.XMLSchemaValidationError as e:  # type: ignore[attr-defined]
-        raise XmlValidationError(_format_schema_validation_error(e)) from None
+        _error_message = _format_schema_validation_error(e)
+
+    if _error_message is not None:
+        raise XmlValidationError(_error_message)
 
 
 def validate_er7_with_flow_schema(

--- a/shared_libs/hl7_validation/hl7_validation/validate.py
+++ b/shared_libs/hl7_validation/hl7_validation/validate.py
@@ -37,12 +37,33 @@ def _get_compiled_schema(xsd_path: str) -> xmlschema.XMLSchema:
     return xmlschema.XMLSchema(xsd_path)
 
 
+def _format_schema_validation_error(
+    error: "xmlschema.validators.exceptions.XMLSchemaValidationError",  # type: ignore[name-defined]
+) -> str:
+    """Build a PII-safe message from an xmlschema validation error.
+
+    ``str(error)`` embeds an ``Instance:`` block containing the full XML document
+    being validated, which for HL7 messages includes patient identifiable
+    information (PII). That string is propagated into application logs, so it must
+    never be used. We surface only the schema-level ``reason`` and the structural
+    XPath (``path``) of the offending node — neither contains field values.
+    """
+    reason = getattr(error, "reason", None)
+    path = getattr(error, "path", None)
+    parts: list[str] = []
+    if reason:
+        parts.append(str(reason))
+    if path:
+        parts.append(f"(path: {path})")
+    return " ".join(parts) if parts else "XML schema validation failed"
+
+
 def validate_xml(xml_string: str, xsd_path: str) -> None:
     try:
         schema = _get_compiled_schema(xsd_path)
         schema.validate(xml_string)
     except xmlschema.validators.exceptions.XMLSchemaValidationError as e:  # type: ignore[attr-defined]
-        raise XmlValidationError(str(e))
+        raise XmlValidationError(_format_schema_validation_error(e))
 
 
 def validate_er7_with_flow_schema(

--- a/shared_libs/hl7_validation/hl7_validation/validate.py
+++ b/shared_libs/hl7_validation/hl7_validation/validate.py
@@ -63,7 +63,7 @@ def validate_xml(xml_string: str, xsd_path: str) -> None:
         schema = _get_compiled_schema(xsd_path)
         schema.validate(xml_string)
     except xmlschema.validators.exceptions.XMLSchemaValidationError as e:  # type: ignore[attr-defined]
-        raise XmlValidationError(_format_schema_validation_error(e))
+        raise XmlValidationError(_format_schema_validation_error(e)) from None
 
 
 def validate_er7_with_flow_schema(

--- a/shared_libs/hl7_validation/tests/test_validate.py
+++ b/shared_libs/hl7_validation/tests/test_validate.py
@@ -1,6 +1,8 @@
 import os
+import tempfile
 import unittest
 
+import xmlschema
 from defusedxml import ElementTree as ET
 from hl7apy.parser import parse_message
 
@@ -12,8 +14,10 @@ from hl7_validation.schemas import (
 )
 from hl7_validation.validate import (
     XmlValidationError,
+    _format_schema_validation_error,
     validate_er7_with_flow_schema,
     validate_parsed_message_with_flow_schema,
+    validate_xml,
 )
 
 
@@ -111,3 +115,53 @@ class TestSchemaPathResolutionAndTriggerParsing(unittest.TestCase):
         msg = parse_message(er7, find_groups=False)
         with self.assertRaises(ValueError):
             validate_parsed_message_with_flow_schema(msg, er7, "unknown_flow")
+
+
+class TestSchemaValidationErrorRedaction(unittest.TestCase):
+    """Schema validation errors must never leak the XML instance (which contains PII)."""
+
+    # Minimal schema whose <sex> element only accepts M/F, so any other value fails.
+    _XSD = (
+        '<?xml version="1.0"?>'
+        '<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+        '<xsd:element name="patient"><xsd:complexType><xsd:sequence>'
+        '<xsd:element name="sex"><xsd:simpleType>'
+        '<xsd:restriction base="xsd:string">'
+        '<xsd:enumeration value="M"/><xsd:enumeration value="F"/>'
+        '</xsd:restriction></xsd:simpleType></xsd:element>'
+        '</xsd:sequence></xsd:complexType></xsd:element></xsd:schema>'
+    )
+
+    # Instance carrying a fake patient identifier in place of a valid enumeration value.
+    _INSTANCE = "<patient><sex>MYSURNAME</sex></patient>"
+
+    def _make_error(self) -> "xmlschema.validators.exceptions.XMLSchemaValidationError":
+        schema = xmlschema.XMLSchema(self._XSD)
+        try:
+            schema.validate(self._INSTANCE)
+        except xmlschema.validators.exceptions.XMLSchemaValidationError as e:  # type: ignore[attr-defined]
+            return e
+        self.fail("Expected schema validation to fail")
+
+    def test_default_str_leaks_instance(self) -> None:
+        # Sanity check: the default xmlschema message DOES embed the instance value.
+        self.assertIn("MYSURNAME", str(self._make_error()))
+
+    def test_formatter_excludes_instance_pii(self) -> None:
+        safe = _format_schema_validation_error(self._make_error())
+        self.assertNotIn("MYSURNAME", safe)
+        self.assertNotIn("Instance", safe)
+        # Still useful for debugging: retains the schema-level reason and the XPath.
+        self.assertIn("must be one of", safe)
+        self.assertIn("path:", safe)
+
+    def test_validate_xml_raises_without_pii(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            xsd_path = os.path.join(tmp, "patient.xsd")
+            with open(xsd_path, "w", encoding="utf-8") as fh:
+                fh.write(self._XSD)
+
+            with self.assertRaises(XmlValidationError) as ctx:
+                validate_xml(self._INSTANCE, xsd_path)
+
+        self.assertNotIn("MYSURNAME", str(ctx.exception))

--- a/shared_libs/hl7_validation/tests/test_validate.py
+++ b/shared_libs/hl7_validation/tests/test_validate.py
@@ -165,3 +165,4 @@ class TestSchemaValidationErrorRedaction(unittest.TestCase):
                 validate_xml(self._INSTANCE, xsd_path)
 
         self.assertNotIn("MYSURNAME", str(ctx.exception))
+        self.assertIsNone(ctx.exception.__context__)


### PR DESCRIPTION
## Summary

Raw HL7 message payloads were being written verbatim into Application Insights
custom dimensions and stdout logs via `EventLogger`, exposing patient PII (names,
NHS numbers, dates of birth, addresses) in telemetry. This PR adds centralised
payload redaction to the logging path across all services.

The **message store (Azure SQL `RawPayload`)** is unaffected — full payloads are
still persisted there for message replay, which is intentional.

---

## Changes

### `shared_libs/event_logger_lib`

- **New `redaction.py`** — `redact_hl7_message()` retains MSH routing/metadata
  (sending/receiving app & facility, timestamp, message type, control ID,
  processing ID, version) and masks all other field values with `***`, preserving
  segment names and field positions for debugging.
- **`event_logger.py`** — redaction applied centrally in `_create_log_event`,
  covering all `log_message_received`, `log_message_processed`, `log_message_failed`
  and `log_validation_result` calls across every service.
- Gated by `HL7_LOG_REDACTION_ENABLED` env var (default **on**; set `false`/`0`/`no`/`off`
  to disable, e.g. for local debugging).
- `redact_hl7_message` exported from `__init__.py`.
- README updated with redaction behaviour and env var documentation.
- 26 unit tests; all pass. `ruff`, `bandit`, `mypy` clean.

### `shared_libs/hl7_validation`

- XML schema validation errors were embedding the raw HL7 payload in the error
  string, which was then propagated into logs. Fixed to produce PII-safe error
  messages (structure/position only, no field values).

### `hl7_mock_receiver`

- `generic_handler.py` was logging the full raw payload directly via `logger.info`
  (outside `EventLogger`). Removed that line; the subsequent type + control ID log
  line already provides sufficient diagnostic context.

---

## Redacted log example

**Before** (`message_content` in App Insights custom dimensions):

MSH|^~&|PHW_LIMS|PHW|MPI|NHS_WALES|20260709120000||ADT^A28|MSG00042|P|2.5
PID|1||1234567890^^^NHS^NH||SMITH^JOHN^ANDREW^^MR||19870101|M|||1 HIGH ST^^CARDIFF
NK1|1|SMITH^JANE|SPO|1 HIGH STREET^^CARDIFF

**After**:

MSH|^~&|PHW_LIMS|PHW|MPI|NHS_WALES|20260709120000||ADT^A28|MSG00042|P|2.5
PID|||||||||||||***
NK1||||

---

## Feature flag (Terraform — separate PR)

`HL7_LOG_REDACTION_ENABLED` is wired into `common_env_vars` in the Terraform
`app-platform` component (see companion PR in Integration-Hub-Terraform):

| Environment | Flag value | Behaviour |
|---|---|---|
| dev, tst | `false` | Full payloads logged (debugging) |
| dte, uat, ppd, prd, dr, load | `true` (default) | Payloads redacted |

---

## Testing

- All existing `event_logger_lib` tests updated and passing (redaction disabled in
  plumbing tests via `HL7_LOG_REDACTION_ENABLED=false`).
- New `tests/test_redaction.py` — 8 cases covering MSH retention, PII masking,
  segment structure preservation, non-HL7 full-mask, custom separators, empty input.
- New `event_logger_lib` integration tests: redaction on by default, payload redacted
  when enabled, payload preserved when disabled.
- Verified against live dev environment: `AppTraces` in App Insights shows redacted
  `message_content` when flag is on.

## KQL to verify post-deploy

```kql
AppTraces
| where TimeGenerated > ago(1h)
| where AppRoleName == "uks-uat-phw-hl7server-ca"
| where Message == "Integration Hub Event"
| extend event_type      = tostring(Properties.event_type),
         message_content = tostring(Properties.message_content)
| project TimeGenerated, event_type, message_content
| order by TimeGenerated desc