### PR TITLE
fix: allow partially succeeded/failed builds when downloading coverage history

### DIFF
--- a/pipeline-ado/code-coverage.yml
+++ b/pipeline-ado/code-coverage.yml
@@ -230,6 +230,14 @@ stages:
               pipeline: '$(System.DefinitionId)'
               runVersion: 'latestFromBranch'
               runBranch: 'refs/heads/main'
+              # This step's own continueOnError means a run with no prior history (e.g. the
+              # first run, or one where this download failed) completes as "partially succeeded"
+              # rather than "succeeded". Without these two flags, latestFromBranch only considers
+              # fully "succeeded" builds, so once one run is marked partially succeeded, every
+              # later run fails to find it and is marked partially succeeded too — a self
+              # -perpetuating loop where history is never found again.
+              allowPartiallySucceededBuilds: true
+              allowFailedBuilds: true
               artifact: 'coverage-history'
               targetPath: '$(Pipeline.Workspace)/coverage-history'
 


### PR DESCRIPTION
## Problem

The `code-coverage.yml` pipeline's `Download Previous Coverage History (if any)` step could never find a previous run's history, always logging:

```
##[error]No builds currently exist in the pipeline definition supplied.
```

## Root Cause

That step has `continueOnError: true`. When it fails (e.g. there's no history yet on the first run), the failed-but-continued task marks the overall build result as **PartiallySucceeded** instead of **Succeeded**.

`DownloadPipelineArtifact@2` with `runVersion: latestFromBranch` only considers fully **succeeded** builds by default (`allowPartiallySucceededBuilds` / `allowFailedBuilds` both default to `false`). So the very next run can't find that prior PartiallySucceeded build either, fails the same step again, and the build is marked PartiallySucceeded again — a self-perpetuating loop where history is never found.

## Fix

Set `allowPartiallySucceededBuilds: true` and `allowFailedBuilds: true` on the `Download Previous Coverage History` task so it can find and download history from a previous run regardless of that run's overall result.