### PR TITLE
Fixed missing save button on U7 configuration

### DIFF
--- a/dev_tools/ultra7/ultra7/ui/endpoint_dialog.py
+++ b/dev_tools/ultra7/ultra7/ui/endpoint_dialog.py
@@ -110,6 +110,7 @@ class EndpointDialog(tk.Toplevel):
             headers[name.strip()] = value.strip()
         return headers
 
+    def _save(self) -> None:
         kind = self._kind.get()
         port_text = self._port.get().strip()
         port: int | None = None


### PR DESCRIPTION
The save button has been restored in the Ultra7 configuration panel.