### PR TITLE
feat: add rest_server pipeline conf to pipeline-ado

### DIFF
--- a/pipeline-ado/build-apps.yml
+++ b/pipeline-ado/build-apps.yml
@@ -15,6 +15,7 @@ parameters:
     default:
       - hl7server
       - hl7restserver
+      - restserver
       - hl7sender
       - hl7mockreceiver
       - hl7subscriptionsender
@@ -55,6 +56,17 @@ stages:
           parameters:
             appName: 'hl7_rest_server'
             appDisplayName: 'HL7 REST Server'
+            pythonVersion: '3.13'
+            poolName: ${{ variables.POOL_NAME }}
+
+  - ${{ if containsValue(parameters.buildApps, 'restserver') }}:
+    - stage: CodeQuality_restserver
+      displayName: 'Code Quality — REST Server'
+      jobs:
+        - template: templates/code-quality-template.yml
+          parameters:
+            appName: 'rest_server'
+            appDisplayName: 'REST Server'
             pythonVersion: '3.13'
             poolName: ${{ variables.POOL_NAME }}
 
@@ -202,6 +214,25 @@ stages:
             appName: 'hl7restserver'
             dockerfilePath: 'hl7_rest_server/Dockerfile'
             buildContext: 'hl7_rest_server'
+            additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
+            acrName: $(acrName)
+            azureServiceConnection: $(azureServiceConnection)
+            POOL_NAME: ${{ variables.POOL_NAME }}
+            SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}
+
+  - ${{ if containsValue(parameters.buildApps, 'restserver') }}:
+    - stage: Build_restserver
+      displayName: 'Build — REST Server'
+      dependsOn: CodeQuality_restserver
+      condition: in(dependencies.CodeQuality_restserver.result, 'Succeeded', 'SucceededWithIssues')
+      jobs:
+        - template: templates/docker-build-push-template.yml
+          parameters:
+            jobName: 'BuildPushRestServer'
+            displayName: 'Build and Push REST Server'
+            appName: 'restserver'
+            dockerfilePath: 'rest_server/Dockerfile'
+            buildContext: 'rest_server'
             additionalContexts: 'shared_libs=shared_libs,ca-certs=ca-certs'
             acrName: $(acrName)
             azureServiceConnection: $(azureServiceConnection)

--- a/pipeline-ado/pr-validation.yml
+++ b/pipeline-ado/pr-validation.yml
@@ -13,6 +13,7 @@ pr:
     include:
       - hl7_server/**
       - hl7_rest_server/**
+      - rest_server/**
       - hl7_phw_transformer/**
       - hl7_sender/**
       - hl7_subscription_sender/**
@@ -91,6 +92,7 @@ stages:
               APPS=(
                 "hl7_server|HL7 Server||unittest"
                 "hl7_rest_server|HL7 REST Server||unittest"
+                "rest_server|REST Server||unittest"
                 "hl7_phw_transformer|PHW HL7 Transformer||unittest"
                 "hl7_sender|HL7 Sender||unittest"
                 "hl7_subscription_sender|HL7 Subscription Sender||unittest"

--- a/pipeline-ado/release-apps.yml
+++ b/pipeline-ado/release-apps.yml
@@ -17,6 +17,7 @@ parameters:
       - WDS HL7Server
       - Mosaiq HL7Server
       - HL7 REST Server
+      - REST Server
       - HL7 Phw Transformer
       - HL7 Chemo Transformer
       - HL7 Pims Transformer
@@ -71,6 +72,9 @@ resources:
       trigger: none
     - pipeline: 'HL7 REST Server - Build'
       source: 'HL7 REST Server - Build'
+      trigger: none
+    - pipeline: 'REST Server - Build'
+      source: 'REST Server - Build'
       trigger: none
     - pipeline: 'HL7 Phw Transformer - Build'
       source: 'HL7 Phw Transformer - Build'
@@ -152,6 +156,12 @@ stages:
           appImageName: 'hl7restserver'
           appFunctionMidfix: ''
           buildPipeline: 'HL7 REST Server - Build'
+
+        # REST Server (generic configurable REST/HTTP ingestion server)
+        - name: 'REST Server'
+          appImageName: 'restserver'
+          appFunctionMidfix: ''
+          buildPipeline: 'REST Server - Build'
 
         # HL7 Transformer Variants
         - name: 'HL7 Phw Transformer'

--- a/pipeline-ado/restserver-build.yml
+++ b/pipeline-ado/restserver-build.yml
@@ -6,10 +6,10 @@ trigger:
       - release-*
   paths:
     include:
-      - rest_server/*
-      - shared_libs/*
-      - pipeline-ado/templates/*
-      - ca-certs/*
+      - rest_server/**
+      - shared_libs/**
+      - pipeline-ado/templates/**
+      - ca-certs/**
 
 pr: none
 

--- a/pipeline-ado/restserver-build.yml
+++ b/pipeline-ado/restserver-build.yml
@@ -1,0 +1,53 @@
+# REST Server Build Pipeline
+trigger:
+  branches:
+    include:
+      - main
+      - release-*
+  paths:
+    include:
+      - rest_server/*
+      - shared_libs/*
+      - pipeline-ado/templates/*
+      - ca-certs/*
+
+pr: none
+
+parameters:
+  - name: SEMANTIC_VERSION
+    displayName: 'Semantic Version'
+    type: string
+    default: 'v0.1.0'
+
+variables:
+  acrName: 'uksdhcwihsharedcr'
+  azureServiceConnection: 'Azure - NHSWales-DHCW-IntegrationHub-Subscription'
+  POOL_NAME: 'UKS-DHCW-IH-DEV-ADOManagedPool'
+
+stages:
+  - stage: CodeQuality
+    displayName: 'Code Quality & Tests'
+    jobs:
+      - template: templates/code-quality-template.yml
+        parameters:
+          appName: 'rest_server'
+          appDisplayName: 'REST Server'
+          pythonVersion: '3.13'
+          poolName: ${{ variables.POOL_NAME }}
+
+  - stage: BuildAndPushRestServer
+    displayName: 'Build and Push REST Server'
+    dependsOn: CodeQuality
+    jobs:
+      - template: templates/docker-build-push-template.yml
+        parameters:
+          jobName: 'BuildPushRestServer'
+          displayName: 'Build and Push REST Server'
+          appName: 'restserver'
+          dockerfilePath: 'rest_server/Dockerfile'
+          buildContext: 'rest_server'
+          additionalContexts: "shared_libs=shared_libs,ca-certs=ca-certs"
+          acrName: $(acrName)
+          azureServiceConnection: $(azureServiceConnection)
+          POOL_NAME: ${{ variables.POOL_NAME }}
+          SEMANTIC_VERSION: ${{ parameters.SEMANTIC_VERSION }}


### PR DESCRIPTION
## Summary

Adds Azure DevOps pipeline configuration for the new `rest_server` service, published as the `restserver` ACR image (matching `image_name_rest_server` in Integration-Hub-Terraform), required to support the LIMS SOAP flow migration (see `Integration-Hub-Terraform/REST_SERVER_TERRAFORM_CHANGE_REQUIREMENTS.md`).

## Changes

- **New `pipeline-ado/restserver-build.yml`**: standalone build pipeline for `rest_server/`, triggered on changes to `rest_server/*`, `shared_libs/*`, pipeline templates, and `ca-certs/*`.
- **`pipeline-ado/build-apps.yml`**: registers `restserver` in the consolidated build pipeline (`buildApps` default list, `CodeQuality_restserver` and `Build_restserver` stages).
- **`pipeline-ado/pr-validation.yml`**: adds `rest_server/**` to PR trigger paths and `rest_server` to the code quality/unit test loop.
- **`pipeline-ado/release-apps.yml`**: adds a new `REST Server` release target (pipeline resource + `appConfig` entry, image `restserver`) alongside the existing `HL7 REST Server` entry. Kept as a separate release target rather than replacing the existing `LIMS HL7 SOAP Server` entry, consistent with the phased-migration approach.

## Notes

- The existing `hl7soapserver` image/release path is untouched — this only adds new pipeline plumbing for `rest_server`.
