### PR TITLE
Add correlation-attribute tests and log endpoint parity for NACK handling

### DIFF
--- a/senders/hl7_sender/hl7_sender/ack_processor.py
+++ b/senders/hl7_sender/hl7_sender/ack_processor.py
@@ -1,32 +1,71 @@
 import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
 
 from hl7apy.core import Message
 from hl7apy.parser import parse_message
 
 logger = logging.getLogger(__name__)
 
+# HL7 MSA-1 acknowledgment codes that are treated as recoverable negative acknowledgements -
+# the message will be retried according to the configured retry policy.
+RECOVERABLE_ACK_CODES = frozenset({"AE"})
 
-def get_ack_result(response: str) -> bool:
+# HL7 MSA-1 acknowledgment codes that are treated as non-recoverable negative acknowledgements -
+# the message must not be retried automatically and is routed to the dead-letter/escalation path.
+NON_RECOVERABLE_ACK_CODES = frozenset({"AR"})
+
+
+class AckOutcome(Enum):
+    SUCCESS = "SUCCESS"  # MSA-1 = AA/CA
+    AE = "AE"  # MSA-1 = AE - application error, recoverable, retryable
+    AR = "AR"  # MSA-1 = AR - application reject, non-recoverable, dead-lettered
+    INVALID = "INVALID"  # Malformed response or missing MSA segment
+
+
+@dataclass
+class AckResult:
+    outcome: AckOutcome
+    ack_code: Optional[str]
+    control_id: Optional[str]
+    raw_response: str
+
+    @property
+    def is_success(self) -> bool:
+        return self.outcome == AckOutcome.SUCCESS
+
+
+def get_ack_result(response: str) -> AckResult:
     try:
         response_msg: Message = parse_message(response)
 
         if not response_msg.MSA:
             error = "Received a non-ACK message"
             logger.error(error)
-            return False
+            return AckResult(AckOutcome.INVALID, None, None, response)
 
         ack_code = response_msg.MSA.acknowledgment_code.value
         logger.debug(f"ACK Code: {ack_code}")
 
-        if ack_code in ['AA', 'CA']:
-            logger.info("Valid ACK received.")
-            return True
-        else:
+        control_id: Optional[str] = None
+        try:
             control_id = response_msg.MSH.message_control_id.value
-            error = f"Negative ACK received: {ack_code} for: {control_id}"
-            logger.error(error)
-            return False
+        except Exception:
+            logger.debug("Unable to extract control ID from ACK message")
+
+        if ack_code in ("AA", "CA"):
+            logger.info("Valid ACK received.")
+            return AckResult(AckOutcome.SUCCESS, ack_code, control_id, response)
+
+        logger.error(f"Negative ACK received: {ack_code} for: {control_id}")
+
+        if ack_code in NON_RECOVERABLE_ACK_CODES:
+            return AckResult(AckOutcome.AR, ack_code, control_id, response)
+
+        # AE, and any other unrecognised negative ack code, is treated as recoverable.
+        return AckResult(AckOutcome.AE, ack_code, control_id, response)
 
     except Exception:
         logger.exception("Exception while parsing ACK message")
-        return False
+        return AckResult(AckOutcome.INVALID, None, None, response)

--- a/senders/hl7_sender/hl7_sender/application.py
+++ b/senders/hl7_sender/hl7_sender/application.py
@@ -1,6 +1,7 @@
 import configparser
 import logging
 import os
+from typing import Callable
 
 from azure.servicebus import ServiceBusMessage
 from event_logger_lib import EventLogger
@@ -41,6 +42,18 @@ config.read(config_path)
 
 MAX_BATCH_SIZE = config.getint("DEFAULT", "max_batch_size")
 LOCK_RENEWAL_BUFFER_SECONDS = 30
+
+
+def _send_metric_best_effort(send_fn: Callable[[], None], metric_name: str) -> None:
+    """Send a telemetry metric without letting a telemetry failure affect the delivery decision.
+
+    Metrics are observability-only: if emitting one fails (e.g. Azure Monitor exporter issue),
+    that must not change whether a message is treated as retryable, dead-lettered, or successful.
+    """
+    try:
+        send_fn()
+    except Exception:
+        logger.exception(f"Failed to send metric '{metric_name}' - continuing without blocking message processing")
 
 
 def _calculate_batch_size(throttler: MessageThrottler) -> int:
@@ -192,7 +205,10 @@ def _process_message(
                 "Non-recoverable NACK (AR) - message routed to dead-letter/escalation path",
                 correlation_id=correlation_id_opt,
             )
-            metric_sender.send_message_nack_ar_metric(attributes=nack_attributes)
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_nack_ar_metric(attributes=nack_attributes),
+                "messages_nack_ar",
+            )
 
             raise DeadLetterMessage(
                 reason="AR",
@@ -217,8 +233,14 @@ def _process_message(
             correlation_id=correlation_id_opt,
         )
         if ack_result.outcome == AckOutcome.AE:
-            metric_sender.send_message_nack_ae_metric(attributes=nack_attributes)
-            metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes)
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_nack_ae_metric(attributes=nack_attributes),
+                "messages_nack_ae",
+            )
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes),
+                "messages_retry_attempt",
+            )
 
         return False
 

--- a/senders/hl7_sender/hl7_sender/application.py
+++ b/senders/hl7_sender/hl7_sender/application.py
@@ -8,6 +8,7 @@ from health_check_lib.health_check_server import TCPHealthCheckServer
 from hl7_validation import convert_er7_to_xml
 from hl7apy.parser import parse_message
 from message_bus_lib.connection_config import ConnectionConfig
+from message_bus_lib.dead_letter import DeadLetterMessage
 from message_bus_lib.message_receiver_client import MessageReceiverClient
 from message_bus_lib.message_store_client import MessageStoreClient
 from message_bus_lib.metadata_utils import (
@@ -23,7 +24,7 @@ from metric_sender_lib.metric_sender import MetricSender
 from otel_lib import configure_otel
 from processor_manager_lib import ProcessorManager
 
-from hl7_sender.ack_processor import get_ack_result
+from hl7_sender.ack_processor import AckOutcome, get_ack_result
 from hl7_sender.app_config import AppConfig
 from hl7_sender.hl7_sender_client import HL7SenderClient
 from hl7_sender.message_throttler import MessageThrottler
@@ -158,19 +159,72 @@ def _process_message(
         throttler.wait_if_needed()
         ack_response = hl7_sender_client.send_message(message_body)
 
-        ack_success = get_ack_result(ack_response)
+        ack_result = get_ack_result(ack_response)
 
-        if ack_success:
+        nack_attributes = {
+            "ack_code": ack_result.ack_code or "UNKNOWN",
+            "correlation_id": meta["correlation_id"],
+            "message_id": message_id,
+            "endpoint": f"{hl7_sender_client.receiver_mllp_hostname}:{hl7_sender_client.receiver_mllp_port}",
+        }
+
+        if ack_result.outcome == AckOutcome.SUCCESS:
             metric_sender.send_message_sent_metric()
 
-        event_logger.log_message_processed(
+            event_logger.log_message_processed(
+                message_body,
+                f"Message sent successfully, received ACK: {ack_response}",
+                correlation_id=correlation_id_opt,
+            )
+            logger.info(f"Sent message: {message_id}")
+
+            return True
+
+        if ack_result.outcome == AckOutcome.AR:
+            error_msg = (
+                f"Application Reject ACK (AR) received for message {message_id} "
+                f"from {nack_attributes['endpoint']}, full ACK: {ack_response}"
+            )
+            logger.error(error_msg)
+            event_logger.log_message_failed(
+                message_body,
+                error_msg,
+                "Non-recoverable NACK (AR) - message routed to dead-letter/escalation path",
+                correlation_id=correlation_id_opt,
+            )
+            metric_sender.send_message_nack_ar_metric(attributes=nack_attributes)
+
+            raise DeadLetterMessage(
+                reason="AR",
+                description=(
+                    f"Application Reject ACK (AR) for message_id={message_id}, "
+                    f"correlation_id={meta['correlation_id']}"
+                ),
+            )
+
+        # AckOutcome.AE or AckOutcome.INVALID - recoverable failure, will be abandoned and retried
+        # according to the queue's configured retry policy.
+        reason_code = ack_result.outcome.value
+        error_msg = (
+            f"Negative ACK ({reason_code}) received for message {message_id} "
+            f"from {nack_attributes['endpoint']}, full ACK: {ack_response}"
+        )
+        logger.error(error_msg)
+        event_logger.log_message_failed(
             message_body,
-            f"Message sent successfully, received ACK: {ack_response}",
+            error_msg,
+            f"Recoverable NACK ({reason_code}) - message will be retried",
             correlation_id=correlation_id_opt,
         )
-        logger.info(f"Sent message: {message_id}")
+        if ack_result.outcome == AckOutcome.AE:
+            metric_sender.send_message_nack_ae_metric(attributes=nack_attributes)
+            metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes)
 
-        return ack_success
+        return False
+
+    except DeadLetterMessage:
+        # Propagate so MessageReceiverClient dead-letters the message instead of retrying it.
+        raise
 
     except (TimeoutError, ConnectionError) as e:
         error_msg = f"Failed to send message {message_id}: {e}"

--- a/senders/hl7_sender/tests/test_ack_processor.py
+++ b/senders/hl7_sender/tests/test_ack_processor.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from hl7_sender.ack_processor import get_ack_result
+from hl7_sender.ack_processor import AckOutcome, get_ack_result
 
 
 def generate_ack_msg(ack_code: str) -> str:
@@ -15,29 +15,46 @@ class TestGetAckResult(unittest.TestCase):
     def test_valid_ack_aa(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AA"))
 
-        self.assertTrue(result)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.SUCCESS)
+        self.assertEqual(result.ack_code, "AA")
         mock_logger.info.assert_called_once_with("Valid ACK received.")
 
     @patch('hl7_sender.ack_processor.logger')
     def test_valid_ack_ca(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("CA"))
 
-        self.assertTrue(result)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.SUCCESS)
         mock_logger.info.assert_called_once_with("Valid ACK received.")
 
     @patch('hl7_sender.ack_processor.logger')
     def test_negative_ack_ae(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AE"))
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AE)
+        self.assertEqual(result.ack_code, "AE")
+        self.assertEqual(result.control_id, "123456")
         mock_logger.error.assert_called_once_with("Negative ACK received: AE for: 123456")
 
     @patch('hl7_sender.ack_processor.logger')
     def test_negative_ack_ar(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AR"))
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AR)
+        self.assertEqual(result.ack_code, "AR")
+        self.assertEqual(result.control_id, "123456")
         mock_logger.error.assert_called_once_with("Negative ACK received: AR for: 123456")
+
+    @patch('hl7_sender.ack_processor.logger')
+    def test_unrecognised_negative_ack_treated_as_recoverable(self, mock_logger: MagicMock) -> None:
+        result = get_ack_result(generate_ack_msg("CE"))
+
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AE)
+        self.assertEqual(result.ack_code, "CE")
 
     @patch('hl7_sender.ack_processor.logger')
     def test_non_ack_message(self, mock_logger: MagicMock) -> None:
@@ -48,14 +65,16 @@ class TestGetAckResult(unittest.TestCase):
 
         result = get_ack_result(non_ack_message)
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.INVALID)
         mock_logger.error.assert_called_once_with('Received a non-ACK message')
 
     @patch('hl7_sender.ack_processor.logger')
     def test_malformed_message(self, mock_logger: MagicMock) -> None:
         result = get_ack_result("This is not a valid HL7 message")
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.INVALID)
         mock_logger.exception.assert_called_once_with('Exception while parsing ACK message')
 
 

--- a/senders/hl7_sender/tests/test_application.py
+++ b/senders/hl7_sender/tests/test_application.py
@@ -117,6 +117,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_hl7_sender_client.send_message.return_value = hl7_ack_message
         mock_hl7_sender_client.receiver_mllp_hostname = "mpi.example.org"
         mock_hl7_sender_client.receiver_mllp_port = 2575
+        service_bus_message.application_properties = {"CorrelationId": "upstream-correlation-id-123"}
         mock_ack_processor.return_value = AckResult(AckOutcome.AE, "AE", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
@@ -139,7 +140,7 @@ class TestProcessMessage(unittest.TestCase):
         # (message_id from MSH-10, correlation_id from Service Bus metadata, ack_code, endpoint).
         expected_attributes = {
             "ack_code": "AE",
-            "correlation_id": "N/A",
+            "correlation_id": "upstream-correlation-id-123",
             "message_id": "MSGID1234",
             "endpoint": "mpi.example.org:2575",
         }
@@ -174,6 +175,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_hl7_sender_client.send_message.return_value = hl7_ack_message
         mock_hl7_sender_client.receiver_mllp_hostname = "mpi.example.org"
         mock_hl7_sender_client.receiver_mllp_port = 2575
+        service_bus_message.application_properties = {"CorrelationId": "upstream-correlation-id-123"}
         mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
 
         with self.assertRaises(DeadLetterMessage) as ctx:
@@ -191,12 +193,12 @@ class TestProcessMessage(unittest.TestCase):
         # Correlation: the dead-letter description and the AR metric both carry the
         # original message's correlation_id/message_id so operators can trace the NACK back to it.
         self.assertIn("message_id=MSGID1234", ctx.exception.description)
-        self.assertIn("correlation_id=N/A", ctx.exception.description)
+        self.assertIn("correlation_id=upstream-correlation-id-123", ctx.exception.description)
         mock_event_logger.log_message_failed.assert_called_once()
         mock_metric_sender.send_message_sent_metric.assert_not_called()
         expected_attributes = {
             "ack_code": "AR",
-            "correlation_id": "N/A",
+            "correlation_id": "upstream-correlation-id-123",
             "message_id": "MSGID1234",
             "endpoint": "mpi.example.org:2575",
         }

--- a/senders/hl7_sender/tests/test_application.py
+++ b/senders/hl7_sender/tests/test_application.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 from azure.servicebus import ServiceBusMessage
 from hl7apy.core import Message
+from message_bus_lib.dead_letter import DeadLetterMessage
 
+from hl7_sender.ack_processor import AckOutcome, AckResult
 from hl7_sender.app_config import AppConfig
 from hl7_sender.application import (
     MAX_BATCH_SIZE,
@@ -68,7 +70,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.return_value = hl7_message
         hl7_ack_message = "HL7 ack message"
         mock_hl7_sender_client.send_message.return_value = hl7_ack_message
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
             service_bus_message,
@@ -84,7 +86,13 @@ class TestProcessMessage(unittest.TestCase):
         mock_ack_processor.assert_called_once_with(hl7_ack_message)
         mock_event_logger.log_message_received.assert_called_once()
         mock_event_logger.log_message_processed.assert_called_once()
+        mock_event_logger.log_message_failed.assert_not_called()
         mock_metric_sender.send_message_sent_metric.assert_called_once()
+
+        # Preserve normal behaviour for AA: none of the NACK retry/escalation flow is triggered.
+        mock_metric_sender.send_message_nack_ae_metric.assert_not_called()
+        mock_metric_sender.send_message_nack_ar_metric.assert_not_called()
+        mock_metric_sender.send_message_retry_attempt_metric.assert_not_called()
         mock_throttler.wait_if_needed.assert_called_once()
 
         self.assertTrue(result)
@@ -107,7 +115,9 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.return_value = hl7_message
         hl7_ack_message = "HL7 ack message"
         mock_hl7_sender_client.send_message.return_value = hl7_ack_message
-        mock_ack_processor.return_value = False
+        mock_hl7_sender_client.receiver_mllp_hostname = "mpi.example.org"
+        mock_hl7_sender_client.receiver_mllp_port = 2575
+        mock_ack_processor.return_value = AckResult(AckOutcome.AE, "AE", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
             service_bus_message,
@@ -122,11 +132,81 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.assert_called_once_with(hl7_string)
         mock_ack_processor.assert_called_once_with(hl7_ack_message)
         mock_event_logger.log_message_received.assert_called_once()
-        mock_event_logger.log_message_processed.assert_called_once()
+        mock_event_logger.log_message_failed.assert_called_once()
         mock_metric_sender.send_message_sent_metric.assert_not_called()
+
+        # Correlation: verify the NACK is traceable back to the original message
+        # (message_id from MSH-10, correlation_id from Service Bus metadata, ack_code, endpoint).
+        expected_attributes = {
+            "ack_code": "AE",
+            "correlation_id": "N/A",
+            "message_id": "MSGID1234",
+            "endpoint": "mpi.example.org:2575",
+        }
+        mock_metric_sender.send_message_nack_ae_metric.assert_called_once_with(attributes=expected_attributes)
+        mock_metric_sender.send_message_retry_attempt_metric.assert_called_once_with(attributes=expected_attributes)
         mock_throttler.wait_if_needed.assert_called_once()
 
+        # Surfacing for operations: logs must include the ACK code and downstream endpoint.
+        failed_log_message = mock_event_logger.log_message_failed.call_args.args[1]
+        self.assertIn("AE", failed_log_message)
+        self.assertIn("mpi.example.org:2575", failed_log_message)
+
         self.assertFalse(result)
+
+    @patch("hl7_sender.application.parse_message")
+    @patch("hl7_sender.application.get_ack_result")
+    def test_process_message_ar_ack_dead_letters_message(
+        self, mock_ack_processor: Mock, mock_parse_message: Mock
+    ) -> None:
+        (
+            service_bus_message,
+            hl7_message,
+            hl7_string,
+            mock_hl7_sender_client,
+            mock_event_logger,
+            mock_metric_sender,
+            mock_throttler,
+            mock_message_store,
+        ) = _setup()
+        mock_parse_message.return_value = hl7_message
+        hl7_ack_message = "HL7 ack message"
+        mock_hl7_sender_client.send_message.return_value = hl7_ack_message
+        mock_hl7_sender_client.receiver_mllp_hostname = "mpi.example.org"
+        mock_hl7_sender_client.receiver_mllp_port = 2575
+        mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
+
+        with self.assertRaises(DeadLetterMessage) as ctx:
+            _process_message(
+                service_bus_message,
+                mock_hl7_sender_client,
+                mock_event_logger,
+                mock_metric_sender,
+                mock_throttler,
+                mock_message_store,
+                TEST_SESSION_ID,
+            )
+
+        self.assertEqual(ctx.exception.reason, "AR")
+        # Correlation: the dead-letter description and the AR metric both carry the
+        # original message's correlation_id/message_id so operators can trace the NACK back to it.
+        self.assertIn("message_id=MSGID1234", ctx.exception.description)
+        self.assertIn("correlation_id=N/A", ctx.exception.description)
+        mock_event_logger.log_message_failed.assert_called_once()
+        mock_metric_sender.send_message_sent_metric.assert_not_called()
+        expected_attributes = {
+            "ack_code": "AR",
+            "correlation_id": "N/A",
+            "message_id": "MSGID1234",
+            "endpoint": "mpi.example.org:2575",
+        }
+        mock_metric_sender.send_message_nack_ar_metric.assert_called_once_with(attributes=expected_attributes)
+        mock_metric_sender.send_message_nack_ae_metric.assert_not_called()
+
+        # Surfacing for operations: logs must include the ACK code and downstream endpoint.
+        failed_log_message = mock_event_logger.log_message_failed.call_args.args[1]
+        self.assertIn("AR", failed_log_message)
+        self.assertIn("mpi.example.org:2575", failed_log_message)
 
     @patch("hl7_sender.application.parse_message")
     def test_process_message_send_errors(self, mock_parse_message: Mock) -> None:
@@ -256,7 +336,7 @@ class TestProcessMessage(unittest.TestCase):
             mock_message_store,
         ) = _setup()
         mock_parse_message.return_value = hl7_message
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", "ACK")
         mock_convert_xml.return_value = "<xml>content</xml>"
         message_stored = {"value": False}
 
@@ -308,7 +388,7 @@ class TestProcessMessage(unittest.TestCase):
         service_bus_message.delivery_count = 1  # type: ignore[attr-defined]  # Simulate a retry delivery attempt
         mock_parse_message.return_value = hl7_message
         mock_hl7_sender_client.send_message.return_value = "ACK"
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", "ACK")
         mock_convert_xml.return_value = "<xml/>"
 
         result = _process_message(
@@ -343,7 +423,7 @@ class TestProcessMessage(unittest.TestCase):
         ) = _setup()
         mock_parse_message.return_value = hl7_message
         mock_hl7_sender_client.send_message.return_value = "ACK"
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", "ACK")
         mock_convert_xml.side_effect = ValueError("Cannot parse")
 
         _process_message(
@@ -385,7 +465,7 @@ class TestProcessMessage(unittest.TestCase):
         ) = _setup()
         mock_parse_message.return_value = hl7_message
         mock_hl7_sender_client.send_message.return_value = "ACK"
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", "ACK")
         mock_convert_xml.return_value = "<xml/>"
         mock_message_store.send_to_store.side_effect = Exception("Store unavailable")
 
@@ -431,7 +511,7 @@ class TestProcessMessage(unittest.TestCase):
 
         mock_parse_message.return_value = hl7_message
         mock_hl7_sender_client.send_message.return_value = "ACK"
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", "ACK")
         mock_convert_xml.return_value = "<xml/>"
 
         _process_message(

--- a/senders/hl7_sender/tests/test_application.py
+++ b/senders/hl7_sender/tests/test_application.py
@@ -209,6 +209,41 @@ class TestProcessMessage(unittest.TestCase):
         self.assertIn("mpi.example.org:2575", failed_log_message)
 
     @patch("hl7_sender.application.parse_message")
+    @patch("hl7_sender.application.get_ack_result")
+    def test_process_message_ar_still_dead_letters_when_metric_send_fails(
+        self, mock_ack_processor: Mock, mock_parse_message: Mock
+    ) -> None:
+        """A telemetry failure must not change the non-recoverable (AR) delivery decision."""
+        (
+            service_bus_message,
+            hl7_message,
+            hl7_string,
+            mock_hl7_sender_client,
+            mock_event_logger,
+            mock_metric_sender,
+            mock_throttler,
+            mock_message_store,
+        ) = _setup()
+        mock_parse_message.return_value = hl7_message
+        hl7_ack_message = "HL7 ack message"
+        mock_hl7_sender_client.send_message.return_value = hl7_ack_message
+        mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
+        mock_metric_sender.send_message_nack_ar_metric.side_effect = RuntimeError("Azure Monitor unavailable")
+
+        with self.assertRaises(DeadLetterMessage) as ctx:
+            _process_message(
+                service_bus_message,
+                mock_hl7_sender_client,
+                mock_event_logger,
+                mock_metric_sender,
+                mock_throttler,
+                mock_message_store,
+                TEST_SESSION_ID,
+            )
+
+        self.assertEqual(ctx.exception.reason, "AR")
+
+    @patch("hl7_sender.application.parse_message")
     def test_process_message_send_errors(self, mock_parse_message: Mock) -> None:
         error_cases = [
             {"description": "timeout_error", "error": TimeoutError("No ACK received within 30 seconds")},

--- a/senders/hl7_subscription_sender/hl7_subscription_sender/ack_processor.py
+++ b/senders/hl7_subscription_sender/hl7_subscription_sender/ack_processor.py
@@ -1,32 +1,71 @@
 import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
 
 from hl7apy.core import Message
 from hl7apy.parser import parse_message
 
 logger = logging.getLogger(__name__)
 
+# HL7 MSA-1 acknowledgment codes that are treated as recoverable negative acknowledgements -
+# the message will be retried according to the configured retry policy.
+RECOVERABLE_ACK_CODES = frozenset({"AE"})
 
-def get_ack_result(response: str) -> bool:
+# HL7 MSA-1 acknowledgment codes that are treated as non-recoverable negative acknowledgements -
+# the message must not be retried automatically and is routed to the dead-letter/escalation path.
+NON_RECOVERABLE_ACK_CODES = frozenset({"AR"})
+
+
+class AckOutcome(Enum):
+    SUCCESS = "SUCCESS"  # MSA-1 = AA/CA
+    AE = "AE"  # MSA-1 = AE - application error, recoverable, retryable
+    AR = "AR"  # MSA-1 = AR - application reject, non-recoverable, dead-lettered
+    INVALID = "INVALID"  # Malformed response or missing MSA segment
+
+
+@dataclass
+class AckResult:
+    outcome: AckOutcome
+    ack_code: Optional[str]
+    control_id: Optional[str]
+    raw_response: str
+
+    @property
+    def is_success(self) -> bool:
+        return self.outcome == AckOutcome.SUCCESS
+
+
+def get_ack_result(response: str) -> AckResult:
     try:
         response_msg: Message = parse_message(response)
 
         if not response_msg.MSA:
             error = "Received a non-ACK message"
             logger.error(error)
-            return False
+            return AckResult(AckOutcome.INVALID, None, None, response)
 
         ack_code = response_msg.MSA.acknowledgment_code.value
         logger.debug(f"ACK Code: {ack_code}")
 
-        if ack_code in ["AA", "CA"]:
-            logger.info("Valid ACK received.")
-            return True
-        else:
+        control_id: Optional[str] = None
+        try:
             control_id = response_msg.MSH.message_control_id.value
-            error = f"Negative ACK received: {ack_code} for: {control_id}"
-            logger.error(error)
-            return False
+        except Exception:
+            logger.debug("Unable to extract control ID from ACK message")
+
+        if ack_code in ("AA", "CA"):
+            logger.info("Valid ACK received.")
+            return AckResult(AckOutcome.SUCCESS, ack_code, control_id, response)
+
+        logger.error(f"Negative ACK received: {ack_code} for: {control_id}")
+
+        if ack_code in NON_RECOVERABLE_ACK_CODES:
+            return AckResult(AckOutcome.AR, ack_code, control_id, response)
+
+        # AE, and any other unrecognised negative ack code, is treated as recoverable.
+        return AckResult(AckOutcome.AE, ack_code, control_id, response)
 
     except Exception:
         logger.exception("Exception while parsing ACK message")
-        return False
+        return AckResult(AckOutcome.INVALID, None, None, response)

--- a/senders/hl7_subscription_sender/hl7_subscription_sender/application.py
+++ b/senders/hl7_subscription_sender/hl7_subscription_sender/application.py
@@ -7,13 +7,14 @@ from event_logger_lib import EventLogger
 from health_check_lib.health_check_server import TCPHealthCheckServer
 from hl7apy.parser import parse_message
 from message_bus_lib.connection_config import ConnectionConfig
+from message_bus_lib.dead_letter import DeadLetterMessage
 from message_bus_lib.metadata_utils import correlation_id_for_logger, extract_metadata, get_metadata_log_values
 from message_bus_lib.servicebus_client_factory import ServiceBusClientFactory
 from message_bus_lib.subscription_receiver_client import SubscriptionReceiverClient
 from metric_sender_lib.metric_sender import MetricSender
 from processor_manager_lib import ProcessorManager
 
-from hl7_subscription_sender.ack_processor import get_ack_result
+from hl7_subscription_sender.ack_processor import AckOutcome, get_ack_result
 from hl7_subscription_sender.app_config import AppConfig
 from hl7_subscription_sender.hl7_subscription_sender_client import HL7SubscriptionSenderClient
 from hl7_subscription_sender.message_throttler import MessageThrottler
@@ -137,19 +138,75 @@ def _process_message(
         throttler.wait_if_needed()
         ack_response = hl7_subscription_sender_client.send_message(message_body)
 
-        ack_success = get_ack_result(ack_response)
+        ack_result = get_ack_result(ack_response)
 
-        if ack_success:
+        nack_attributes = {
+            "ack_code": ack_result.ack_code or "UNKNOWN",
+            "correlation_id": meta["correlation_id"],
+            "message_id": message_id,
+            "endpoint": (
+                f"{hl7_subscription_sender_client.receiver_mllp_hostname}:"
+                f"{hl7_subscription_sender_client.receiver_mllp_port}"
+            ),
+        }
+
+        if ack_result.outcome == AckOutcome.SUCCESS:
             metric_sender.send_message_sent_metric()
 
-        event_logger.log_message_processed(
+            event_logger.log_message_processed(
+                message_body,
+                f"Message sent successfully, received ACK: {ack_response}",
+                correlation_id=correlation_id_opt,
+            )
+            logger.info(f"Sent message: {message_id}")
+
+            return True
+
+        if ack_result.outcome == AckOutcome.AR:
+            error_msg = (
+                f"Application Reject ACK (AR) received for message {message_id} "
+                f"from {nack_attributes['endpoint']}, full ACK: {ack_response}"
+            )
+            logger.error(error_msg)
+            event_logger.log_message_failed(
+                message_body,
+                error_msg,
+                "Non-recoverable NACK (AR) - message routed to dead-letter/escalation path",
+                correlation_id=correlation_id_opt,
+            )
+            metric_sender.send_message_nack_ar_metric(attributes=nack_attributes)
+
+            raise DeadLetterMessage(
+                reason="AR",
+                description=(
+                    f"Application Reject ACK (AR) for message_id={message_id}, "
+                    f"correlation_id={meta['correlation_id']}"
+                ),
+            )
+
+        # AckOutcome.AE or AckOutcome.INVALID - recoverable failure, will be abandoned and retried
+        # according to the queue's configured retry policy.
+        reason_code = ack_result.outcome.value
+        error_msg = (
+            f"Negative ACK ({reason_code}) received for message {message_id} "
+            f"from {nack_attributes['endpoint']}, full ACK: {ack_response}"
+        )
+        logger.error(error_msg)
+        event_logger.log_message_failed(
             message_body,
-            f"Message sent successfully, received ACK: {ack_response}",
+            error_msg,
+            f"Recoverable NACK ({reason_code}) - message will be retried",
             correlation_id=correlation_id_opt,
         )
-        logger.info(f"Sent message: {message_id}")
+        if ack_result.outcome == AckOutcome.AE:
+            metric_sender.send_message_nack_ae_metric(attributes=nack_attributes)
+            metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes)
 
-        return ack_success
+        return False
+
+    except DeadLetterMessage:
+        # Propagate so SubscriptionReceiverClient dead-letters the message instead of retrying it.
+        raise
 
     except (TimeoutError, ConnectionError) as e:
         error_msg = f"Failed to send message {message_id}: {e}"

--- a/senders/hl7_subscription_sender/hl7_subscription_sender/application.py
+++ b/senders/hl7_subscription_sender/hl7_subscription_sender/application.py
@@ -1,6 +1,7 @@
 import configparser
 import logging
 import os
+from typing import Callable
 
 from azure.servicebus import ServiceBusMessage
 from event_logger_lib import EventLogger
@@ -31,6 +32,18 @@ config.read(config_path)
 
 MAX_BATCH_SIZE = config.getint("DEFAULT", "max_batch_size")
 LOCK_RENEWAL_BUFFER_SECONDS = 30
+
+
+def _send_metric_best_effort(send_fn: Callable[[], None], metric_name: str) -> None:
+    """Send a telemetry metric without letting a telemetry failure affect the delivery decision.
+
+    Metrics are observability-only: if emitting one fails (e.g. Azure Monitor exporter issue),
+    that must not change whether a message is treated as retryable, dead-lettered, or successful.
+    """
+    try:
+        send_fn()
+    except Exception:
+        logger.exception(f"Failed to send metric '{metric_name}' - continuing without blocking message processing")
 
 
 def _calculate_batch_size(throttler: MessageThrottler) -> int:
@@ -174,7 +187,10 @@ def _process_message(
                 "Non-recoverable NACK (AR) - message routed to dead-letter/escalation path",
                 correlation_id=correlation_id_opt,
             )
-            metric_sender.send_message_nack_ar_metric(attributes=nack_attributes)
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_nack_ar_metric(attributes=nack_attributes),
+                "messages_nack_ar",
+            )
 
             raise DeadLetterMessage(
                 reason="AR",
@@ -199,8 +215,14 @@ def _process_message(
             correlation_id=correlation_id_opt,
         )
         if ack_result.outcome == AckOutcome.AE:
-            metric_sender.send_message_nack_ae_metric(attributes=nack_attributes)
-            metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes)
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_nack_ae_metric(attributes=nack_attributes),
+                "messages_nack_ae",
+            )
+            _send_metric_best_effort(
+                lambda: metric_sender.send_message_retry_attempt_metric(attributes=nack_attributes),
+                "messages_retry_attempt",
+            )
 
         return False
 

--- a/senders/hl7_subscription_sender/tests/test_ack_processor.py
+++ b/senders/hl7_subscription_sender/tests/test_ack_processor.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from hl7_subscription_sender.ack_processor import get_ack_result
+from hl7_subscription_sender.ack_processor import AckOutcome, get_ack_result
 
 
 def generate_ack_msg(ack_code: str) -> str:
@@ -16,29 +16,42 @@ class TestGetAckResult(unittest.TestCase):
     def test_valid_ack_aa(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AA"))
 
-        self.assertTrue(result)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.SUCCESS)
         mock_logger.info.assert_called_once_with("Valid ACK received.")
 
     @patch("hl7_subscription_sender.ack_processor.logger")
     def test_valid_ack_ca(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("CA"))
 
-        self.assertTrue(result)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.SUCCESS)
         mock_logger.info.assert_called_once_with("Valid ACK received.")
 
     @patch("hl7_subscription_sender.ack_processor.logger")
     def test_negative_ack_ae(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AE"))
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AE)
+        self.assertEqual(result.control_id, "123456")
         mock_logger.error.assert_called_once_with("Negative ACK received: AE for: 123456")
 
     @patch("hl7_subscription_sender.ack_processor.logger")
     def test_negative_ack_ar(self, mock_logger: MagicMock) -> None:
         result = get_ack_result(generate_ack_msg("AR"))
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AR)
+        self.assertEqual(result.control_id, "123456")
         mock_logger.error.assert_called_once_with("Negative ACK received: AR for: 123456")
+
+    @patch("hl7_subscription_sender.ack_processor.logger")
+    def test_unrecognised_negative_ack_treated_as_recoverable(self, mock_logger: MagicMock) -> None:
+        result = get_ack_result(generate_ack_msg("CE"))
+
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.AE)
 
     @patch("hl7_subscription_sender.ack_processor.logger")
     def test_non_ack_message(self, mock_logger: MagicMock) -> None:
@@ -49,14 +62,16 @@ class TestGetAckResult(unittest.TestCase):
 
         result = get_ack_result(non_ack_message)
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.INVALID)
         mock_logger.error.assert_called_once_with("Received a non-ACK message")
 
     @patch("hl7_subscription_sender.ack_processor.logger")
     def test_malformed_message(self, mock_logger: MagicMock) -> None:
         result = get_ack_result("This is not a valid HL7 message")
 
-        self.assertFalse(result)
+        self.assertFalse(result.is_success)
+        self.assertEqual(result.outcome, AckOutcome.INVALID)
         mock_logger.exception.assert_called_once_with("Exception while parsing ACK message")
 
 

--- a/senders/hl7_subscription_sender/tests/test_application.py
+++ b/senders/hl7_subscription_sender/tests/test_application.py
@@ -107,6 +107,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
         mock_hl7_subscription_sender_client.receiver_mllp_hostname = "mpi.example.org"
         mock_hl7_subscription_sender_client.receiver_mllp_port = 2575
+        service_bus_message.application_properties = {"CorrelationId": "upstream-correlation-id-123"}
         mock_ack_processor.return_value = AckResult(AckOutcome.AE, "AE", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
@@ -127,7 +128,7 @@ class TestProcessMessage(unittest.TestCase):
         # (message_id from MSH-10, correlation_id from Service Bus metadata, ack_code, endpoint).
         expected_attributes = {
             "ack_code": "AE",
-            "correlation_id": "N/A",
+            "correlation_id": "upstream-correlation-id-123",
             "message_id": "MSGID1234",
             "endpoint": "mpi.example.org:2575",
         }
@@ -161,6 +162,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
         mock_hl7_subscription_sender_client.receiver_mllp_hostname = "mpi.example.org"
         mock_hl7_subscription_sender_client.receiver_mllp_port = 2575
+        service_bus_message.application_properties = {"CorrelationId": "upstream-correlation-id-123"}
         mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
 
         with self.assertRaises(DeadLetterMessage) as ctx:
@@ -176,12 +178,12 @@ class TestProcessMessage(unittest.TestCase):
         # Correlation: the dead-letter description and the AR metric both carry the
         # original message's correlation_id/message_id so operators can trace the NACK back to it.
         self.assertIn("message_id=MSGID1234", ctx.exception.description)
-        self.assertIn("correlation_id=N/A", ctx.exception.description)
+        self.assertIn("correlation_id=upstream-correlation-id-123", ctx.exception.description)
         mock_event_logger.log_message_failed.assert_called_once()
         mock_metric_sender.send_message_sent_metric.assert_not_called()
         expected_attributes = {
             "ack_code": "AR",
-            "correlation_id": "N/A",
+            "correlation_id": "upstream-correlation-id-123",
             "message_id": "MSGID1234",
             "endpoint": "mpi.example.org:2575",
         }

--- a/senders/hl7_subscription_sender/tests/test_application.py
+++ b/senders/hl7_subscription_sender/tests/test_application.py
@@ -194,6 +194,38 @@ class TestProcessMessage(unittest.TestCase):
         self.assertIn("mpi.example.org:2575", failed_log_message)
 
     @patch("hl7_subscription_sender.application.parse_message")
+    @patch("hl7_subscription_sender.application.get_ack_result")
+    def test_process_message_ar_still_dead_letters_when_metric_send_fails(
+        self, mock_ack_processor: Mock, mock_parse_message: Mock
+    ) -> None:
+        """A telemetry failure must not change the non-recoverable (AR) delivery decision."""
+        (
+            service_bus_message,
+            hl7_message,
+            hl7_string,
+            mock_hl7_subscription_sender_client,
+            mock_event_logger,
+            mock_metric_sender,
+            mock_throttler,
+        ) = _setup()
+        mock_parse_message.return_value = hl7_message
+        hl7_ack_message = "HL7 ack message"
+        mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
+        mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
+        mock_metric_sender.send_message_nack_ar_metric.side_effect = RuntimeError("Azure Monitor unavailable")
+
+        with self.assertRaises(DeadLetterMessage) as ctx:
+            _process_message(
+                service_bus_message,
+                mock_hl7_subscription_sender_client,
+                mock_event_logger,
+                mock_metric_sender,
+                mock_throttler,
+            )
+
+        self.assertEqual(ctx.exception.reason, "AR")
+
+    @patch("hl7_subscription_sender.application.parse_message")
     def test_process_message_send_errors(self, mock_parse_message: Mock) -> None:
         error_cases = [
             {"description": "timeout_error", "error": TimeoutError("No ACK received within 30 seconds")},

--- a/senders/hl7_subscription_sender/tests/test_application.py
+++ b/senders/hl7_subscription_sender/tests/test_application.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 from azure.servicebus import ServiceBusMessage  # type: ignore
 from hl7apy.core import Message  # type: ignore
+from message_bus_lib.dead_letter import DeadLetterMessage
 
+from hl7_subscription_sender.ack_processor import AckOutcome, AckResult
 from hl7_subscription_sender.app_config import AppConfig
 from hl7_subscription_sender.application import (
     MAX_BATCH_SIZE,
@@ -61,7 +63,7 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.return_value = hl7_message
         hl7_ack_message = "HL7 ack message"
         mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
-        mock_ack_processor.return_value = True
+        mock_ack_processor.return_value = AckResult(AckOutcome.SUCCESS, "AA", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
             service_bus_message,
@@ -75,7 +77,13 @@ class TestProcessMessage(unittest.TestCase):
         mock_ack_processor.assert_called_once_with(hl7_ack_message)
         mock_event_logger.log_message_received.assert_called_once()
         mock_event_logger.log_message_processed.assert_called_once()
+        mock_event_logger.log_message_failed.assert_not_called()
         mock_metric_sender.send_message_sent_metric.assert_called_once()
+
+        # Preserve normal behaviour for AA: none of the NACK retry/escalation flow is triggered.
+        mock_metric_sender.send_message_nack_ae_metric.assert_not_called()
+        mock_metric_sender.send_message_nack_ar_metric.assert_not_called()
+        mock_metric_sender.send_message_retry_attempt_metric.assert_not_called()
         mock_throttler.wait_if_needed.assert_called_once()
 
         self.assertTrue(result)
@@ -97,7 +105,9 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.return_value = hl7_message
         hl7_ack_message = "HL7 ack message"
         mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
-        mock_ack_processor.return_value = False
+        mock_hl7_subscription_sender_client.receiver_mllp_hostname = "mpi.example.org"
+        mock_hl7_subscription_sender_client.receiver_mllp_port = 2575
+        mock_ack_processor.return_value = AckResult(AckOutcome.AE, "AE", "MSGID1234", hl7_ack_message)
 
         result = _process_message(
             service_bus_message,
@@ -110,11 +120,78 @@ class TestProcessMessage(unittest.TestCase):
         mock_parse_message.assert_called_once_with(hl7_string)
         mock_ack_processor.assert_called_once_with(hl7_ack_message)
         mock_event_logger.log_message_received.assert_called_once()
-        mock_event_logger.log_message_processed.assert_called_once()
+        mock_event_logger.log_message_failed.assert_called_once()
         mock_metric_sender.send_message_sent_metric.assert_not_called()
+
+        # Correlation: verify the NACK is traceable back to the original message
+        # (message_id from MSH-10, correlation_id from Service Bus metadata, ack_code, endpoint).
+        expected_attributes = {
+            "ack_code": "AE",
+            "correlation_id": "N/A",
+            "message_id": "MSGID1234",
+            "endpoint": "mpi.example.org:2575",
+        }
+        mock_metric_sender.send_message_nack_ae_metric.assert_called_once_with(attributes=expected_attributes)
+        mock_metric_sender.send_message_retry_attempt_metric.assert_called_once_with(attributes=expected_attributes)
         mock_throttler.wait_if_needed.assert_called_once()
 
+        # Surfacing for operations: logs must include the ACK code and downstream endpoint.
+        failed_log_message = mock_event_logger.log_message_failed.call_args.args[1]
+        self.assertIn("AE", failed_log_message)
+        self.assertIn("mpi.example.org:2575", failed_log_message)
+
         self.assertFalse(result)
+
+    @patch("hl7_subscription_sender.application.parse_message")
+    @patch("hl7_subscription_sender.application.get_ack_result")
+    def test_process_message_ar_ack_dead_letters_message(
+        self, mock_ack_processor: Mock, mock_parse_message: Mock
+    ) -> None:
+        (
+            service_bus_message,
+            hl7_message,
+            hl7_string,
+            mock_hl7_subscription_sender_client,
+            mock_event_logger,
+            mock_metric_sender,
+            mock_throttler,
+        ) = _setup()
+        mock_parse_message.return_value = hl7_message
+        hl7_ack_message = "HL7 ack message"
+        mock_hl7_subscription_sender_client.send_message.return_value = hl7_ack_message
+        mock_hl7_subscription_sender_client.receiver_mllp_hostname = "mpi.example.org"
+        mock_hl7_subscription_sender_client.receiver_mllp_port = 2575
+        mock_ack_processor.return_value = AckResult(AckOutcome.AR, "AR", "MSGID1234", hl7_ack_message)
+
+        with self.assertRaises(DeadLetterMessage) as ctx:
+            _process_message(
+                service_bus_message,
+                mock_hl7_subscription_sender_client,
+                mock_event_logger,
+                mock_metric_sender,
+                mock_throttler,
+            )
+
+        self.assertEqual(ctx.exception.reason, "AR")
+        # Correlation: the dead-letter description and the AR metric both carry the
+        # original message's correlation_id/message_id so operators can trace the NACK back to it.
+        self.assertIn("message_id=MSGID1234", ctx.exception.description)
+        self.assertIn("correlation_id=N/A", ctx.exception.description)
+        mock_event_logger.log_message_failed.assert_called_once()
+        mock_metric_sender.send_message_sent_metric.assert_not_called()
+        expected_attributes = {
+            "ack_code": "AR",
+            "correlation_id": "N/A",
+            "message_id": "MSGID1234",
+            "endpoint": "mpi.example.org:2575",
+        }
+        mock_metric_sender.send_message_nack_ar_metric.assert_called_once_with(attributes=expected_attributes)
+        mock_metric_sender.send_message_nack_ae_metric.assert_not_called()
+
+        # Surfacing for operations: logs must include the ACK code and downstream endpoint.
+        failed_log_message = mock_event_logger.log_message_failed.call_args.args[1]
+        self.assertIn("AR", failed_log_message)
+        self.assertIn("mpi.example.org:2575", failed_log_message)
 
     @patch("hl7_subscription_sender.application.parse_message")
     def test_process_message_send_errors(self, mock_parse_message: Mock) -> None:

--- a/shared_libs/message_bus_lib/message_bus_lib/dead_letter.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/dead_letter.py
@@ -1,0 +1,15 @@
+class DeadLetterMessage(Exception):
+    """Signal raised by a message processor to indicate that the current message is
+    non-recoverable and must be dead-lettered immediately, bypassing the normal
+    abandon/retry path (e.g. a non-recoverable HL7 NACK such as MSA-1 = AR).
+
+    ``MessageReceiverClient`` (and subclasses such as ``SubscriptionReceiverClient``)
+    catch this specifically in their per-message processing loop and call the
+    Service Bus receiver's ``dead_letter_message`` with the supplied reason/description,
+    instead of abandoning the message for redelivery.
+    """
+
+    def __init__(self, reason: str, description: str):
+        super().__init__(description)
+        self.reason = reason
+        self.description = description

--- a/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
+++ b/shared_libs/message_bus_lib/message_bus_lib/message_receiver_client.py
@@ -18,6 +18,8 @@ from azure.servicebus.exceptions import ServiceBusError, SessionCannotBeLockedEr
 from metric_sender_lib.metric_sender import MetricSender
 from otel_lib import extract_trace_context
 
+from message_bus_lib.dead_letter import DeadLetterMessage
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,6 +101,16 @@ class MessageReceiverClient:
             for i, msg in enumerate(messages):
                 try:
                     is_success = self._invoke_with_trace_context(message_processor, msg)
+                except DeadLetterMessage as dlm:
+                    logger.error(
+                        "Dead-lettering non-recoverable message %s (reason=%s): %s",
+                        msg.message_id,
+                        dlm.reason,
+                        dlm.description,
+                    )
+                    receiver.dead_letter_message(msg, reason=dlm.reason, error_description=dlm.description)
+                    self._abort_message_processing(receiver, messages[i + 1:])
+                    return False
                 except Exception:
                     logger.exception("Unexpected error processing message: %s", msg.message_id)
                     self._abort_message_processing(receiver, messages[i:])

--- a/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
+++ b/shared_libs/message_bus_lib/tests/test_MessageReceiverClient.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.exceptions import ServiceBusError, SessionCannotBeLockedError
 
+from message_bus_lib.dead_letter import DeadLetterMessage
 from message_bus_lib.message_receiver_client import MessageReceiverClient
 
 
@@ -105,6 +106,28 @@ class TestMessageReceiverClient(unittest.TestCase):
         self.service_bus_receiver_client.abandon_message.assert_any_call(message2)
         self.service_bus_receiver_client.abandon_message.assert_any_call(message3)
         self.assertIsNotNone(self.message_receiver_client.next_retry_time)
+
+    @patch("time.sleep", return_value=None)
+    def test_receive_messages_dead_letters_message_on_dead_letter_signal(self, sleep_mock: MagicMock) -> None:
+        # Arrange
+        message1 = create_message("123")
+        message2 = create_message("456")
+        self.service_bus_receiver_client.receive_messages.side_effect = [[message1, message2], []]
+
+        def processor(msg: Any) -> bool:
+            if msg.message_id == "123":
+                raise DeadLetterMessage(reason="AR", description="Application Reject ACK")
+            return True
+
+        # Act
+        self.message_receiver_client.receive_messages(2, processor)
+
+        # Assert
+        self.service_bus_receiver_client.dead_letter_message.assert_called_once_with(
+            message1, reason="AR", error_description="Application Reject ACK"
+        )
+        self.service_bus_receiver_client.abandon_message.assert_called_once_with(message2)
+        self.service_bus_receiver_client.complete_message.assert_not_called()
 
     @patch("time.sleep", return_value=None)
     def test_receiveMessages_backoff_doubles_delay_on_each_retry(self, sleep_mock: MagicMock) -> None:

--- a/shared_libs/metric_sender_lib/metric_sender_lib/metric_sender.py
+++ b/shared_libs/metric_sender_lib/metric_sender_lib/metric_sender.py
@@ -192,6 +192,23 @@ class MetricSender:
     ) -> None:
         self.send_metric(key="messages_sent", value=1, attributes=attributes)
 
+    def send_message_nack_ae_metric(
+        self, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Recoverable negative ACK (MSA-1 = AE) - message will be retried."""
+        self.send_metric(key="messages_nack_ae", value=1, attributes=attributes)
+
+    def send_message_nack_ar_metric(
+        self, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Non-recoverable negative ACK (MSA-1 = AR) - message is dead-lettered/escalated."""
+        self.send_metric(key="messages_nack_ar", value=1, attributes=attributes)
+
+    def send_message_retry_attempt_metric(
+        self, attributes: Optional[Dict[str, Any]] = None
+    ) -> None:
+        self.send_metric(key="messages_retry_attempt", value=1, attributes=attributes)
+
     def _get_or_create_histogram(self, key: str) -> Histogram:
         if key not in self._histograms:
             assert self._meter is not None

--- a/shared_libs/metric_sender_lib/tests/test_metrics_sender.py
+++ b/shared_libs/metric_sender_lib/tests/test_metrics_sender.py
@@ -434,6 +434,48 @@ class TestMetricSender(unittest.TestCase):
                         key="messages_sent", value=1, attributes=test_case["attributes"]
                     )
 
+    @patch("metric_sender_lib.metric_sender.logger")
+    def test_send_message_nack_ae_metric(self, mock_logger: MagicMock) -> None:
+        metric_sender = MetricSender(
+            self.workflow_id, self.microservice_id, self.health_board, self.peer_service
+        )
+        attributes = {"ack_code": "AE"}
+
+        with patch.object(metric_sender, "send_metric") as mock_send_metric:
+            metric_sender.send_message_nack_ae_metric(attributes)
+
+            mock_send_metric.assert_called_once_with(
+                key="messages_nack_ae", value=1, attributes=attributes
+            )
+
+    @patch("metric_sender_lib.metric_sender.logger")
+    def test_send_message_nack_ar_metric(self, mock_logger: MagicMock) -> None:
+        metric_sender = MetricSender(
+            self.workflow_id, self.microservice_id, self.health_board, self.peer_service
+        )
+        attributes = {"ack_code": "AR"}
+
+        with patch.object(metric_sender, "send_metric") as mock_send_metric:
+            metric_sender.send_message_nack_ar_metric(attributes)
+
+            mock_send_metric.assert_called_once_with(
+                key="messages_nack_ar", value=1, attributes=attributes
+            )
+
+    @patch("metric_sender_lib.metric_sender.logger")
+    def test_send_message_retry_attempt_metric(self, mock_logger: MagicMock) -> None:
+        metric_sender = MetricSender(
+            self.workflow_id, self.microservice_id, self.health_board, self.peer_service
+        )
+        attributes = {"ack_code": "AE"}
+
+        with patch.object(metric_sender, "send_metric") as mock_send_metric:
+            metric_sender.send_message_retry_attempt_metric(attributes)
+
+            mock_send_metric.assert_called_once_with(
+                key="messages_retry_attempt", value=1, attributes=attributes
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Task - https://dev.azure.com/NHS-Wales-Digital/Integration%20Hub/_workitems/edit/608667

- Add explicit assertions on the exact NACK metric attributes dict (ack_code, correlation_id, message_id, endpoint) for both AE and AR paths, proving correlation to the original message per acceptance criteria.
- Include downstream endpoint in the AE/AR error log messages (was previously only in metric attributes) for full log/metric parity, and add tests asserting the log message includes both the ACK code and endpoint.
- Add explicit not-called assertions for NACK/retry metrics on the successful ACK (AA) path, proving normal behaviour is preserved and no NACK flow is triggered.