### PR TITLE
Fix Windows AttributeError on socket.MSG_DONTWAIT in is_socket_closed

### DIFF
--- a/senders/hl7_sender/hl7_sender/hl7_sender_client.py
+++ b/senders/hl7_sender/hl7_sender/hl7_sender_client.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import select
 import socket
 from typing import Any, Optional, Type
@@ -9,7 +8,6 @@ from hl7apy.consts import MLLP_ENCODING_CHARS
 
 logger = logging.getLogger(__name__)
 ENCODING_CHARS = MLLP_ENCODING_CHARS.SB + MLLP_ENCODING_CHARS.EB + MLLP_ENCODING_CHARS.CR
-WINDOWS_OS = "nt"
 
 
 def is_socket_closed(sock: socket.socket) -> bool:
@@ -17,8 +15,10 @@ def is_socket_closed(sock: socket.socket) -> bool:
         # Check if the socket is readable (may indicate data or EOF)
         readable, _, _ = select.select([sock], [], [], 0)
         if readable:
-            # this will try to read bytes without blocking and also without removing them from buffer (peek only)
-            flags = socket.MSG_PEEK if os.name == WINDOWS_OS else socket.MSG_DONTWAIT | socket.MSG_PEEK
+            # this will try to read bytes without blocking and also without removing them from buffer (peek only).
+            # MSG_DONTWAIT is POSIX-only and absent from the socket module on Windows, so it is looked up
+            # dynamically and simply omitted (MSG_PEEK alone) on platforms that don't define it.
+            flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
             data = sock.recv(16, flags)
             return len(data) == 0
         return False  # no data, but socket is fine

--- a/senders/hl7_sender/tests/test_hl7_sender_client.py
+++ b/senders/hl7_sender/tests/test_hl7_sender_client.py
@@ -1,12 +1,10 @@
-import os
 import socket
 import unittest
 from typing import Any, Callable, Dict
 from unittest.mock import Mock, patch
 
+from hl7_sender import hl7_sender_client as client_module
 from hl7_sender.hl7_sender_client import HL7SenderClient, is_socket_closed
-
-WINDOWS_OS = "nt"
 
 
 class TestIsSocketClosed(unittest.TestCase):
@@ -41,10 +39,8 @@ class TestIsSocketClosed(unittest.TestCase):
         # Assert
         self.assertFalse(result)
         mock_select.assert_called_once_with([mock_socket], [], [], 0)
-        if os.name == WINDOWS_OS:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
-        else:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_DONTWAIT | socket.MSG_PEEK)  # type: ignore
+        expected_flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
+        mock_socket.recv.assert_called_once_with(16, expected_flags)
 
     @patch('hl7_sender.hl7_sender_client.select.select')
     def test_socket_readable_with_empty_data_socket_closed(self, mock_select: Mock) -> None:
@@ -61,10 +57,41 @@ class TestIsSocketClosed(unittest.TestCase):
         # Assert
         self.assertTrue(result)
         mock_select.assert_called_once_with([mock_socket], [], [], 0)
-        if os.name == WINDOWS_OS:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
-        else:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_DONTWAIT | socket.MSG_PEEK)  # type: ignore
+        expected_flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
+        mock_socket.recv.assert_called_once_with(16, expected_flags)
+
+    @patch('hl7_sender.hl7_sender_client.select.select')
+    def test_socket_readable_uses_msg_peek_only_when_dontwait_unavailable(self, mock_select: Mock) -> None:
+        """Simulates platforms (e.g. native Windows) where socket.MSG_DONTWAIT isn't defined at all."""
+        mock_socket = Mock(spec=socket.socket)
+        mock_select.return_value = ([mock_socket], [], [])
+        mock_socket.recv.return_value = b"data"
+
+        had_attr = hasattr(client_module.socket, "MSG_DONTWAIT")
+        original = getattr(client_module.socket, "MSG_DONTWAIT", None)
+        if had_attr:
+            delattr(client_module.socket, "MSG_DONTWAIT")
+        try:
+            result = is_socket_closed(mock_socket)
+        finally:
+            if had_attr:
+                client_module.socket.MSG_DONTWAIT = original
+
+        self.assertFalse(result)
+        mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
+
+    @patch('hl7_sender.hl7_sender_client.select.select')
+    def test_socket_readable_includes_msg_dontwait_when_available(self, mock_select: Mock) -> None:
+        """Simulates POSIX platforms where socket.MSG_DONTWAIT is defined."""
+        mock_socket = Mock(spec=socket.socket)
+        mock_select.return_value = ([mock_socket], [], [])
+        mock_socket.recv.return_value = b"data"
+
+        with patch.object(client_module.socket, "MSG_DONTWAIT", 0x40, create=True):
+            result = is_socket_closed(mock_socket)
+
+        self.assertFalse(result)
+        mock_socket.recv.assert_called_once_with(16, 0x40 | socket.MSG_PEEK)
 
     @patch('hl7_sender.hl7_sender_client.select.select')
     def test_socket_recv_raises_blocking_io_error(self, mock_select: Mock) -> None:

--- a/senders/hl7_subscription_sender/hl7_subscription_sender/hl7_subscription_sender_client.py
+++ b/senders/hl7_subscription_sender/hl7_subscription_sender/hl7_subscription_sender_client.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import select
 import socket
 from typing import Any, Optional, Type
@@ -9,7 +8,6 @@ from hl7apy.consts import MLLP_ENCODING_CHARS
 
 logger = logging.getLogger(__name__)
 ENCODING_CHARS = MLLP_ENCODING_CHARS.SB + MLLP_ENCODING_CHARS.EB + MLLP_ENCODING_CHARS.CR
-WINDOWS_OS = "nt"
 
 
 def is_socket_closed(sock: socket.socket) -> bool:
@@ -17,8 +15,10 @@ def is_socket_closed(sock: socket.socket) -> bool:
         # Check if the socket is readable (may indicate data or EOF)
         readable, _, _ = select.select([sock], [], [], 0)
         if readable:
-            # this will try to read bytes without blocking and also without removing them from buffer (peek only)
-            flags = socket.MSG_PEEK if os.name == WINDOWS_OS else socket.MSG_DONTWAIT | socket.MSG_PEEK
+            # this will try to read bytes without blocking and also without removing them from buffer (peek only).
+            # MSG_DONTWAIT is POSIX-only and absent from the socket module on Windows, so it is looked up
+            # dynamically and simply omitted (MSG_PEEK alone) on platforms that don't define it.
+            flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
             data = sock.recv(16, flags)
             return len(data) == 0
         return False  # no data, but socket is fine

--- a/senders/hl7_subscription_sender/tests/test_hl7_subscription_sender_client.py
+++ b/senders/hl7_subscription_sender/tests/test_hl7_subscription_sender_client.py
@@ -1,12 +1,10 @@
-import os
 import socket
 import unittest
 from typing import Any, Callable, Dict
 from unittest.mock import Mock, patch
 
+from hl7_subscription_sender import hl7_subscription_sender_client as client_module
 from hl7_subscription_sender.hl7_subscription_sender_client import HL7SubscriptionSenderClient, is_socket_closed
-
-WINDOWS_OS = "nt"
 
 
 class TestIsSocketClosed(unittest.TestCase):
@@ -40,10 +38,8 @@ class TestIsSocketClosed(unittest.TestCase):
 
         self.assertFalse(result)
         mock_select.assert_called_once_with([mock_socket], [], [], 0)
-        if os.name == WINDOWS_OS:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
-        else:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_DONTWAIT | socket.MSG_PEEK)  # type: ignore
+        expected_flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
+        mock_socket.recv.assert_called_once_with(16, expected_flags)
 
     @patch("hl7_subscription_sender.hl7_subscription_sender_client.select.select")
     def test_socket_readable_with_empty_data_socket_closed(self, mock_select: Mock) -> None:
@@ -60,10 +56,8 @@ class TestIsSocketClosed(unittest.TestCase):
 
         self.assertTrue(result)
         mock_select.assert_called_once_with([mock_socket], [], [], 0)
-        if os.name == WINDOWS_OS:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
-        else:
-            mock_socket.recv.assert_called_once_with(16, socket.MSG_DONTWAIT | socket.MSG_PEEK)  # type: ignore
+        expected_flags = socket.MSG_PEEK | getattr(socket, "MSG_DONTWAIT", 0)
+        mock_socket.recv.assert_called_once_with(16, expected_flags)
 
     @patch("hl7_subscription_sender.hl7_subscription_sender_client.select.select")
     def test_socket_recv_raises_blocking_io_error(self, mock_select: Mock) -> None:
@@ -124,33 +118,38 @@ class TestIsSocketClosed(unittest.TestCase):
 
         mock_select.assert_called_once_with([mock_socket], [], [], 0)
 
-    @patch("hl7_subscription_sender.hl7_subscription_sender_client.os.name", "nt")
     @patch("hl7_subscription_sender.hl7_subscription_sender_client.select.select")
-    def test_socket_readable_uses_msg_peek_only_on_windows(self, mock_select: Mock) -> None:
-        """Test that Windows OS uses MSG_PEEK flag only (without MSG_DONTWAIT)."""
+    def test_socket_readable_uses_msg_peek_only_when_dontwait_unavailable(self, mock_select: Mock) -> None:
+        """Simulates platforms (e.g. native Windows) where socket.MSG_DONTWAIT isn't defined at all."""
         mock_socket = Mock(spec=socket.socket)
         mock_select.return_value = ([mock_socket], [], [])
         mock_socket.recv.return_value = b"data"
 
-        result = is_socket_closed(mock_socket)
+        had_attr = hasattr(client_module.socket, "MSG_DONTWAIT")
+        original = getattr(client_module.socket, "MSG_DONTWAIT", None)
+        if had_attr:
+            delattr(client_module.socket, "MSG_DONTWAIT")
+        try:
+            result = is_socket_closed(mock_socket)
+        finally:
+            if had_attr:
+                client_module.socket.MSG_DONTWAIT = original
 
         self.assertFalse(result)
-        # Verify Windows uses only MSG_PEEK (no MSG_DONTWAIT)
         mock_socket.recv.assert_called_once_with(16, socket.MSG_PEEK)
 
-    @patch("hl7_subscription_sender.hl7_subscription_sender_client.os.name", "posix")
     @patch("hl7_subscription_sender.hl7_subscription_sender_client.select.select")
-    def test_socket_readable_uses_msg_peek_and_dontwait_on_non_windows(self, mock_select: Mock) -> None:
-        """Test that non-Windows OS uses MSG_PEEK | MSG_DONTWAIT flags."""
+    def test_socket_readable_includes_msg_dontwait_when_available(self, mock_select: Mock) -> None:
+        """Simulates POSIX platforms where socket.MSG_DONTWAIT is defined."""
         mock_socket = Mock(spec=socket.socket)
         mock_select.return_value = ([mock_socket], [], [])
         mock_socket.recv.return_value = b"data"
 
-        result = is_socket_closed(mock_socket)
+        with patch.object(client_module.socket, "MSG_DONTWAIT", 0x40, create=True):
+            result = is_socket_closed(mock_socket)
 
         self.assertFalse(result)
-        # Verify non-Windows uses MSG_PEEK | MSG_DONTWAIT
-        mock_socket.recv.assert_called_once_with(16, socket.MSG_DONTWAIT | socket.MSG_PEEK)  # type: ignore
+        mock_socket.recv.assert_called_once_with(16, 0x40 | socket.MSG_PEEK)
 
 
 class TestHL7SenderClient(unittest.TestCase):


### PR DESCRIPTION
dev note
this may not need to go in other PR has a similar fix - https://github.com/DHCW-Digital-Health-and-Care-Wales/Integration-Hub-Beta/pull/355
See what you think.

socket.MSG_DONTWAIT is a POSIX-only constant and is genuinely absent from the socket module on native Windows. is_socket_closed() now looks it up dynamically via getattr(socket, 'MSG_DONTWAIT', 0) inline on each call, instead of branching on os.name, so it never raises and still applies the flag wherever the platform supports it.

Updated both hl7_sender and hl7_subscription_sender client/test files to drop the os.name/WINDOWS_OS branching and replace the previously os.name-forced tests with deterministic tests that patch the presence /absence of socket.MSG_DONTWAIT directly.