### PR TITLE
refactor: extract integer parsing logic into a reusable helper function

### DIFF
--- a/dashboard/dashboard/app.py
+++ b/dashboard/dashboard/app.py
@@ -63,6 +63,7 @@ from dashboard.services.azure_monitor import (
 )
 from dashboard.services.container_apps import get_container_apps_metrics
 from dashboard.services.flows import build_flow_data, get_active_flows, get_flows, overall_health, queue_to_workflow_id
+from dashboard.services.form_utils import parse_int_form_field
 from dashboard.services.service_bus import get_message_metrics, get_queues
 from dashboard.services.traces import get_trace
 
@@ -884,12 +885,6 @@ def alarm_config_page() -> str:
         cfg = load_alarm_config()
         rules_cfg = cfg.setdefault("rules", {})
 
-        def _int(field: str, default: int) -> int:
-            try:
-                return max(1, int(request.form.get(field, default)))
-            except (ValueError, TypeError):
-                return default
-
         # Handle deletions
         for key in list(request.form):
             if key.startswith("delete_"):
@@ -907,10 +902,10 @@ def alarm_config_page() -> str:
             entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
-            entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60)
-            entry["day_threshold_minutes"] = _int(f"day_threshold_{rid}", 60)
-            entry["evening_threshold_minutes"] = _int(f"evening_threshold_{rid}", 120)
-            entry["weekend_threshold_minutes"] = _int(f"weekend_threshold_{rid}", 240)
+            entry["alerting_gap_minutes"] = parse_int_form_field(request.form, f"alerting_gap_{rid}", 60)
+            entry["day_threshold_minutes"] = parse_int_form_field(request.form, f"day_threshold_{rid}", 60)
+            entry["evening_threshold_minutes"] = parse_int_form_field(request.form, f"evening_threshold_{rid}", 120)
+            entry["weekend_threshold_minutes"] = parse_int_form_field(request.form, f"weekend_threshold_{rid}", 240)
 
         # Add new rule
         new_wid = (request.form.get("new_workflow_id") or "").strip()
@@ -921,10 +916,10 @@ def alarm_config_page() -> str:
                 "display_name": (request.form.get("new_display_name") or "").strip(),
                 "alarm_enabled": "new_enabled" in request.form,
                 "workflow_id": new_wid,
-                "day_threshold_minutes": _int("new_day_threshold", 60),
-                "evening_threshold_minutes": _int("new_evening_threshold", 120),
-                "weekend_threshold_minutes": _int("new_weekend_threshold", 240),
-                "alerting_gap_minutes": _int("new_alerting_gap", 60),
+                "day_threshold_minutes": parse_int_form_field(request.form, "new_day_threshold", 60),
+                "evening_threshold_minutes": parse_int_form_field(request.form, "new_evening_threshold", 120),
+                "weekend_threshold_minutes": parse_int_form_field(request.form, "new_weekend_threshold", 240),
+                "alerting_gap_minutes": parse_int_form_field(request.form, "new_alerting_gap", 60),
                 "email_alerts_enabled": False,
                 "email_ooh_enabled": False,
             }
@@ -1169,12 +1164,6 @@ def alarm2_config_page() -> str:
         cfg = load_alarm2_config()
         rules_cfg = cfg.setdefault("rules", {})
 
-        def _int(field: str, default: int, minimum: int = 0) -> int:
-            try:
-                return max(minimum, int(request.form.get(field, default)))
-            except (ValueError, TypeError):
-                return default
-
         # --- Handle deletions first ---
         for key in list(request.form):
             if key.startswith("delete_"):
@@ -1192,10 +1181,14 @@ def alarm2_config_page() -> str:
             entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
-            entry["day_threshold_minutes"] = _int(f"day_threshold_{rid}", 60, minimum=0)
-            entry["evening_threshold_minutes"] = _int(f"evening_threshold_{rid}", 120, minimum=0)
-            entry["weekend_threshold_minutes"] = _int(f"weekend_threshold_{rid}", 240, minimum=0)
-            entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60, minimum=1)
+            entry["day_threshold_minutes"] = parse_int_form_field(request.form, f"day_threshold_{rid}", 60, minimum=0)
+            entry["evening_threshold_minutes"] = parse_int_form_field(
+                request.form, f"evening_threshold_{rid}", 120, minimum=0
+            )
+            entry["weekend_threshold_minutes"] = parse_int_form_field(
+                request.form, f"weekend_threshold_{rid}", 240, minimum=0
+            )
+            entry["alerting_gap_minutes"] = parse_int_form_field(request.form, f"alerting_gap_{rid}", 60, minimum=1)
 
         # --- Add new rule if submitted ---
         new_wid = (request.form.get("new_workflow_id") or "").strip()
@@ -1206,10 +1199,14 @@ def alarm2_config_page() -> str:
                 "display_name": (request.form.get("new_display_name") or "").strip() or new_wid,
                 "alarm_enabled": "new_enabled" in request.form,
                 "workflow_id": new_wid,
-                "day_threshold_minutes": _int("new_day_threshold", 60, minimum=0),
-                "evening_threshold_minutes": _int("new_evening_threshold", 120, minimum=0),
-                "weekend_threshold_minutes": _int("new_weekend_threshold", 240, minimum=0),
-                "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
+                "day_threshold_minutes": parse_int_form_field(request.form, "new_day_threshold", 60, minimum=0),
+                "evening_threshold_minutes": parse_int_form_field(
+                    request.form, "new_evening_threshold", 120, minimum=0
+                ),
+                "weekend_threshold_minutes": parse_int_form_field(
+                    request.form, "new_weekend_threshold", 240, minimum=0
+                ),
+                "alerting_gap_minutes": parse_int_form_field(request.form, "new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
                 "email_ooh_enabled": False,
             }
@@ -1265,12 +1262,6 @@ def alarm3_config_page() -> str:
         cfg = load_alarm3_config()
         rules_cfg = cfg.setdefault("rules", {})
 
-        def _int(field: str, default: int, minimum: int = 0) -> int:
-            try:
-                return max(minimum, int(request.form.get(field, default)))
-            except (ValueError, TypeError):
-                return default
-
         for key in list(request.form):
             if key.startswith("delete_"):
                 rid = key[len("delete_") :]
@@ -1286,9 +1277,11 @@ def alarm3_config_page() -> str:
             entry["email_ooh_enabled"] = f"email_ooh_{rid}" in request.form and entry["email_alerts_enabled"]
             entry["display_name"] = (request.form.get(f"display_name_{rid}") or "").strip()
             entry["workflow_id"] = (request.form.get(f"workflow_id_{rid}") or "").strip()
-            entry["window_duration_minutes"] = _int(f"window_duration_{rid}", 15, minimum=1)
-            entry["threshold"] = _int(f"threshold_{rid}", 1, minimum=1)
-            entry["alerting_gap_minutes"] = _int(f"alerting_gap_{rid}", 60, minimum=1)
+            entry["window_duration_minutes"] = parse_int_form_field(
+                request.form, f"window_duration_{rid}", 15, minimum=1
+            )
+            entry["threshold"] = parse_int_form_field(request.form, f"threshold_{rid}", 1, minimum=1)
+            entry["alerting_gap_minutes"] = parse_int_form_field(request.form, f"alerting_gap_{rid}", 60, minimum=1)
 
         new_wid = (request.form.get("new_workflow_id") or "").strip()
         new_id = None
@@ -1298,9 +1291,9 @@ def alarm3_config_page() -> str:
                 "display_name": (request.form.get("new_display_name") or "").strip() or f"{new_wid} Failures",
                 "alarm_enabled": "new_enabled" in request.form,
                 "workflow_id": new_wid,
-                "window_duration_minutes": _int("new_window_duration", 15, minimum=1),
-                "threshold": _int("new_threshold", 1, minimum=1),
-                "alerting_gap_minutes": _int("new_alerting_gap", 60, minimum=1),
+                "window_duration_minutes": parse_int_form_field(request.form, "new_window_duration", 15, minimum=1),
+                "threshold": parse_int_form_field(request.form, "new_threshold", 1, minimum=1),
+                "alerting_gap_minutes": parse_int_form_field(request.form, "new_alerting_gap", 60, minimum=1),
                 "email_alerts_enabled": False,
                 "email_ooh_enabled": False,
             }

--- a/dashboard/dashboard/services/form_utils.py
+++ b/dashboard/dashboard/services/form_utils.py
@@ -19,9 +19,10 @@ def parse_int_form_field(
 ) -> int:
     """Parse an integer field from a submitted form, clamped to a minimum.
 
-    Falls back to ``default`` if the field is missing or not a valid integer.
-    Mirrors the previous per-route ``_int`` closures: alarm1's implicit
-    ``max(1, ...)`` behaviour is preserved via the ``minimum=1`` default.
+    If the field is missing, returns ``max(minimum, default)``.
+    If the value is present but not a valid integer, returns ``default``.
+    Mirrors the previous per-route ``_int`` closures; alarm1's implicit
+    ``max(1, ...)`` is preserved via the ``minimum=1`` default.
     """
     try:
         return max(minimum, int(form.get(field, default)))

--- a/dashboard/dashboard/services/form_utils.py
+++ b/dashboard/dashboard/services/form_utils.py
@@ -1,0 +1,29 @@
+"""
+Shared helpers for parsing Flask ``request.form`` data.
+
+Extracted from the near-identical ``_int`` closures previously duplicated in
+``alarm_config_page``, ``alarm2_config_page`` and ``alarm3_config_page`` in
+``dashboard/app.py``.
+"""
+
+from __future__ import annotations
+
+from werkzeug.datastructures import ImmutableMultiDict
+
+
+def parse_int_form_field(
+    form: ImmutableMultiDict,
+    field: str,
+    default: int,
+    minimum: int = 1,
+) -> int:
+    """Parse an integer field from a submitted form, clamped to a minimum.
+
+    Falls back to ``default`` if the field is missing or not a valid integer.
+    Mirrors the previous per-route ``_int`` closures: alarm1's implicit
+    ``max(1, ...)`` behaviour is preserved via the ``minimum=1`` default.
+    """
+    try:
+        return max(minimum, int(form.get(field, default)))
+    except (ValueError, TypeError):
+        return default

--- a/dashboard/tests/test_form_utils.py
+++ b/dashboard/tests/test_form_utils.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for dashboard.services.form_utils.
+
+Covers the parse_int_form_field helper, extracted from the previously
+duplicated ``_int`` closures in app.py's alarm config routes.
+"""
+
+from __future__ import annotations
+
+from werkzeug.datastructures import ImmutableMultiDict
+
+from dashboard.services.form_utils import parse_int_form_field
+
+
+class TestParseIntFormField:
+    def test_returns_submitted_value_when_valid(self) -> None:
+        form = ImmutableMultiDict({"gap": "30"})
+        assert parse_int_form_field(form, "gap", 60) == 30
+
+    def test_returns_default_when_field_missing(self) -> None:
+        form = ImmutableMultiDict({})
+        assert parse_int_form_field(form, "gap", 60) == 60
+
+    def test_returns_default_when_value_not_an_integer(self) -> None:
+        form = ImmutableMultiDict({"gap": "not-a-number"})
+        assert parse_int_form_field(form, "gap", 60) == 60
+
+    def test_clamps_to_default_minimum_of_one(self) -> None:
+        form = ImmutableMultiDict({"gap": "0"})
+        assert parse_int_form_field(form, "gap", 60) == 1
+
+    def test_clamps_to_explicit_minimum(self) -> None:
+        form = ImmutableMultiDict({"threshold": "-5"})
+        assert parse_int_form_field(form, "threshold", 1, minimum=0) == 0
+
+    def test_allows_zero_when_minimum_is_zero(self) -> None:
+        form = ImmutableMultiDict({"threshold": "0"})
+        assert parse_int_form_field(form, "threshold", 60, minimum=0) == 0


### PR DESCRIPTION
AB#600186

Refactor Dashboard - stage 1

Extract the  _int(...)  helper (lowest risk, do first)
Duplicated 3× inside  alarm_config_page ,  alarm2_config_page ,  alarm3_config_page  (app.py:887, 1172, 1268). Move to a small  dashboard/utils.py  (or  services/form_utils.py ). Pure function, no Flask/global state — trivial to unit test in isolation, zero impact on existing route tests.
