### PR TITLE
fix: remove duplicate 'PMS HL7 Subscription Sender' entry in release-…

### DIFF
--- a/pipeline-ado/release-apps.yml
+++ b/pipeline-ado/release-apps.yml
@@ -230,11 +230,6 @@ stages:
           appFunctionMidfix: 'pms'
           buildPipeline: 'HL7 SOAP Server - Build'
 
-        - name: 'PMS HL7 Subscription Sender'
-          appImageName: 'hl7subsndr'
-          appFunctionMidfix: 'pms'
-          buildPipeline: 'HL7 Subscription Sender - Build'
-
         # Mock Receiver
         - name: 'HL7 Mock Receiver'
           appImageName: 'hl7mockreceiver'


### PR DESCRIPTION
…apps.yml

The appConfig list had two identical entries for 'PMS HL7 Subscription Sender'
Broke the release pipeline (duplicate parameter/stage name).
Removed the duplicate, keeping the entry grouped with the other subscription senders under the 'HL7 Sender Variants' section.