### PR TITLE
fix: copy MSH-11 processing ID from the inbound message into the ACK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,5 @@ dashboard/alarm*_config.json
 
 # Local-only Podman container definitions (not committed to source control)
 Dockerfile.podman
-local/docker-compose.yml
-local/justfile
 local/justfile.docker
 .dockerignore

--- a/hl7_server/hl7_server/hl7_ack_builder.py
+++ b/hl7_server/hl7_server/hl7_ack_builder.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from field_utils_lib import get_hl7_field_value
 from hl7apy.consts import VALIDATION_LEVEL
 from hl7apy.core import Message, Segment
 
@@ -25,7 +26,7 @@ class HL7AckBuilder:
         # HL7 v2.5 section 2.9.2.2 requires MSH-11 to be copied from the initiating message, so a
         # test message is never acknowledged as production. MSH-11 is required in the ACK, so fall
         # back to "P" if the inbound message omitted it.
-        ack.msh.msh_11 = original_msg.msh.msh_11.value or Hl7Constants.PROCESSING_ID_PRODUCTION
+        ack.msh.msh_11 = get_hl7_field_value(original_msg.msh, "msh_11") or Hl7Constants.PROCESSING_ID_PRODUCTION
         ack.msh.msh_12 = original_msg.msh.msh_12.value
 
         # Build MSA segment

--- a/hl7_server/hl7_server/hl7_ack_builder.py
+++ b/hl7_server/hl7_server/hl7_ack_builder.py
@@ -22,7 +22,10 @@ class HL7AckBuilder:
         ack.msh.msh_9.trigger_event = original_msg.msh.msh_9.trigger_event.value
         ack.msh.msh_9.message_structure = Hl7Constants.ACK_MESSAGE_TYPE_FORMAT
         ack.msh.msh_10 = message_control_id
-        ack.msh.msh_11 = Hl7Constants.PROCESSING_ID_PRODUCTION
+        # HL7 v2.5 section 2.9.2.2 requires MSH-11 to be copied from the initiating message, so a
+        # test message is never acknowledged as production. MSH-11 is required in the ACK, so fall
+        # back to "P" if the inbound message omitted it.
+        ack.msh.msh_11 = original_msg.msh.msh_11.value or Hl7Constants.PROCESSING_ID_PRODUCTION
         ack.msh.msh_12 = original_msg.msh.msh_12.value
 
         # Build MSA segment

--- a/hl7_server/tests/test_hl7_ack_builder.py
+++ b/hl7_server/tests/test_hl7_ack_builder.py
@@ -1,0 +1,60 @@
+import unittest
+
+from hl7apy.core import Message
+from hl7apy.parser import parse_message
+
+from hl7_server.hl7_ack_builder import HL7AckBuilder
+
+MESSAGE_CONTROL_ID = "202505052323364444"
+
+
+def _inbound_message(processing_id: str) -> str:
+    """Build a minimal inbound ADT^A31 with the given MSH-11 processing ID."""
+    return (
+        f"MSH|^~\\&|252|252|100|100|20250505232332||ADT^A31^ADT_A05|{MESSAGE_CONTROL_ID}|"
+        f"{processing_id}|2.5\r"
+        "PID|1||123456^^^Hospital^MR||Doe^John\r"
+    )
+
+
+class TestHL7AckBuilder(unittest.TestCase):
+    def setUp(self) -> None:
+        self.builder = HL7AckBuilder()
+
+    def _build(self, processing_id: str) -> Message:
+        original_msg = parse_message(_inbound_message(processing_id), find_groups=False)
+        return self.builder.build_ack(MESSAGE_CONTROL_ID, original_msg)
+
+    def test_processing_id_copied_from_test_message(self) -> None:
+        # A test message must not be acknowledged as production (HL7 v2.5 section 2.9.2.2).
+        ack = self._build("T")
+
+        self.assertEqual("T", ack.msh.msh_11.value)
+
+    def test_processing_id_copied_from_production_message(self) -> None:
+        ack = self._build("P")
+
+        self.assertEqual("P", ack.msh.msh_11.value)
+
+    def test_processing_id_defaults_when_inbound_field_missing(self) -> None:
+        # MSH-11 is required in the ACK, so an absent inbound value must still yield a valid message.
+        ack = self._build("")
+
+        self.assertEqual("P", ack.msh.msh_11.value)
+
+    def test_ack_header_and_msa_built_correctly(self) -> None:
+        ack = self._build("T")
+
+        # Sending and receiving application/facility are swapped relative to the inbound message.
+        self.assertEqual("100", ack.msh.msh_3.value)
+        self.assertEqual("100", ack.msh.msh_4.value)
+        self.assertEqual("252", ack.msh.msh_5.value)
+        self.assertEqual("252", ack.msh.msh_6.value)
+        self.assertEqual("ACK^A31^ACK", ack.msh.msh_9.value)
+        self.assertEqual("2.5", ack.msh.msh_12.value)
+        self.assertEqual("AA", ack.msa.msa_1.value)
+        self.assertEqual(MESSAGE_CONTROL_ID, ack.msa.msa_2.value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -130,8 +130,8 @@ services:
     build:
       context: ../hl7_phw_transformer
       additional_contexts:
-      - ca-certs=../ca-certs
-      - shared_libs=../shared_libs
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
     env_file:
       - ./phw-hl7-transformer.env
     <<: *default-healthcheck

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,406 @@
+name: integration-hub
+
+x-healthcheck: &default-healthcheck
+  healthcheck:
+    test: ["CMD", "python", "-c", "import socket, sys; s=socket.socket(); s.settimeout(2); s.connect(('localhost', 9000)); s.close()"]
+    interval: 10s
+    timeout: 3s
+    retries: 3
+    start_period: 5s
+
+services:
+  sb-emulator:
+    container_name: "sb-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
+    volumes:
+      - "${HOST_WORKSPACE_PATH:-..}/local/ServiceBusEmulatorConfig.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+    restart: on-failure
+    environment:
+      SQL_SERVER: sqledge
+      ACCEPT_EULA: "Y"
+    env_file:
+      - ./.secrets
+    depends_on:
+      - sqledge
+    networks:
+      integration-hub:
+        aliases:
+          - "sb-emulator"
+  sqledge:
+    container_name: "sqledge"
+    image: "mcr.microsoft.com/azure-sql-edge:latest"
+    restart: on-failure
+    networks:
+      integration-hub:
+        aliases:
+          - "sqledge"
+    environment:
+      ACCEPT_EULA: "Y"
+    env_file:
+      - ./.secrets
+
+  sqlserver:
+    container_name: sqlserver
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    restart: on-failure
+    ports:
+      - "1433:1433"
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: Express
+    env_file:
+      - ./.secrets
+    volumes:
+      - ./sql-scripts:/var/opt/mssql/scripts
+    entrypoint: [ "/bin/sh", "/var/opt/mssql/scripts/entrypoint.sh" ]
+    networks:
+      integration-hub:
+        aliases:
+          - "sqlserver"
+
+  message-store-service:
+    container_name: message-store-service
+    build:
+      context: ../message_store_service
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./.secrets
+      - ./message-store-service.env
+    <<: *default-healthcheck
+    depends_on:
+      - sb-emulator
+      - sqlserver
+    restart: on-failure
+    networks:
+      integration-hub:
+        aliases:
+          - "message-store-service"
+
+  message-replay-job:
+    container_name: message-replay-job
+    build:
+      context: ../message_replay_job
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./.secrets
+      - ./message-replay-job.env
+    depends_on:
+      - sb-emulator
+      - sqlserver
+    restart: "no"
+    profiles:
+      - replay
+    networks:
+      integration-hub:
+        aliases:
+          - "message-replay-job"
+
+  phw-hl7-server:
+    container_name: phw-hl7-server
+    build:
+      context: ../hl7_server
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./phw-hl7-server.env
+    ports:
+      - "2575:2575"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - phw-to-mpi
+    networks:
+      integration-hub:
+        aliases:
+          - "phw-hl7-server"
+
+  phw-hl7-transformer:
+    container_name: phw-hl7-transformer
+    build:
+      context: ../hl7_phw_transformer
+      additional_contexts:
+      - ca-certs=../ca-certs
+      - shared_libs=../shared_libs
+    env_file:
+      - ./phw-hl7-transformer.env
+    <<: *default-healthcheck
+    depends_on:
+      - sb-emulator
+    profiles:
+      - phw-to-mpi
+    restart: on-failure
+    networks:
+      integration-hub:
+        aliases:
+          - "phw-hl7-transformer"
+            
+  mpi-hl7-sender:
+    container_name: mpi-hl7-sender
+    build:
+      context: ../hl7_sender
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./mpi-hl7-sender.env
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - phw-to-mpi
+      - paris-to-mpi
+      - chemo-to-mpi
+      - pims-to-mpi
+    networks:
+      integration-hub:
+        aliases:
+          - "mpi-hl7-sender"
+
+  mpi-hl7-mock-receiver:
+    container_name: mpi-hl7-mock-receiver
+    build:
+      context: ../hl7_mock_receiver
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./mpi-hl7-mock-receiver.env
+    ports:
+      - "2576:2576"
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - phw-to-mpi
+      - paris-to-mpi
+      - chemo-to-mpi
+      - pims-to-mpi
+      - mpi-to-topic
+    networks:
+      integration-hub:
+        aliases:
+          - "mpi-hl7-mock-receiver"
+
+  paris-hl7-server:
+    container_name: paris-hl7-server
+    build:
+      context: ../hl7_server
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./paris-hl7-server.env
+    ports:
+      - "2577:2577"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - paris-to-mpi
+    networks:
+      integration-hub:
+        aliases:
+          - "paris-hl7-server"
+
+  chemo-hl7-server:
+    container_name: chemo-hl7-server
+    build:
+      context: ../hl7_server
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./chemo-hl7-server.env
+    ports:
+      - "2578:2578"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - chemo-to-mpi
+    networks:
+      integration-hub:
+        aliases:
+          - "chemo-hl7-server"
+
+  chemo-hl7-transformer:
+    container_name: chemo-hl7-transformer
+    build:
+      context: ../hl7_chemo_transformer
+      additional_contexts:
+      - ca-certs=../ca-certs
+      - shared_libs=../shared_libs
+    env_file:
+      - ./chemo-hl7-transformer.env
+    <<: *default-healthcheck
+    depends_on:
+      - sb-emulator
+    profiles:
+      - chemo-to-mpi
+    restart: on-failure
+    networks:
+      integration-hub:
+        aliases:
+          - "chemo-hl7-transformer"
+
+  pims-hl7-server:
+    container_name: pims-hl7-server
+    build:
+      context: ../hl7_server
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./pims-hl7-server.env
+    ports:
+      - "2579:2579"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - pims-to-mpi
+    networks:
+      integration-hub:
+        aliases:
+          - "pims-hl7-server"
+  
+  pims-hl7-transformer:
+    container_name: pims-hl7-transformer
+    build:
+      context: ../hl7_pims_transformer
+      additional_contexts:
+      - ca-certs=../ca-certs
+      - shared_libs=../shared_libs
+    env_file:
+      - ./pims-hl7-transformer.env
+    <<: *default-healthcheck
+    depends_on:
+      - sb-emulator
+    profiles:
+      - pims-to-mpi
+    restart: on-failure
+    networks:
+      integration-hub:
+        aliases:
+          - "pims-hl7-transformer"
+
+  mpi-hl7-server:
+    container_name: mpi-hl7-server
+    build:
+      context: ../hl7_server
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./mpi-hl7-server.env
+    ports:
+      - "2580:2580"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - mpi-to-topic
+    networks:
+      integration-hub:
+        aliases:
+          - "mpi-hl7-server"
+
+  mpi-hl7-chemo-sender:
+    container_name: mpi-hl7-chemo-sender
+    build:
+      context: ../hl7_subscription_sender
+      dockerfile: ./Dockerfile
+      additional_contexts:
+        - ca-certs=../ca-certs
+        - shared_libs=../shared_libs
+    env_file:
+      - ./mpi-hl7-chemo-sender.env
+    ports:
+      - "2581:2581"
+    <<: *default-healthcheck
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - mpi-to-topic
+    networks:
+      integration-hub:
+        aliases:
+          - "mpi-hl7-chemo-sender"
+
+  # BusWatch - Allows peeking at messages on Service Bus emulator
+  # http://localhost:8080
+  bus-watch:
+    container_name: bus-watch-server
+    build:
+      context: ../buswatch
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./ServiceBusEmulatorConfig.json:/app/ServiceBusEmulatorConfig.json:ro
+    env_file:
+      - ./buswatch.env
+    ports:
+      - "127.0.0.1:8080:8080"
+    restart: on-failure
+    depends_on:
+      - sb-emulator
+    profiles:
+      - phw-to-mpi
+      - paris-to-mpi
+      - chemo-to-mpi
+      - pims-to-mpi
+      - mpi-to-topic
+    networks:
+      integration-hub:
+        aliases:
+          - "buswatch"
+
+  # Azure Cosmos DB emulator - persistence backend for the NOC dashboard.
+  # First start pulls a ~1GB image and takes ~1 minute to become healthy.
+  cosmos-emulator:
+    container_name: cosmos-emulator
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+    pull_policy: always
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    environment:
+      # Fewer partitions = faster startup and lower memory for local dev.
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: "3"
+      # Persist emulator data across restarts.
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
+    volumes:
+      - cosmos-data:/tmp/cosmos/appdata
+    restart: unless-stopped
+    profiles:
+      - dashboard
+    networks:
+      integration-hub:
+        aliases:
+          - "cosmos-emulator"
+
+networks:
+  integration-hub:
+
+volumes:
+  cosmos-data:

--- a/local/justfile
+++ b/local/justfile
@@ -1,0 +1,219 @@
+# Integration Hub - Local Development Commands (Podman Edition)
+# ============================================
+#
+# A modern command runner for Integration Hub local development using Podman.
+#
+# Quick Start Guide:
+# -----------------
+# 1. List all available commands:     just --list
+# 2. Install dependencies:            just install
+# 3. Generate secrets:                just secrets
+# 4. Build a profile:                 just build phw-to-mpi
+# 5. Start services:                  just start phw-to-mpi
+# 6. Send a test message:             just send test_message.hl7
+# 7. View logs:                       just logs mpi-hl7-mock-receiver
+# 8. Stop all services:               just stop
+#
+# Available Profiles:
+# ------------------
+# - phw-to-mpi     : Public Health Wales to MPI integration
+# - paris-to-mpi   : PARIS to MPI integration
+# - chemo-to-mpi   : Chemo to MPI integration
+# - pims-to-mpi    : PIMS to MPI integration
+# - mpi-to-topic   : MPI to Outbound Integration
+#
+# Tips:
+# -----
+# - Most commands provide detailed feedback with next steps
+# - Dependencies are handled automatically (e.g., secrets are generated when needed)
+# - Use 'just run' as a shortcut to install, generate secrets, and start services
+# - Pass multiple profiles by repeating commands or use "*" for all profiles
+# - This justfile uses podman-compose instead of docker compose
+#
+# For more information, see local/README.md and local/PODMAN_COMPOSE_SETUP.md
+
+# ============================================
+# Configuration Variables
+# ============================================
+
+# Use PowerShell as the recipe shell on Windows hosts.
+set windows-shell := ["pwsh.exe", "-NoLogo", "-NoProfile", "-Command"]
+
+# Default MLLP port for sending HL7 messages
+default_port := "2575"
+
+# Secrets file path
+secrets_file := ".secrets"
+
+# Python interpreter
+python := "python3"
+
+# ============================================
+# Default Recipe (shows help)
+# ============================================
+
+# Show this help message with all available commands
+@default:
+    just --list --unsorted
+
+# ============================================
+# Profiles
+# ============================================
+
+# Lists the available profiles
+@profiles:
+    echo "Available profiles for use with other commands:"
+    echo ""
+    echo "  - phw-to-mpi     : Public Health Wales to MPI integration"
+    echo "  - paris-to-mpi   : PARIS to MPI integration"
+    echo "  - chemo-to-mpi   : Chemo to MPI integration"
+    echo "  - pims-to-mpi    : PIMS to MPI integration"
+    echo "  - mpi-to-topic   : MPI Outbound integration"
+    echo "  - replay         : Message Replay Job"
+    echo ""
+    echo "💡 Run 'just start <profile>' to start services"
+
+# ============================================
+# Setup & Installation
+# ============================================
+
+# Install Python dependencies (hl7 library for MLLP operations)
+@install:
+    echo "📦 Installing Python dependencies..."
+    echo ""
+    {{python}} -m pip install hl7
+    echo ""
+    echo "✅ Installation complete!"
+    echo "💡 Next steps:"
+    echo "   - Run 'just secrets' to generate required secrets"
+    echo "   - Run 'just start <profile>' to start services"
+
+# Generate the .secrets file with random values (required for containers)
+@secrets:
+    echo "🔒 Generating secrets file..."
+    echo ""
+    {{python}} generate_secrets.py > {{secrets_file}}
+    echo "✅ Secrets file created at: ./{{secrets_file}}"
+    echo "💡 This file contains randomly generated secrets for local development"
+    echo "💡 Next step: Run 'just start <profile>' to launch services"
+
+# ============================================
+# Podman Container Management
+# ============================================
+
+# Build (or rebuild) Podman containers for a specific profile
+@build profile:
+    echo "⚒️  Building Podman containers for profile: {{profile}}"
+    echo ""
+    echo "📋 Profile selected: {{profile}}"
+    echo "🔨 This may take a few minutes on first build..."
+    echo ""
+    podman-compose --profile {{profile}} build
+    echo ""
+    echo "✅ Build complete for profile: {{profile}}"
+    echo "💡 Next step: Run 'just start {{profile}}' to start the services"
+
+# Start Podman containers for a specific profile (auto-generates secrets if needed)
+@start profile: (_ensure-secrets)
+    echo "▶️  Starting Podman Compose services..."
+    echo ""
+    echo "📋 Profile: {{profile}}"
+    echo "🚀 Launching containers in detached mode..."
+    echo ""
+    podman-compose --profile {{profile}} up -d
+    echo ""
+    echo "✅ Services started successfully!"
+    echo "📍 Running containers for profile: {{profile}}"
+    echo ""
+    echo "💡 Next steps examples:"
+    echo "   - Check status: podman ps"
+    echo "   - View logs: just logs phw-hl7-server"
+    echo "   - Send test message: just send ./sample_messages/phw-to-mpi.sample.hl7"
+    echo "   - Stop services: just stop"
+
+# Stop all Podman containers across all profiles
+@stop:
+    echo "⏹️  Stopping all Podman Compose services..."
+    echo ""
+    podman-compose --profile "*" down
+    echo ""
+    echo "✅ All services stopped"
+    echo "💡 To restart: just start <profile>"
+
+# ============================================
+# Testing & Debugging
+# ============================================
+
+# Send a HL7 message to a specific port (default: 2575)
+@send file port=default_port:
+    echo "🧪 Sending HL7 message..."
+    echo ""
+    echo "📄 File: {{file}}"
+    echo "🔌 Port: {{port}}"
+    echo "🎯 Target: 127.0.0.1:{{port}}"
+    echo ""
+    # HL7 separates segments with CR only, which terminals render as an overwrite of the
+    # previous line. Translate CR to LF so the ACK is legible instead of appearing corrupt.
+    mllp_send --loose --file {{file}} --port {{port}} 127.0.0.1 | {{python}} -c "import sys; sys.stdout.write(sys.stdin.read().replace('\r','\n'))"
+    echo ""
+    echo "✅ Message sent!"
+    echo "💡 Check logs with: just logs <service-name>"
+    echo "💡 Profile specific ports:"
+    echo "   - 2575 (PHW)"
+    echo "   - 2577 (PARIS)"
+    echo "   - 2578 (Chemo)"
+    echo "   - 2579 (PIMS)"
+    echo "   - 2580 (MPI Outbound)"
+
+# Follow logs from Podman containers (optionally filter by service name)
+@logs *services:
+    echo "📖 Following container logs..."
+    echo ""
+    {{ if services == "" { "echo '📋 Showing logs for all services'" } else { "echo '📋 Filtering logs for: " + services + "'" } }}
+    echo "💡 Press Ctrl+C to stop following logs"
+    echo ""
+    podman-compose logs -f {{services}}
+
+# ============================================
+# Convenience Recipes
+# ============================================
+
+# Complete setup: install dependencies, generate secrets (if needed), and optionally start services
+@run *profile: (_ensure-secrets)
+    echo "🚀 Running complete setup..."
+    echo ""
+    just install
+    echo ""
+    {{ if profile != "" { "echo ''\njust start " + profile } else { "echo ''\necho \"✅ Setup complete! Ready to start services.\"\necho \"💡 Run 'just start <profile>' to launch a specific profile\"" } }}
+
+# Rebuild containers and restart services for a profile (useful after code changes)
+@restart profile:
+    echo "🔄 Rebuilding and restarting services..."
+    echo ""
+    just build {{profile}}
+    echo ""
+    just stop
+    echo ""
+    just start {{profile}}
+    echo ""
+    echo "✅ Services rebuilt and restarted!"
+
+# Clean up: stop all containers and remove the secrets file
+@clean:
+    echo "🧹 Cleaning up local environment..."
+    echo ""
+    just stop
+    echo ""
+    echo "🗑️  Removing secrets file..."
+    rm -f {{secrets_file}}
+    echo ""
+    echo "✅ Cleanup complete!"
+    echo "💡 Run 'just run' to set up the environment again"
+
+# ============================================
+# Internal Helper Recipes (prefixed with _)
+# ============================================
+
+# Internal: Ensure secrets file exists, generate if missing
+@_ensure-secrets:
+    {{ if path_exists(secrets_file) == "false" { "echo '🔒 Secrets file not found, generating...'\necho ''\njust secrets\necho ''" } else { "" } }}


### PR DESCRIPTION
HL7 v2.5 section 2.9.2.2 requires MSH-11 in an acknowledgement to be copied from the initiating message. The ACK builder hardcoded 'P', so a test message in DEV/TST was acknowledged as production. It now falls back to 'P' only when the inbound message omits the field, since MSH-11 is required in the ACK.

Add unit tests for HL7AckBuilder, which previously had none - the existing handler tests only exercised a mocked builder.

Also track local/justfile and local/docker-compose.yml, and make the justfile send recipe translate CR to LF. HL7 separates segments with CR only, which terminals render as an overwrite of the previous line, making a valid ACK look corrupt.