### PR TITLE
fix: align cosmos_store container helper name with tests

### DIFF
--- a/dashboard/dashboard/services/cosmos_store.py
+++ b/dashboard/dashboard/services/cosmos_store.py
@@ -95,7 +95,7 @@ def _get_client() -> CosmosClient | None:
     return _client_cache["client"]
 
 
-def _get_alarm_container() -> Any | None:
+def _get_container() -> Any | None:
     """Return the alarm container client, creating the database/container in dev.
 
     When key-based auth is used (emulator / dev) the database and container are created
@@ -134,7 +134,7 @@ def get_document(pk: str, doc_id: str) -> dict | None:
     ``None`` when the document is missing, Cosmos is not configured, or a read error
     occurs. Errors are logged and swallowed so callers can fall back to defaults.
     """
-    container = _get_alarm_container()
+    container = _get_container()
     if container is None:
         return None
 
@@ -156,7 +156,7 @@ def upsert_document(pk: str, doc_id: str, data: dict) -> None:
     fields. Errors are logged and swallowed so a persistence outage never breaks a
     request — matching the previous JSON-file save behaviour.
     """
-    container = _get_alarm_container()
+    container = _get_container()
     if container is None:
         if is_configured():
             log.error("Cannot persist Cosmos document %s/%s — container unavailable", pk, doc_id)

--- a/dashboard/tests/test_cosmos_store.py
+++ b/dashboard/tests/test_cosmos_store.py
@@ -199,7 +199,7 @@ class TestGetContainer:
             patch.object(cosmos_store.config, "COSMOS_DATABASE", "db"),
             patch.object(cosmos_store.config, "COSMOS_CONTAINER", "alarms"),
         ):
-            result = cosmos_store._get_alarm_container()
+            result = cosmos_store._get_container()
 
         assert result is existing_container
         database.get_container_client.assert_called_once_with("alarms")
@@ -217,9 +217,9 @@ class TestGetContainer:
             patch.object(cosmos_store.config, "COSMOS_DATABASE", "db"),
             patch.object(cosmos_store.config, "COSMOS_CONTAINER", "alarms"),
         ):
-            assert cosmos_store._get_alarm_container() is None
+            assert cosmos_store._get_container() is None
 
     def test_returns_none_when_client_unavailable(self) -> None:
         with patch.object(cosmos_store, "_get_client", return_value=None):
-            assert cosmos_store._get_alarm_container() is None
+            assert cosmos_store._get_container() is None
 


### PR DESCRIPTION
Rename _get_alarm_container to _get_container in cosmos_store and fix the three TestGetContainer cases that still called the old name, so the unit tests patch and invoke a consistent symbol.