### PR TITLE
fix: batch code coverage pipeline trigger and add paths filter

### DIFF
--- a/pipeline-ado/code-coverage.yml
+++ b/pipeline-ado/code-coverage.yml
@@ -4,9 +4,18 @@
 # and a persisted trend history, for use by the "Code Coverage" ADO Dashboard widget.
 # See docs/code_coverage.md for the full plan.
 trigger:
+  # batch collapses several rapid merges to main into a single queued run instead of
+  # one run per push (which is what caused the burst of ~60 runs when this pipeline was added).
+  batch: true
   branches:
     include:
       - main
+  # Skip runs for changes that can't affect coverage (docs, other pipeline definitions).
+  paths:
+    exclude:
+      - docs/**
+      - '**/*.md'
+      - pipeline-ado/**
 pr: none
 
 variables:


### PR DESCRIPTION
## Summary

The `code-coverage.yml` pipeline was the only CI-triggered pipeline in `pipeline-ado/` with **no `batch` setting and no `paths` filter**. As a result, every push to `main` queued its own run with no collapsing, causing a burst of ~60 queued pipeline runs when the pipeline was first added.

## Changes

- **`batch: true`** — collapses concurrent/rapid merges to `main` into a single queued run instead of one run per push. This is the primary fix for the run pile-up.
- **`paths: exclude`** — skips runs when a push only touches `docs/**`, markdown, or `pipeline-ado/**`, none of which affect measured coverage. This brings the pipeline in line with the `paths`-scoped triggers used by every other build pipeline in the repo.

## Notes

- Azure DevOps does not retroactively run a newly added pipeline against historical commits, so the ~60 runs were genuinely one unbatched run per recent `main` push — not a self-trigger loop (this pipeline only publishes artifacts and never pushes back to git).
- Trade-off: with `pipeline-ado/**` excluded, edits to `code-coverage.yml` itself won't auto-trigger a coverage run and would need to be run manually.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>