### PR TITLE
feat: add build/release pipeline for rest_server

### DIFF
--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -23,6 +23,7 @@ parameters:
       - hl7phwtransformer
       - hl7chemotransformer
       - hl7soapserver
+      - restserver
       - messagestoreservice
       - messagereplayjob
       - dashboard
@@ -147,6 +148,17 @@ stages:
             pythonVersion: '3.13'
             poolName: ${{ variables.POOL_NAME }}
 
+  - ${{ if containsValue(parameters.buildApps, 'restserver') }}:
+    - stage: CodeQuality_restserver
+      displayName: 'Code Quality — REST Server'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'rest_server'
+            appDisplayName: 'REST Server'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
+
   - ${{ if containsValue(parameters.buildApps, 'messagestoreservice') }}:
     - stage: CodeQuality_messagestoreservice
       displayName: 'Code Quality — Message Store Service'
@@ -207,6 +219,7 @@ stages:
       displayName: 'Build — HL7 REST Server'
       dependsOn: CodeQuality_hl7restserver
       condition: in(dependencies.CodeQuality_hl7restserver.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
         - template: templates/docker-build-push-template.yml
           parameters:
             jobName: 'BuildPushHL7RestServer'
@@ -366,6 +379,25 @@ stages:
             appName: 'hl7soapserver'
             dockerfilePath: 'hl7_soap_server/Dockerfile'
             buildContext: 'hl7_soap_server'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - ${{ if containsValue(parameters.buildApps, 'restserver') }}:
+    - stage: Build_restserver
+      displayName: 'Build — REST Server'
+      dependsOn: CodeQuality_restserver
+      condition: in(dependencies.CodeQuality_restserver.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushRestServer'
+            displayName: 'Build and Push REST Server'
+            appName: 'restserver'
+            dockerfilePath: 'rest_server/Dockerfile'
+            buildContext: 'rest_server'
             additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
             acrName: $(acrName)
             azureServiceConnection: $(azureServiceConnection)

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -21,6 +21,7 @@ pr:
       - transformers/hl7_chemo_transformer/**
       - transformers/hl7_pims_transformer/**
       - hl7_soap_server/**
+      - rest_server/**
       - buswatch/**
       - message_store_service/**
       - shared_libs/**
@@ -100,6 +101,7 @@ stages:
                 "transformers/hl7_chemo_transformer|Chemo HL7 Transformer||unittest"
                 "transformers/hl7_pims_transformer|PIMS HL7 Transformer||unittest"
                 "hl7_soap_server|HL7 SOAP Server||unittest"
+                "rest_server|REST Server||unittest"
                 "message_store_service|Message Store Service||unittest"
                 "buswatch|BusWatch||unittest"
                 "shared_libs/message_bus_lib|Message Bus Library|message_bus_lib|unittest"

--- a/pipeline-ado/release-apps.yml
+++ b/pipeline-ado/release-apps.yml
@@ -94,6 +94,9 @@ resources:
     - pipeline: 'HL7 SOAP Server - Build'
       source: 'HL7 SOAP Server - Build'
       trigger: none
+    - pipeline: 'REST Server - Build'
+      source: 'REST Server - Build'
+      trigger: none
     - pipeline: 'HL7 Mock Receiver - Build'
       source: 'HL7 Mock Receiver - Build'
       trigger: none
@@ -157,7 +160,7 @@ stages:
           appFunctionMidfix: ''
           buildPipeline: 'HL7 REST Server - Build'
 
-        # REST Server (generic configurable REST/HTTP ingestion server)
+        # REST Server (generic rest_server image; replaces hl7_soap_server/hl7_rest_server per docs/rest_merge.md)
         - name: 'REST Server'
           appImageName: 'restserver'
           appFunctionMidfix: ''


### PR DESCRIPTION
## What

Adds the missing build/release pipeline for the new consolidated `rest_server/` service, publishing it to ACR as **`restserver`**. This unblocks the Terraform LIMS cutover ([Integration-Hub-Terraform#190](https://github.com/DHCW-Digital-Health-and-Care-Wales/Integration-Hub-Terraform/pull/190)), which deploys that image name for the LIMS SOAP flow in DEV/TST.

`hl7_soap_server` and `hl7_rest_server` keep their own existing pipelines/images untouched, so rollback stays possible until they're formally retired (per `docs/rest_merge.md` §8/§9).

## Changes

- **`pipeline-ado/restserver-build.yml`** (new): per-path CI trigger on `rest_server/*` — code quality (`unittest`, matching `rest_server/check.sh`) + build/push to ACR as `restserver`. Mirrors `hl7soapserver-build.yml`/`hl7restserver-build.yml`.
- **`pipeline-ado/pr-validation.yml`**: added `rest_server/**` to the PR trigger paths and `rest_server` to the consolidated code-quality/unit-test app list.
- **`pipeline-ado/build-apps.yml`**: added `restserver` to the consolidated `buildApps` parameter default, with matching `CodeQuality_restserver`/`Build_restserver` stages.
- **`pipeline-ado/release-apps.yml`**: added a `REST Server` entry (`appImageName: restserver`) to `selectedApp` values and `appConfig`, and a `REST Server - Build` pipeline resource — so the image can be promoted through environments the same way `HL7 REST Server` already is.

## Bug fix found along the way

`build-apps.yml`'s `Build_hl7restserver` stage was missing its `jobs:` key, which made the **entire file invalid YAML** (confirmed with `yaml.safe_load` — every stage in the file, not just this one, would have failed to parse in Azure DevOps). Fixed as part of this change since it's the same file and blocks anything in it, including the new `restserver` stages, from ever running.

## Validation

- Validated all four YAML files with `yaml.safe_load` (no ADO-specific linter available locally) — all parse cleanly now.
- Not run through actual Azure DevOps (no access from here) — please trigger a run of `restserver-build.yml` (or `build-apps.yml` with `buildApps: [restserver]`) to confirm the image builds and pushes successfully before merging the Terraform PR.
