### PR TITLE
feat: Add Azure Cosmos DB persistence for NOC dashboard alarms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,11 +191,13 @@ uv run gunicorn dashboard.app:app --bind 0.0.0.0:8080
 
 Key files:
 - `dashboard/app.py` — Flask routes, 30s in-memory cache for `/api/status`
-- `dashboard/config.py` — All env vars (Azure creds, queue names, thresholds)
+- `dashboard/config.py` — All env vars (Azure creds, queue names, thresholds, Cosmos DB)
 - `dashboard/services/service_bus.py` — Queue depth via Azure Management API
 - `dashboard/services/azure_monitor.py` — Exceptions + message counts from Log Analytics
 - `dashboard/services/flows.py` — Flow definitions and health calculation
 - `dashboard/services/container_apps.py` — Container Apps metrics
+- `dashboard/services/cosmos_store.py` — Azure Cosmos DB persistence for alarm config/state (azure-cosmos SDK)
+- `dashboard/services/alarm1.py` / `alarm2.py` / `alarm3.py` — Alarm rules; config/state stored in Cosmos
 
 Required environment variables (see `config.py` for full list):
 ```
@@ -205,6 +207,20 @@ AZURE_SERVICE_BUS_NAMESPACE
 AZURE_LOG_ANALYTICS_WORKSPACE_ID
 FLASK_SECRET_KEY
 ```
+
+Alarm config/state persistence (Azure Cosmos DB) uses:
+```
+COSMOS_ENDPOINT            # account URI; empty disables persistence (reads return empty)
+COSMOS_KEY                 # account key -> key auth + auto-create DB/container; empty -> AAD RBAC
+COSMOS_DATABASE            # default: integration-hub-dashboard
+COSMOS_CONTAINER           # default: alarms (partition key /pk)
+COSMOS_DISABLE_SSL_VERIFY  # true only for the local emulator's self-signed cert
+```
+Locally, run the Cosmos emulator via the shared Compose stack in `local/`
+(`docker compose --profile dashboard up -d cosmos-emulator`), then start the dashboard
+on the host with `uv run flask`.
+In cloud, leave `COSMOS_KEY` empty (Managed Identity RBAC) and set `COSMOS_DISABLE_SSL_VERIFY=false`;
+the database/container must be provisioned via Terraform.
 
 The app degrades gracefully — all pages return data (or empty state) when Azure is not configured.
 
@@ -231,6 +247,7 @@ Docker Compose profiles in `local/` map to flows:
 - `paris-to-mpi` — Paris server, sender (no transformer)
 - `chemo-to-mpi` — Chemo server, transformer, sender
 - `pims-to-mpi` — PIMS server, transformer, sender
+- `dashboard` — Cosmos DB emulator for the NOC dashboard (run the dashboard itself on the host with `uv run flask`)
 
 Start a profile: `docker compose --profile phw-to-mpi up`
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -18,6 +18,32 @@ Open http://127.0.0.1:5000
 If `dashboard/.env` exists, the dashboard loads it automatically at startup.
 Values already exported in the shell still take precedence.
 
+### Alarm persistence (Cosmos DB)
+
+Alarm configuration and runtime state are persisted to Azure Cosmos DB via the
+`azure-cosmos` SDK (`dashboard/services/cosmos_store.py`). Each alarm namespace
+(`alarm1`/`alarm2`/`alarm3`) stores a `config` and a `state` document in a single
+container partitioned on `/pk`.
+
+For local development, run the Cosmos DB emulator. It lives in the shared Compose stack
+under `local/` on the `dashboard` profile:
+
+```bash
+cd ../local
+docker compose --profile dashboard up -d cosmos-emulator
+```
+
+The emulator takes ~1 minute to become healthy. Then run the dashboard on the host via
+`uv run flask` (see [Running locally](#running-locally)) — the `dashboard/.env` values
+point at the emulator on `https://localhost:8081` using Microsoft's well-known emulator
+key (not a secret) and disable TLS verification for the self-signed certificate. The
+database and container are created automatically on first use when a key is configured.
+
+In cloud environments, set `COSMOS_ENDPOINT` to the account URI, leave `COSMOS_KEY`
+empty to use Managed Identity / service-principal RBAC (data-plane role required), and
+set `COSMOS_DISABLE_SSL_VERIFY=false`. The database and container must be provisioned
+ahead of time (e.g. via Terraform).
+
 ## Running with Docker
 
 ```bash
@@ -46,6 +72,16 @@ docker run -p 8080:8080 --env-file dashboard.env integration-hub-dashboard
 
 All queue names are also overridable (e.g. `QUEUE_PHW_PRE`, `QUEUE_PHW_POST`).
 See `dashboard/config.py` for the full list.
+
+### Cosmos DB persistence variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COSMOS_ENDPOINT` | Cosmos account URI (emulator: `https://localhost:8081`). Empty disables persistence. | — |
+| `COSMOS_KEY` | Account key. When set, key auth is used and the DB/container are auto-created; empty uses RBAC. | — |
+| `COSMOS_DATABASE` | Cosmos database name | `integration-hub-dashboard` |
+| `COSMOS_CONTAINER` | Cosmos container name (partition key `/pk`) | `alarms` |
+| `COSMOS_DISABLE_SSL_VERIFY` | Disable TLS verification — required for the local emulator only | `false` |
 
 ## Azure authentication
 

--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -153,6 +153,13 @@ log = logging.getLogger(__name__)
 app = Flask(__name__)
 app.secret_key = config.FLASK_SECRET_KEY
 
+# Log Cosmos persistence status at startup so it is visible in Container App log
+# streams and makes misconfigured deployments immediately obvious.
+if config.COSMOS_ENDPOINT:
+    log.info("Cosmos persistence ENABLED — endpoint: %s", config.COSMOS_ENDPOINT)
+else:
+    log.warning("Cosmos persistence DISABLED — COSMOS_ENDPOINT is not set; alarm config/state will not be persisted")
+
 # ---------------------------------------------------------------------------
 # Internationalisation (Flask-Babel)
 # ---------------------------------------------------------------------------

--- a/dashboard/dashboard/config.py
+++ b/dashboard/dashboard/config.py
@@ -19,6 +19,21 @@ AZURE_APP_INSIGHTS_RESOURCE_ID = os.getenv("AZURE_APP_INSIGHTS_RESOURCE_ID", "")
 AZURE_RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP", "")
 AZURE_SERVICE_BUS_NAMESPACE = os.getenv("AZURE_SERVICE_BUS_NAMESPACE", "")
 
+# Azure Cosmos DB — persistence for alarm configuration and runtime state.
+# Locally this points at the Cosmos DB emulator; in cloud environments it points at
+# the provisioned Cosmos account. When COSMOS_ENDPOINT is empty the dashboard degrades
+# gracefully (alarm config/state simply read back empty).
+COSMOS_ENDPOINT = os.getenv("COSMOS_ENDPOINT", "")
+# Account key. When set (e.g. the emulator's well-known key) key-based auth is used;
+# when empty the shared Azure credential (Managed Identity / service principal) is used
+# for data-plane RBAC against the Cosmos account.
+COSMOS_KEY = os.getenv("COSMOS_KEY", "")
+COSMOS_DATABASE = os.getenv("COSMOS_DATABASE", "integration-hub")
+COSMOS_CONTAINER = os.getenv("COSMOS_CONTAINER", "alarms")
+# Disable TLS verification — required for the local Cosmos emulator's self-signed
+# certificate. Must never be enabled against a real Cosmos account.
+COSMOS_DISABLE_SSL_VERIFY = os.getenv("COSMOS_DISABLE_SSL_VERIFY", "false").lower() == "true"
+
 # Environment label derived from AZURE_RESOURCE_GROUP.
 # Pattern: UK-South-DHCW-IntHub-{ENV}-App-RG → extracts {ENV} (e.g. TST, DEV, PRD).
 # Returns empty string if the RG value is absent or doesn't match the expected pattern.

--- a/dashboard/dashboard/services/alarm1.py
+++ b/dashboard/dashboard/services/alarm1.py
@@ -1,7 +1,8 @@
 """Alarm service — workflow message inactivity monitoring (Alarm 1).
 
-Config is persisted to ``alarm1_config.json`` in the dashboard root directory.
-State (last alarm fired time per rule) is persisted to ``alarm_state.json``.
+Config and state are persisted to Azure Cosmos DB (see :mod:`dashboard.services.cosmos_store`).
+Config is stored as the ``config`` document and per-rule alarm state (last-fired
+timestamps, pauses) as the ``state`` document, both in the ``alarm1`` partition.
 
 Each rule targets a specific workflow_id and has five settings:
   alarm_enabled            – bool, whether Alarm 1 is active for this rule
@@ -19,22 +20,23 @@ timestamp is cleared so the next inactivity event fires immediately.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
+from dashboard.services import cosmos_store
 from dashboard.services.alarm_time_utils import get_current_period
 from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
 
-CONFIG_PATH = Path(__file__).parent.parent.parent / "alarm1_config.json"
-STATE_PATH = Path(__file__).parent.parent.parent / "alarm_state.json"
+# Cosmos partition (alarm namespace) and document ids for this alarm's config/state.
+COSMOS_PK = "alarm1"
+CONFIG_DOC_ID = "config"
+STATE_DOC_ID = "state"
 
 # Defaults
 DEFAULT_DAY_THRESHOLD = 60
@@ -49,38 +51,31 @@ DEFAULT_ALERTING_GAP = 60
 
 
 def load_alarm_config() -> dict:
-    """Load alarm config from JSON file. Returns empty config on missing/corrupt file."""
-    if not CONFIG_PATH.exists():
+    """Load alarm config from Cosmos DB. Returns empty config when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, CONFIG_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm config: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def save_alarm_config(cfg: dict) -> None:
-    """Persist alarm config to JSON file."""
-    CONFIG_PATH.write_text(json.dumps(cfg, indent=2, default=str), encoding="utf-8")
+    """Persist alarm config to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, CONFIG_DOC_ID, cfg)
 
 
 def _load_alarm_state() -> dict:
-    """Load per-rule alarm state (last_alarm_at timestamps) from JSON. Returns empty state on missing/corrupt file."""
-    if not STATE_PATH.exists():
+    """Load per-rule alarm state (last_alarm_at timestamps) from Cosmos. Returns empty state when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, STATE_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm state: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def _save_alarm_state(state: dict) -> None:
-    """Persist per-rule alarm state to JSON, logging errors without raising."""
-    try:
-        STATE_PATH.write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")
-    except OSError as exc:
-        log.error("Failed to save alarm state: %s", exc)
+    """Persist per-rule alarm state to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, STATE_DOC_ID, state)
 
 
 # ---------------------------------------------------------------------------
@@ -367,7 +362,7 @@ def get_alarm_status() -> list[dict]:
         'healthy'    – last message received within the inactivity threshold
         'unknown'    – no message data found in the 30-day lookback window
 
-    State (last_alarm_at per rule) is persisted to alarm_state.json so that
+    State (last_alarm_at per rule) is persisted to Cosmos DB so that
     cooldowns survive dashboard restarts.
     """
     cfg = load_alarm_config()

--- a/dashboard/dashboard/services/alarm2.py
+++ b/dashboard/dashboard/services/alarm2.py
@@ -1,7 +1,8 @@
 """Alarm 2 service — outgoing message inactivity monitoring.
 
-Config is persisted to ``alarm2_config.json`` in the dashboard root directory.
-State (last alarm fired time per rule) is persisted to ``alarm2_state.json``.
+Config and state are persisted to Azure Cosmos DB (see :mod:`dashboard.services.cosmos_store`).
+Config is stored as the ``config`` document and per-rule alarm state (last-fired
+timestamps, pauses) as the ``state`` document, both in the ``alarm2`` partition.
 
 Each rule monitors the most recent ``messages_sent`` metric for a specific
 workflow_id and has the following settings:
@@ -23,23 +24,24 @@ Status values returned per rule:
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 import re
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
+from dashboard.services import cosmos_store
 from dashboard.services.alarm_time_utils import PERIOD_SHORT_LABELS, get_current_period
 from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
 
-CONFIG_PATH = Path(__file__).parent.parent.parent / "alarm2_config.json"
-STATE_PATH = Path(__file__).parent.parent.parent / "alarm2_state.json"
+# Cosmos partition (alarm namespace) and document ids for this alarm's config/state.
+COSMOS_PK = "alarm2"
+CONFIG_DOC_ID = "config"
+STATE_DOC_ID = "state"
 
 DEFAULT_DAY_THRESHOLD = 60
 DEFAULT_EVENING_THRESHOLD = 120
@@ -62,38 +64,31 @@ KNOWN_RULES: list[dict] = [
 
 
 def load_alarm2_config() -> dict:
-    """Load Alarm 2 config from JSON. Returns empty config on missing/corrupt file."""
-    if not CONFIG_PATH.exists():
+    """Load Alarm 2 config from Cosmos DB. Returns empty config when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, CONFIG_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm2 config: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def save_alarm2_config(cfg: dict) -> None:
-    """Persist Alarm 2 config to JSON."""
-    CONFIG_PATH.write_text(json.dumps(cfg, indent=2, default=str), encoding="utf-8")
+    """Persist Alarm 2 config to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, CONFIG_DOC_ID, cfg)
 
 
 def _load_alarm2_state() -> dict:
-    """Load per-rule Alarm 2 state (last_alarm_at timestamps) from JSON. Returns empty state on missing/corrupt file."""
-    if not STATE_PATH.exists():
+    """Load per-rule Alarm 2 state (last_alarm_at timestamps) from Cosmos. Returns empty state when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, STATE_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm2 state: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def _save_alarm2_state(state: dict) -> None:
-    """Persist per-rule Alarm 2 state to JSON, logging errors without raising."""
-    try:
-        STATE_PATH.write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")
-    except OSError as exc:
-        log.error("Failed to save alarm2 state: %s", exc)
+    """Persist per-rule Alarm 2 state to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, STATE_DOC_ID, state)
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/dashboard/services/alarm3.py
+++ b/dashboard/dashboard/services/alarm3.py
@@ -1,7 +1,8 @@
 """Alarm 3 service — message processing failure monitoring.
 
-Config is persisted to ``alarm3_config.json`` in the dashboard root directory.
-State (last alarm fired time per rule) is persisted to ``alarm3_state.json``.
+Config and state are persisted to Azure Cosmos DB (see :mod:`dashboard.services.cosmos_store`).
+Config is stored as the ``config`` document and per-rule alarm state (last-fired
+timestamps, pauses) as the ``state`` document, both in the ``alarm3`` partition.
 
 Each rule monitors MESSAGE_FAILED events for a specific workflow_id and has
 the following settings:
@@ -22,21 +23,22 @@ Status values returned per rule:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 
 from dashboard import config
+from dashboard.services import cosmos_store
 from dashboard.services.credentials import get_azure_credential
 
 log = logging.getLogger(__name__)
 
-CONFIG_PATH = Path(__file__).parent.parent.parent / "alarm3_config.json"
-STATE_PATH = Path(__file__).parent.parent.parent / "alarm3_state.json"
+# Cosmos partition (alarm namespace) and document ids for this alarm's config/state.
+COSMOS_PK = "alarm3"
+CONFIG_DOC_ID = "config"
+STATE_DOC_ID = "state"
 
 DEFAULT_WINDOW_MINUTES = 15
 DEFAULT_THRESHOLD = 1
@@ -57,38 +59,31 @@ KNOWN_RULES: list[dict] = [
 
 
 def load_alarm3_config() -> dict:
-    """Load Alarm 3 config from JSON. Returns empty config on missing/corrupt file."""
-    if not CONFIG_PATH.exists():
+    """Load Alarm 3 config from Cosmos DB. Returns empty config when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, CONFIG_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm3 config: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def save_alarm3_config(cfg: dict) -> None:
-    """Persist Alarm 3 config to JSON."""
-    CONFIG_PATH.write_text(json.dumps(cfg, indent=2, default=str), encoding="utf-8")
+    """Persist Alarm 3 config to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, CONFIG_DOC_ID, cfg)
 
 
 def _load_alarm3_state() -> dict:
-    """Load per-rule Alarm 3 state (last_alarm_at timestamps) from JSON. Returns empty state on missing/corrupt file."""
-    if not STATE_PATH.exists():
+    """Load per-rule Alarm 3 state (last_alarm_at timestamps) from Cosmos. Returns empty state when none is stored."""
+    doc = cosmos_store.get_document(COSMOS_PK, STATE_DOC_ID)
+    if not doc:
         return {"rules": {}}
-    try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        log.warning("Failed to load alarm3 state: %s", exc)
-        return {"rules": {}}
+    doc.setdefault("rules", {})
+    return doc
 
 
 def _save_alarm3_state(state: dict) -> None:
-    """Persist per-rule Alarm 3 state to JSON, logging errors without raising."""
-    try:
-        STATE_PATH.write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")
-    except OSError as exc:
-        log.error("Failed to save alarm3 state: %s", exc)
+    """Persist per-rule Alarm 3 state to Cosmos DB."""
+    cosmos_store.upsert_document(COSMOS_PK, STATE_DOC_ID, state)
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/dashboard/services/cosmos_store.py
+++ b/dashboard/dashboard/services/cosmos_store.py
@@ -72,11 +72,18 @@ def _get_client() -> CosmosClient | None:
         # locally. Never disable verification against a real Cosmos account.
         client_kwargs: dict[str, Any] = {}
         if config.COSMOS_DISABLE_SSL_VERIFY:
-            client_kwargs["connection_verify"] = False
-            # The Dockerised emulator advertises its internal container IP via endpoint
-            # discovery, which the host cannot reach. Disabling discovery pins the client
-            # to the configured gateway endpoint (localhost:8081).
-            client_kwargs["enable_endpoint_discovery"] = False
+            endpoint = config.COSMOS_ENDPOINT.lower()
+            if "localhost" not in endpoint and "127.0.0.1" not in endpoint and "cosmos-emulator" not in endpoint:
+                log.error(
+                    "Refusing to disable Cosmos TLS verification for non-local endpoint: %s",
+                    config.COSMOS_ENDPOINT,
+                )
+            else:
+                client_kwargs["connection_verify"] = False
+                # The Dockerised emulator advertises its internal container IP via endpoint
+                # discovery, which the host cannot reach. Disabling discovery pins the client
+                # to the configured gateway endpoint (localhost:8081).
+                client_kwargs["enable_endpoint_discovery"] = False
 
         credential: Any = config.COSMOS_KEY or get_azure_credential()
         try:

--- a/dashboard/dashboard/services/cosmos_store.py
+++ b/dashboard/dashboard/services/cosmos_store.py
@@ -1,0 +1,171 @@
+"""Azure Cosmos DB persistence layer for dashboard alarm config and state.
+
+This module replaces the previous JSON-file persistence used by the alarm services.
+Each alarm namespace (``alarm1``/``alarm2``/``alarm3``) stores two small documents —
+``config`` and ``state`` — in a single Cosmos container partitioned on ``/pk``.
+
+Design notes:
+  * A single :class:`~azure.cosmos.CosmosClient` is created lazily and reused as a
+    process-wide singleton (SDK best practice — the client manages its own connection
+    pool and should not be recreated per request).
+  * Authentication is dual-mode:
+      - When ``COSMOS_KEY`` is set (the local emulator, or key-based cloud access) the
+        account key is used and the database/container are created on demand.
+      - When ``COSMOS_KEY`` is empty the shared Azure credential (Managed Identity /
+        service principal) is used for data-plane RBAC. In this mode the database and
+        container are assumed to already exist (provisioned via Terraform), because
+        creating them requires management-plane permissions the data-plane role lacks.
+  * When ``COSMOS_ENDPOINT`` is not configured every operation is a no-op: reads return
+    ``None`` and writes are skipped. This keeps the dashboard's graceful-degradation
+    behaviour (alarm pages still render with empty config).
+
+The partition key is the alarm namespace (low cardinality but the workload is tiny —
+at most a handful of documents — so this keeps every read a single-partition point read).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from azure.cosmos import CosmosClient, PartitionKey
+from azure.cosmos.exceptions import (
+    CosmosHttpResponseError,
+    CosmosResourceExistsError,
+    CosmosResourceNotFoundError,
+)
+
+from dashboard import config
+from dashboard.services.credentials import get_azure_credential
+
+log = logging.getLogger(__name__)
+
+# Cosmos reserves any property whose name starts with ``_`` (``_rid``, ``_etag`` …)
+# plus the ``id``/``pk`` routing fields. These are stripped from documents on read so
+# callers get back exactly the payload they stored.
+_RESERVED_KEYS = frozenset({"id", "pk"})
+
+# Single-element mutable cache holding the process-wide client. A dict is used (rather
+# than a reassigned module global) so the singleton can be updated without ``global``.
+_client_cache: dict[str, CosmosClient | None] = {"client": None}
+_client_lock = threading.Lock()
+
+
+def is_configured() -> bool:
+    """Return ``True`` when a Cosmos endpoint is configured and persistence is active."""
+    return bool(config.COSMOS_ENDPOINT)
+
+
+def _get_client() -> CosmosClient | None:
+    """Return the process-wide singleton CosmosClient, building it on first use."""
+    if not is_configured():
+        return None
+    if _client_cache["client"] is not None:
+        return _client_cache["client"]
+
+    with _client_lock:
+        if _client_cache["client"] is not None:
+            return _client_cache["client"]
+
+        # The emulator uses a self-signed certificate; verification must be disabled
+        # locally. Never disable verification against a real Cosmos account.
+        client_kwargs: dict[str, Any] = {}
+        if config.COSMOS_DISABLE_SSL_VERIFY:
+            client_kwargs["connection_verify"] = False
+            # The Dockerised emulator advertises its internal container IP via endpoint
+            # discovery, which the host cannot reach. Disabling discovery pins the client
+            # to the configured gateway endpoint (localhost:8081).
+            client_kwargs["enable_endpoint_discovery"] = False
+
+        credential: Any = config.COSMOS_KEY or get_azure_credential()
+        try:
+            _client_cache["client"] = CosmosClient(config.COSMOS_ENDPOINT, credential=credential, **client_kwargs)
+        except Exception as exc:  # noqa: BLE001 — surface as degraded, never crash the app
+            log.error("Failed to initialise Cosmos client: %s", exc)
+            return None
+
+    return _client_cache["client"]
+
+
+def _get_alarm_container() -> Any | None:
+    """Return the alarm container client, creating the database/container in dev.
+
+    When key-based auth is used (emulator / dev) the database and container are created
+    on demand so a fresh emulator needs no manual setup. With RBAC auth they are assumed
+    to already exist.
+    """
+    client = _get_client()
+    if client is None:
+        return None
+
+    try:
+        if config.COSMOS_KEY:
+            database = client.create_database_if_not_exists(id=config.COSMOS_DATABASE)
+            return database.create_container_if_not_exists(
+                id=config.COSMOS_CONTAINER,
+                partition_key=PartitionKey(path="/pk"),
+            )
+        database = client.get_database_client(config.COSMOS_DATABASE)
+        return database.get_container_client(config.COSMOS_CONTAINER)
+    except CosmosResourceExistsError:
+        # Multiple gunicorn workers can race to create the database/container on a
+        # fresh emulator: all read a 404, all attempt to create, and the losers get a
+        # 409 Conflict. That simply means the resource now exists, so return the
+        # existing container client rather than degrading this worker's persistence.
+        database = client.get_database_client(config.COSMOS_DATABASE)
+        return database.get_container_client(config.COSMOS_CONTAINER)
+    except CosmosHttpResponseError as exc:
+        log.error("Failed to access Cosmos container '%s': %s", config.COSMOS_CONTAINER, exc)
+        return None
+
+
+def get_document(pk: str, doc_id: str) -> dict | None:
+    """Read a single document by partition key and id.
+
+    Returns the stored payload (Cosmos system fields and routing keys stripped) or
+    ``None`` when the document is missing, Cosmos is not configured, or a read error
+    occurs. Errors are logged and swallowed so callers can fall back to defaults.
+    """
+    container = _get_alarm_container()
+    if container is None:
+        return None
+
+    try:
+        item = container.read_item(item=doc_id, partition_key=pk)
+    except CosmosResourceNotFoundError:
+        return None
+    except CosmosHttpResponseError as exc:
+        log.warning("Failed to read Cosmos document %s/%s: %s", pk, doc_id, exc)
+        return None
+
+    return {k: v for k, v in item.items() if k not in _RESERVED_KEYS and not k.startswith("_")}
+
+
+def upsert_document(pk: str, doc_id: str, data: dict) -> None:
+    """Create or replace a document identified by ``pk``/``doc_id``.
+
+    The ``data`` payload is stored verbatim alongside the ``id`` and ``pk`` routing
+    fields. Errors are logged and swallowed so a persistence outage never breaks a
+    request — matching the previous JSON-file save behaviour.
+    """
+    container = _get_alarm_container()
+    if container is None:
+        if is_configured():
+            log.error("Cannot persist Cosmos document %s/%s — container unavailable", pk, doc_id)
+        return
+
+    document = {k: v for k, v in data.items() if k not in _RESERVED_KEYS}
+    document["id"] = doc_id
+    document["pk"] = pk
+
+    try:
+        container.upsert_item(body=document)
+    except CosmosHttpResponseError as exc:
+        log.error("Failed to persist Cosmos document %s/%s: %s", pk, doc_id, exc)
+
+
+def _reset_client_for_tests() -> None:
+    """Clear the cached client — used by unit tests to isolate configuration changes."""
+    with _client_lock:
+        _client_cache["client"] = None

--- a/dashboard/dashboard/static/css/style.css
+++ b/dashboard/dashboard/static/css/style.css
@@ -1456,6 +1456,21 @@ a.kpi-card--link:hover {
   word-break: break-word;
 }
 
+.exc-detail-toggle {
+  background: none;
+  border: none;
+  color: var(--accent-cyan);
+  font-size: 0.72rem;
+  padding: 0.3rem 0 0;
+  margin-top: 0.15rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.exc-detail-toggle:hover { text-decoration: underline; }
+
 /* ---------- Footer ---------- */
 .dash-footer {
   text-align: center;

--- a/dashboard/dashboard/templates/exceptions.html
+++ b/dashboard/dashboard/templates/exceptions.html
@@ -87,8 +87,10 @@
                   data-full="{{ exc.message }}"
                   data-short="{{ exc.message | truncate(300) }}"
                   data-target="exc-msg-{{ loop.index }}"
+                  aria-controls="exc-msg-{{ loop.index }}"
+                  aria-expanded="false"
                   onclick="toggleExceptionDetail(this)">
-            <i class="bi bi-chevron-down"></i> <span>{{ _("Show full message") }}</span>
+            <i class="bi bi-chevron-down" aria-hidden="true"></i> <span>{{ _("Show full message") }}</span>
           </button>
           {% endif %}
           {% endif %}

--- a/dashboard/dashboard/templates/exceptions.html
+++ b/dashboard/dashboard/templates/exceptions.html
@@ -141,6 +141,7 @@
     var target = document.getElementById(btn.dataset.target);
     if (!target) return;
     var expanded = btn.classList.toggle('expanded');
+    btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     target.textContent = expanded ? btn.dataset.full : btn.dataset.short;
     var icon = btn.querySelector('i');
     var label = btn.querySelector('span');

--- a/dashboard/dashboard/templates/exceptions.html
+++ b/dashboard/dashboard/templates/exceptions.html
@@ -81,7 +81,16 @@
             </div>
           </div>
           {% if exc.message %}
-          <div class="exception-full-msg">{{ exc.message | truncate(300) }}</div>
+          <div class="exception-full-msg" id="exc-msg-{{ loop.index }}">{{ exc.message | truncate(300) }}</div>
+          {% if exc.message | length > 300 %}
+          <button type="button" class="exc-detail-toggle"
+                  data-full="{{ exc.message }}"
+                  data-short="{{ exc.message | truncate(300) }}"
+                  data-target="exc-msg-{{ loop.index }}"
+                  onclick="toggleExceptionDetail(this)">
+            <i class="bi bi-chevron-down"></i> <span>{{ _("Show full message") }}</span>
+          </button>
+          {% endif %}
           {% endif %}
           {% if exc.operation_id and exc.operation_id | replace('0', '') %}
           <div class="exception-meta mt-1">
@@ -123,6 +132,19 @@
   var i18nSeverityOnly    = {{ _("Severity {sev} only") | tojson }};
   var i18nShowAll         = {{ _("Show all") | tojson }};
   var i18nSortedByRecent  = {{ _("Sorted by most recent") | tojson }};
+  var i18nShowFullMessage = {{ _("Show full message") | tojson }};
+  var i18nShowLess        = {{ _("Show less") | tojson }};
+
+  function toggleExceptionDetail(btn) {
+    var target = document.getElementById(btn.dataset.target);
+    if (!target) return;
+    var expanded = btn.classList.toggle('expanded');
+    target.textContent = expanded ? btn.dataset.full : btn.dataset.short;
+    var icon = btn.querySelector('i');
+    var label = btn.querySelector('span');
+    if (icon) icon.className = expanded ? 'bi bi-chevron-up' : 'bi bi-chevron-down';
+    if (label) label.textContent = expanded ? i18nShowLess : i18nShowFullMessage;
+  }
 
   function setSeverityFilter(sev) {
     var items = document.querySelectorAll('#exception-items .exception-item');

--- a/dashboard/pyproject.toml
+++ b/dashboard/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.13"
 
 dependencies = [
     "azure-communication-email>=1.0.0",
+    "azure-cosmos>=4.9.0",
     "azure-identity>=1.25.0",
     "azure-mgmt-appcontainers>=4.0.0",
     "azure-mgmt-servicebus>=9.0.0",

--- a/dashboard/tests/conftest.py
+++ b/dashboard/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared pytest fixtures for the dashboard test suite.
+
+Unit tests must be hermetic — they must never reach a live Azure Cosmos account or
+the local emulator. Because ``dashboard/.env`` configures ``COSMOS_ENDPOINT`` for local
+development, an autouse fixture disables Cosmos persistence for every test by default so
+alarm config/state reads simply return empty (mirroring the previous "missing JSON file"
+behaviour). Tests that specifically exercise :mod:`dashboard.services.cosmos_store` opt
+back in by patching the endpoint explicitly within the test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from dashboard.services import cosmos_store
+
+
+@pytest.fixture(autouse=True)
+def _disable_cosmos() -> Generator[None, None, None]:
+    """Disable Cosmos persistence for every test and reset the cached client."""
+    cosmos_store._reset_client_for_tests()
+    with patch.object(cosmos_store.config, "COSMOS_ENDPOINT", ""):
+        yield
+    cosmos_store._reset_client_for_tests()

--- a/dashboard/tests/test_cosmos_store.py
+++ b/dashboard/tests/test_cosmos_store.py
@@ -1,0 +1,225 @@
+"""Unit tests for the Cosmos DB persistence layer (dashboard.services.cosmos_store).
+
+These tests mock the Cosmos SDK entirely — no emulator or live account is required.
+They cover:
+  - is_configured()          : endpoint-driven activation
+  - get_document()           : hit / miss / not-configured / error paths and field stripping
+  - upsert_document()        : payload shaping (id/pk injection) and no-op when unconfigured
+  - client auth selection    : key-based vs RBAC credential, and SSL verification toggle
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.cosmos.exceptions import (
+    CosmosHttpResponseError,
+    CosmosResourceExistsError,
+    CosmosResourceNotFoundError,
+)
+
+from dashboard.services import cosmos_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_client() -> Any:
+    """Ensure each test starts and ends with a clean singleton client."""
+    cosmos_store._reset_client_for_tests()
+    yield
+    cosmos_store._reset_client_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# is_configured
+# ---------------------------------------------------------------------------
+
+
+class TestIsConfigured:
+    def test_true_when_endpoint_set(self) -> None:
+        with patch.object(cosmos_store.config, "COSMOS_ENDPOINT", "https://localhost:8081"):
+            assert cosmos_store.is_configured() is True
+
+    def test_false_when_endpoint_empty(self) -> None:
+        with patch.object(cosmos_store.config, "COSMOS_ENDPOINT", ""):
+            assert cosmos_store.is_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# get_document
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocument:
+    def test_returns_none_when_not_configured(self) -> None:
+        with patch.object(cosmos_store.config, "COSMOS_ENDPOINT", ""):
+            assert cosmos_store.get_document("alarm1", "config") is None
+
+    def test_strips_system_and_routing_fields(self) -> None:
+        container = MagicMock()
+        container.read_item.return_value = {
+            "id": "config",
+            "pk": "alarm1",
+            "_rid": "abc",
+            "_etag": "xyz",
+            "_ts": 123,
+            "rules": {"r1": {"alarm_enabled": True}},
+        }
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            result = cosmos_store.get_document("alarm1", "config")
+
+        assert result == {"rules": {"r1": {"alarm_enabled": True}}}
+        container.read_item.assert_called_once_with(item="config", partition_key="alarm1")
+
+    def test_returns_none_on_missing_document(self) -> None:
+        container = MagicMock()
+        container.read_item.side_effect = CosmosResourceNotFoundError(message="missing")
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            assert cosmos_store.get_document("alarm1", "config") is None
+
+    def test_returns_none_on_http_error(self) -> None:
+        container = MagicMock()
+        container.read_item.side_effect = CosmosHttpResponseError(message="boom")
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            assert cosmos_store.get_document("alarm1", "config") is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_document
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertDocument:
+    def test_injects_id_and_pk(self) -> None:
+        container = MagicMock()
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            cosmos_store.upsert_document("alarm2", "state", {"rules": {"r1": {"last_alarm_at": "2026-01-01T00:00:00"}}})
+
+        container.upsert_item.assert_called_once_with(
+            body={"rules": {"r1": {"last_alarm_at": "2026-01-01T00:00:00"}}, "id": "state", "pk": "alarm2"}
+        )
+
+    def test_overrides_reserved_keys_in_payload(self) -> None:
+        """Any stray id/pk in the payload is replaced by the routing arguments."""
+        container = MagicMock()
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            cosmos_store.upsert_document("alarm3", "config", {"id": "hacked", "pk": "hacked", "rules": {}})
+
+        container.upsert_item.assert_called_once_with(body={"rules": {}, "id": "config", "pk": "alarm3"})
+
+    def test_noop_when_container_unavailable(self) -> None:
+        with patch.object(cosmos_store, "_get_container", return_value=None):
+            # Should not raise.
+            cosmos_store.upsert_document("alarm1", "config", {"rules": {}})
+
+    def test_swallows_http_error(self) -> None:
+        container = MagicMock()
+        container.upsert_item.side_effect = CosmosHttpResponseError(message="boom")
+        with patch.object(cosmos_store, "_get_container", return_value=container):
+            # Should log and return without raising.
+            cosmos_store.upsert_document("alarm1", "config", {"rules": {}})
+
+
+# ---------------------------------------------------------------------------
+# _get_client — auth selection
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+    def test_returns_none_when_not_configured(self) -> None:
+        with patch.object(cosmos_store.config, "COSMOS_ENDPOINT", ""):
+            assert cosmos_store._get_client() is None
+
+    def test_uses_key_when_set(self) -> None:
+        with (
+            patch.object(cosmos_store.config, "COSMOS_ENDPOINT", "https://localhost:8081"),
+            patch.object(cosmos_store.config, "COSMOS_KEY", "the-key"),
+            patch.object(cosmos_store.config, "COSMOS_DISABLE_SSL_VERIFY", True),
+            patch("dashboard.services.cosmos_store.CosmosClient") as client_cls,
+        ):
+            cosmos_store._get_client()
+
+        client_cls.assert_called_once_with(
+            "https://localhost:8081", credential="the-key", connection_verify=False, enable_endpoint_discovery=False
+        )
+
+    def test_uses_azure_credential_when_key_absent(self) -> None:
+        sentinel = object()
+        with (
+            patch.object(cosmos_store.config, "COSMOS_ENDPOINT", "https://acct.documents.azure.com"),
+            patch.object(cosmos_store.config, "COSMOS_KEY", ""),
+            patch.object(cosmos_store.config, "COSMOS_DISABLE_SSL_VERIFY", False),
+            patch("dashboard.services.cosmos_store.get_azure_credential", return_value=sentinel),
+            patch("dashboard.services.cosmos_store.CosmosClient") as client_cls,
+        ):
+            cosmos_store._get_client()
+
+        client_cls.assert_called_once_with("https://acct.documents.azure.com", credential=sentinel)
+
+    def test_client_is_cached_singleton(self) -> None:
+        with (
+            patch.object(cosmos_store.config, "COSMOS_ENDPOINT", "https://localhost:8081"),
+            patch.object(cosmos_store.config, "COSMOS_KEY", "the-key"),
+            patch.object(cosmos_store.config, "COSMOS_DISABLE_SSL_VERIFY", False),
+            patch("dashboard.services.cosmos_store.CosmosClient") as client_cls,
+        ):
+            first = cosmos_store._get_client()
+            second = cosmos_store._get_client()
+
+        assert first is second
+        client_cls.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _get_container — database/container resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainer:
+    def test_falls_back_to_existing_container_on_conflict(self) -> None:
+        """A 409 from a concurrent worker's create must resolve to the existing container.
+
+        Two gunicorn workers race to create the container on a fresh emulator: both read
+        a 404, both call create, and the loser receives a 409 Conflict. The loser must
+        return the already-created container rather than degrading to ``None``.
+        """
+        existing_container = MagicMock(name="existing_container")
+        database = MagicMock(name="database")
+        database.create_container_if_not_exists.side_effect = CosmosResourceExistsError(message="already exists")
+        database.get_container_client.return_value = existing_container
+
+        client = MagicMock(name="client")
+        client.create_database_if_not_exists.return_value = database
+        client.get_database_client.return_value = database
+
+        with (
+            patch.object(cosmos_store, "_get_client", return_value=client),
+            patch.object(cosmos_store.config, "COSMOS_KEY", "the-key"),
+            patch.object(cosmos_store.config, "COSMOS_DATABASE", "db"),
+            patch.object(cosmos_store.config, "COSMOS_CONTAINER", "alarms"),
+        ):
+            result = cosmos_store._get_alarm_container()
+
+        assert result is existing_container
+        database.get_container_client.assert_called_once_with("alarms")
+
+    def test_returns_none_on_other_http_error(self) -> None:
+        database = MagicMock(name="database")
+        database.create_container_if_not_exists.side_effect = CosmosHttpResponseError(message="boom")
+
+        client = MagicMock(name="client")
+        client.create_database_if_not_exists.return_value = database
+
+        with (
+            patch.object(cosmos_store, "_get_client", return_value=client),
+            patch.object(cosmos_store.config, "COSMOS_KEY", "the-key"),
+            patch.object(cosmos_store.config, "COSMOS_DATABASE", "db"),
+            patch.object(cosmos_store.config, "COSMOS_CONTAINER", "alarms"),
+        ):
+            assert cosmos_store._get_alarm_container() is None
+
+    def test_returns_none_when_client_unavailable(self) -> None:
+        with patch.object(cosmos_store, "_get_client", return_value=None):
+            assert cosmos_store._get_alarm_container() is None
+

--- a/dashboard/uv.lock
+++ b/dashboard/uv.lock
@@ -42,6 +42,19 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-cosmos"
+version = "4.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/2a/0f2bba256e56626ba2cec97ab81dd002ff47ead1329767760b619afd927a/azure_cosmos-4.16.1.tar.gz", hash = "sha256:fa15d13702b470265a67e2dd9c0794021e6b776856dac6c223dcacc4d8e1d8d1", size = 2377651, upload-time = "2026-06-02T01:08:07.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/b4/9c984ad33ca9e5c378ea472fc9aa38e719c245a4fa58a99d6dabbe0f9a17/azure_cosmos-4.16.1-py3-none-any.whl", hash = "sha256:43717215ec1433c1ea0f0e3d465f9182fb5afff3ae2331e595367122297872f1", size = 499044, upload-time = "2026-06-02T01:08:10.111Z" },
+]
+
+[[package]]
 name = "azure-identity"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
@@ -478,6 +491,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-communication-email" },
+    { name = "azure-cosmos" },
     { name = "azure-identity" },
     { name = "azure-mgmt-appcontainers" },
     { name = "azure-mgmt-servicebus" },
@@ -504,6 +518,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-communication-email", specifier = ">=1.0.0" },
+    { name = "azure-cosmos", specifier = ">=4.9.0" },
     { name = "azure-identity", specifier = ">=1.25.0" },
     { name = "azure-mgmt-appcontainers", specifier = ">=4.0.0" },
     { name = "azure-mgmt-servicebus", specifier = ">=9.0.0" },

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -375,5 +375,33 @@ services:
         aliases:
           - "buswatch"
 
+  # Azure Cosmos DB emulator - persistence backend for the NOC dashboard.
+  # First start pulls a ~1GB image and takes ~1 minute to become healthy.
+  cosmos-emulator:
+    container_name: cosmos-emulator
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+    pull_policy: always
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    environment:
+      # Fewer partitions = faster startup and lower memory for local dev.
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: "3"
+      # Persist emulator data across restarts.
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
+    volumes:
+      - cosmos-data:/tmp/cosmos/appdata
+    restart: unless-stopped
+    profiles:
+      - dashboard
+    networks:
+      integration-hub:
+        aliases:
+          - "cosmos-emulator"
+
 networks:
   integration-hub:
+
+volumes:
+  cosmos-data:
+


### PR DESCRIPTION
## feat: Add Azure Cosmos DB persistence for NOC dashboard alarms

### Summary

Replaces ephemeral in-memory (and previous JSON-file) alarm state with **Azure Cosmos DB**, so alarm configuration and runtime state survive container restarts. Includes a security dependency bump alongside the feature work.

### Changes

#### New: `dashboard/services/cosmos_store.py`
- Lazy singleton `CosmosClient` with dual auth: key-based (for local emulator) or AAD RBAC (for cloud via `DefaultAzureCredential`)
- `COSMOS_DISABLE_SSL_VERIFY` disables both cert verification **and** endpoint discovery — required to pin the Dockerised emulator to `localhost:8081`
- Graceful degradation: all reads return empty state and all writes are no-ops when `COSMOS_ENDPOINT` is unset

#### Updated: `alarm1.py`, `alarm2.py`, `alarm3.py`
- Load and save alarm config/state via `cosmos_store`; public function signatures are unchanged

#### Updated: `dashboard/config.py`
- Five new environment variables: `COSMOS_ENDPOINT`, `COSMOS_KEY`, `COSMOS_DATABASE` (default: `integration-hub-dashboard`), `COSMOS_CONTAINER` (default: `alarms`), `COSMOS_DISABLE_SSL_VERIFY`

#### Updated: `local/docker-compose.yml`
- `cosmos-emulator` service added under the `dashboard` profile; dashboard itself continues to run on the host with `uv run flask`

#### Updated: `dashboard/README.md`
- Local dev setup instructions for the Cosmos emulator

#### Tests
- `tests/conftest.py`: autouse fixture sets `COSMOS_ENDPOINT=''` so all existing tests remain hermetic
- `tests/test_cosmos_store.py`: 225-line test file covering happy path, graceful degradation, key auth vs RBAC, and SSL bypass behaviour

#### Security fix
- `click` bumped to **8.4.2** to resolve [PYSEC-2026-2132](https://osv.dev/vulnerability/PYSEC-2026-2132)

### Deployment notes

| Scenario | Configuration |
|---|---|
| **Local** | Start `cosmos-emulator` via `docker compose --profile dashboard up -d cosmos-emulator`; set `COSMOS_ENDPOINT=https://localhost:8081` + `COSMOS_KEY=<emulator-key>` + `COSMOS_DISABLE_SSL_VERIFY=true` |
| **Cloud (dev/tst/prod)** | Leave `COSMOS_KEY` unset (Managed Identity RBAC); set `COSMOS_ENDPOINT` to the account URI; `COSMOS_DISABLE_SSL_VERIFY=false` |
| **No Cosmos configured** | Omit `COSMOS_ENDPOINT` — dashboard runs with no persistence, alarm state resets on restart |

> The Cosmos DB account, database, and container must be provisioned via the companion Terraform PR before deploying to any cloud environment.

### Related

- Terraform PR: [Feature/dashboard-cosmos #165](https://github.com/DHCW-Digital-Health-and-Care-Wales/Integration-Hub-Terraform/pull/165)