### PR TITLE
fix: correct sender Dockerfile COPY paths to be build-context relative

### DIFF
--- a/senders/hl7_sender/Dockerfile
+++ b/senders/hl7_sender/Dockerfile
@@ -32,7 +32,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv --native-tls sync --locked --no-install-project --no-dev
 
 # Copy the rest of the project source code and install it
-COPY senders/hl7_sender/ /app/senders/hl7_sender
+COPY hl7_sender/ /app/senders/hl7_sender/hl7_sender
 RUN uv --native-tls sync --locked --no-dev
 
 # Place executables in the environment at the front of the path

--- a/senders/hl7_subscription_sender/Dockerfile
+++ b/senders/hl7_subscription_sender/Dockerfile
@@ -32,7 +32,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv --native-tls sync --locked --no-install-project --no-dev
 
 # Copy the rest of the project source code and install it
-COPY senders/hl7_subscription_sender/ /app/senders/hl7_subscription_sender
+COPY hl7_subscription_sender/ /app/senders/hl7_subscription_sender/hl7_subscription_sender
 RUN uv --native-tls sync --locked --no-dev
 
 # Place executables in the environment at the front of the path

--- a/senders/soap_sender/Dockerfile
+++ b/senders/soap_sender/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=shared_libs . /app/shared_libs
 COPY pyproject.toml uv.lock ./
 RUN uv --native-tls sync --locked --no-install-project --no-dev
 
-COPY senders/soap_sender/ /app/senders/soap_sender/
+COPY soap_sender/ /app/senders/soap_sender/soap_sender/
 RUN uv --native-tls sync --locked --no-dev
 
 ENV PATH="/app/senders/soap_sender/.venv/bin:$PATH"

--- a/senders/soap_subscription_sender/Dockerfile
+++ b/senders/soap_subscription_sender/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/senders/soap_subscription_sender
 COPY pyproject.toml uv.lock ./
 RUN uv --native-tls sync --locked --no-install-project --no-dev
 
-COPY senders/soap_subscription_sender/ /app/senders/soap_subscription_sender/
+COPY soap_subscription_sender/ /app/senders/soap_subscription_sender/soap_subscription_sender/
 RUN uv --native-tls sync --locked --no-dev
 
 ENV PATH="/app/senders/soap_subscription_sender/.venv/bin:$PATH"

--- a/senders/soap_subscription_sender/Dockerfile
+++ b/senders/soap_subscription_sender/Dockerfile
@@ -8,6 +8,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app/senders/soap_subscription_sender
 
+# Copy shared libraries
+COPY --from=shared_libs . /app/shared_libs
+
 COPY pyproject.toml uv.lock ./
 RUN uv --native-tls sync --locked --no-install-project --no-dev
 


### PR DESCRIPTION
The Docker build context for each sender is its own project directory (e.g. senders/hl7_sender), matching the pattern used by the transformers. However, the source-copy step still used repo-root relative paths (e.g. 'COPY senders/hl7_sender/ /app/senders/hl7_sender'), which fails in ADO with 'failed to calculate checksum ... not found' since that path doesn't exist inside the build context.

Fixed to copy relative to the build context and nest into the inner package folder, mirroring the working transformers Dockerfiles (e.g. 'COPY hl7_sender/ /app/senders/hl7_sender/hl7_sender').

Affects: hl7_sender, hl7_subscription_sender, soap_sender, soap_subscription_sender.